### PR TITLE
Add simple README for deployment directory

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -8,7 +8,8 @@ This directory contains configuration-as-code to deploy the distributor to suppo
 ## Prerequisites
 
 Deploying these examples requires installation of:
- - `terraform` or `opentofu`
+ - [`terraform`](https://developer.hashicorp.com/terraform/install) or 
+   [`opentofu`](https://opentofu.org/docs/intro/install/)
  - [`terragrunt`](https://terragrunt.gruntwork.io/docs/getting-started/install/)
 
 ## Deploying


### PR DESCRIPTION
This PR adds a small README for the `deployment` directory with instructions for using the terraform/terragrunt configs it contains.

Toward #5 #7