### PR TITLE
Add support for integration in GCP storage

### DIFF
--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -301,9 +301,7 @@ func (s *Storage) updateEntryBundles(ctx context.Context, fromSeq uint64, entrie
 	goSetEntryBundle := func(ctx context.Context, bundleIndex uint64, fromSeq uint64, bundle api.EntryBundle) {
 		seqErr.Go(func() error {
 			if err := s.setEntryBundle(ctx, bundleIndex, fromSeq, &bundle); err != nil {
-				if !errors.Is(os.ErrExist, err) {
-					return err
-				}
+				return err
 			}
 			return nil
 		})

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/storage"
 )
 
 func newSpannerDB(t *testing.T) func() {
@@ -171,11 +172,11 @@ func TestTileRoundtrip(t *testing.T) {
 				t.Fatalf("want tile at %v but found none", expPath)
 			}
 
-			got, err := s.getTile(ctx, test.level, test.index, test.logSize)
+			got, err := s.getTiles(ctx, []storage.TileID{{Level: test.level, Index: test.index}}, test.logSize)
 			if err != nil {
 				t.Fatalf("getTile: %v", err)
 			}
-			if !cmp.Equal(got, wantTile) {
+			if !cmp.Equal(got[0], wantTile) {
 				t.Fatal("roundtrip returned different data")
 			}
 		})

--- a/storage/integrate_test.go
+++ b/storage/integrate_test.go
@@ -17,7 +17,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"sync"
 	"testing"
@@ -190,10 +189,7 @@ func (m *memTileStore[T]) getTile(_ context.Context, id TileID, treeSize uint64)
 	defer m.RUnlock()
 
 	k := layout.TilePath(id.Level, id.Index, treeSize)
-	d, ok := m.mem[k]
-	if !ok {
-		return nil, fmt.Errorf("tile %q: %w", k, os.ErrNotExist)
-	}
+	d := m.mem[k]
 	return d, nil
 }
 
@@ -201,15 +197,15 @@ func (m *memTileStore[T]) getTiles(_ context.Context, ids []TileID, treeSize uin
 	m.RLock()
 	defer m.RUnlock()
 
-	r := []*T{}
-	for _, id := range ids {
+	r := make([]*T, len(ids))
+	for i, id := range ids {
 		k := layout.TilePath(id.Level, id.Index, treeSize)
 		klog.V(1).Infof("mem.getTile(%q, %d)", k, treeSize)
 		d, ok := m.mem[k]
 		if !ok {
-			return nil, fmt.Errorf("tile %q: %w", k, os.ErrNotExist)
+			continue
 		}
-		r = append(r, d)
+		r[i] = d
 	}
 	return r, nil
 }


### PR DESCRIPTION
This PR pulls in the integrate mix-in from #61 and uses it in the GCP storage.

Towards #23 