### PR TITLE
Add outline of GCP spanner implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ require (
 	k8s.io/klog/v2 v2.130.1
 )
 
+require cloud.google.com/go/longrunning v0.5.7 // indirect
+
 require (
 	cel.dev/expr v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240617180043-68d350f18fd4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,11 @@ require (
 	k8s.io/klog/v2 v2.130.1
 )
 
-require cel.dev/expr v0.15.0 // indirect
+require (
+	cel.dev/expr v0.15.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20240617180043-68d350f18fd4 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240624140628-dc46fd24d27d // indirect
+)
 
 require (
 	cloud.google.com/go v0.115.0 // indirect
@@ -53,7 +57,5 @@ require (
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/genproto v0.0.0-20240624140628-dc46fd24d27d // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20240617180043-68d350f18fd4 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240624140628-dc46fd24d27d // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 )

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -133,7 +133,6 @@ func (s *Storage) setTile(ctx context.Context, level, index uint64, tile [][]byt
 	}
 	t := slices.Concat(tile...)
 
-	// Pass an empty rootDir since we don't need this concept in GCS.
 	tPath := layout.TilePath(level, index) + tileSuffix(tileSize)
 
 	return s.objStore.setObject(ctx, tPath, t, &gcs.Conditions{DoesNotExist: true})
@@ -144,7 +143,6 @@ func (s *Storage) setTile(ctx context.Context, level, index uint64, tile [][]byt
 func (s *Storage) getTile(ctx context.Context, level, index, logSize uint64) ([][]byte, error) {
 	tileSize := layout.PartialTileSize(level, index, logSize)
 
-	// Pass an empty rootDir since we don't need this concept in GCS.
 	objName := layout.TilePath(level, index) + tileSuffix(tileSize)
 	data, _, err := s.objStore.getObject(ctx, objName)
 	if err != nil {


### PR DESCRIPTION
This PR adds Spanner support to the GCP storage implementation, along with sequencing support.

TODO: relies on #44, merge & rebase.

Towards #23 
