### PR TITLE
Posix log implementation of tlog-tiles

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -33,7 +33,7 @@ import (
 var (
 	testOrigin      = "example.com/log/testdata"
 	testLogVerifier = mustMakeVerifier("example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx")
-	// Built using serverless/testdata/build_log.sh
+	// Built using testdata/build_log.sh
 	testRawCheckpoints, testCheckpoints = mustLoadTestCheckpoints()
 )
 

--- a/cmd/example-posix/main.go
+++ b/cmd/example-posix/main.go
@@ -1,0 +1,134 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main provides a command line tool for integrating sequenced
+// entries into a serverless log.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/transparency-dev/serverless-log/internal/storage/fs"
+	"golang.org/x/mod/sumdb/note"
+
+	"github.com/transparency-dev/merkle/rfc6962"
+	"github.com/transparency-dev/serverless-log/pkg/log"
+	"k8s.io/klog/v2"
+
+	fmtlog "github.com/transparency-dev/formats/log"
+)
+
+var (
+	storageDir = flag.String("storage_dir", "", "Root directory to store log data.")
+	entries    = flag.String("entries", "", "File path glob of entries to add to the log.")
+	pubKeyFile = flag.String("public_key", "", "Location of public key file. If unset, uses the contents of the SERVERLESS_LOG_PUBLIC_KEY environment variable.")
+	origin     = flag.String("origin", "", "Log origin string to check for in checkpoint.")
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	// Read log public key from file or environment variable
+	var pubKey string
+	if len(*pubKeyFile) > 0 {
+		k, err := os.ReadFile(*pubKeyFile)
+		if err != nil {
+			klog.Exitf("failed to read public_key file: %q", err)
+		}
+		pubKey = string(k)
+	} else {
+		pubKey = os.Getenv("SERVERLESS_LOG_PUBLIC_KEY")
+		if len(pubKey) == 0 {
+			klog.Exit("supply public key file path using --public_key or set SERVERLESS_LOG_PUBLIC_KEY environment variable")
+		}
+	}
+
+	toAdd, err := filepath.Glob(*entries)
+	if err != nil {
+		klog.Exitf("Failed to glob entries %q: %q", *entries, err)
+	}
+	if len(toAdd) == 0 {
+		klog.Exit("Sequence must be run with at least one valid entry")
+	}
+
+	h := rfc6962.DefaultHasher
+	// init storage
+
+	cpRaw, err := fs.ReadCheckpoint(*storageDir)
+	if err != nil {
+		klog.Exitf("Failed to read log checkpoint: %q", err)
+	}
+
+	// Check signatures
+	v, err := note.NewVerifier(pubKey)
+	if err != nil {
+		klog.Exitf("Failed to instantiate Verifier: %q", err)
+	}
+	cp, _, _, err := fmtlog.ParseCheckpoint(cpRaw, *origin, v)
+	if err != nil {
+		klog.Exitf("Failed to parse Checkpoint: %q", err)
+	}
+
+	st, err := fs.Load(*storageDir, cp.Size)
+	if err != nil {
+		klog.Exitf("Failed to load storage: %q", err)
+	}
+
+	// sequence entries
+
+	// entryInfo binds the actual bytes to be added as a leaf with a
+	// user-recognisable name for the source of those bytes.
+	// The name is only used below in order to inform the user of the
+	// sequence numbers assigned to the data from the provided input files.
+	type entryInfo struct {
+		name string
+		b    []byte
+	}
+	entries := make(chan entryInfo, 100)
+	go func() {
+		for _, fp := range toAdd {
+			b, err := os.ReadFile(fp)
+			if err != nil {
+				klog.Exitf("Failed to read entry file %q: %q", fp, err)
+			}
+			entries <- entryInfo{name: fp, b: b}
+		}
+		close(entries)
+	}()
+
+	for entry := range entries {
+		// ask storage to sequence
+		lh := h.HashLeaf(entry.b)
+		dupe := false
+		seq, err := st.Sequence(context.Background(), lh, entry.b)
+		if err != nil {
+			if errors.Is(err, log.ErrDupeLeaf) {
+				dupe = true
+			} else {
+				klog.Exitf("failed to sequence %q: %q", entry.name, err)
+			}
+		}
+		l := fmt.Sprintf("%d: %v", seq, entry.name)
+		if dupe {
+			l += " (dupe)"
+		}
+		klog.Info(l)
+	}
+}

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -1,0 +1,336 @@
+package posix
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/AlCutter/betty/log"
+	"github.com/AlCutter/betty/log/writer"
+	"github.com/transparency-dev/merkle/rfc6962"
+	"github.com/transparency-dev/serverless-log/api"
+	"github.com/transparency-dev/serverless-log/api/layout"
+	"k8s.io/klog/v2"
+)
+
+const (
+	dirPerm  = 0o755
+	filePerm = 0o644
+)
+
+// Storage implements storage functions for a POSIX filesystem.
+// It leverages the POSIX atomic operations.
+type Storage struct {
+	sync.Mutex
+	params log.Params
+	path   string
+	pool   *writer.Pool
+
+	cpFile *os.File
+
+	curTree CurrentTreeFunc
+	newTree NewTreeFunc
+
+	curSize uint64
+}
+
+// NewTreeFunc is the signature of a function which receives information about newly integrated trees.
+type NewTreeFunc func(size uint64, root []byte) error
+
+// CurrentTree is the signature of a function which retrieves the current integrated tree size and root hash.
+type CurrentTreeFunc func() (uint64, []byte, error)
+
+// New creates a new POSIX storage.
+func New(path string, params log.Params, batchMaxAge time.Duration, curTree CurrentTreeFunc, newTree NewTreeFunc) *Storage {
+	curSize, _, err := curTree()
+	if err != nil {
+		panic(err)
+	}
+	r := &Storage{
+		path:    path,
+		params:  params,
+		curSize: curSize,
+		curTree: curTree,
+		newTree: newTree,
+	}
+	r.pool = writer.NewPool(params.EntryBundleSize, batchMaxAge, r.sequenceBatch)
+
+	return r
+}
+
+// lockCP places a POSIX advisory lock for the checkpoint.
+// Note that a) this is advisory, and b) we use an adjacent file to the checkpoint
+// (`checkpoint.lock`) to avoid inherent brittleness of the `fcntrl` API (*any* `Close`
+// operation on this file (even if it's a different FD) from this PID, or overwriting
+// of the file by *any* process breaks the lock.)
+func (s *Storage) lockCP() error {
+	var err error
+	if s.cpFile != nil {
+		panic("not unlocked")
+	}
+	s.cpFile, err = os.OpenFile(filepath.Join(s.path, layout.CheckpointPath+".lock"), syscall.O_CREAT|syscall.O_RDWR|syscall.O_CLOEXEC, filePerm)
+	if err != nil {
+		return err
+	}
+
+	flockT := syscall.Flock_t{
+		Type:   syscall.F_WRLCK,
+		Whence: io.SeekStart,
+		Start:  0,
+		Len:    0,
+	}
+	for {
+		if err := syscall.FcntlFlock(s.cpFile.Fd(), syscall.F_SETLKW, &flockT); err != syscall.EINTR {
+			return err
+		}
+	}
+}
+
+// unlockCP unlocks the `checkpoint.lock` file.
+func (s *Storage) unlockCP() error {
+	if s.cpFile == nil {
+		panic(errors.New("not locked"))
+	}
+	if err := s.cpFile.Close(); err != nil {
+		return err
+	}
+	s.cpFile = nil
+	return nil
+}
+
+// Sequence commits to sequence numbers for an entry
+// Returns the sequence number assigned to the first entry in the batch, or an error.
+func (s *Storage) Sequence(ctx context.Context, b []byte) (uint64, error) {
+	return s.pool.Add(b)
+}
+
+// GetEntryBundle retrieves the Nth entries bundle.
+// If size is != the max size of the bundle, a partial bundle is returned.
+func (s *Storage) GetEntryBundle(ctx context.Context, index, size uint64) ([]byte, error) {
+	bd, bf := layout.SeqPath(s.path, index)
+	if size < uint64(s.params.EntryBundleSize) {
+		bf = fmt.Sprintf("%s.%d", bf, size)
+	}
+	return os.ReadFile(filepath.Join(bd, bf))
+}
+
+// sequenceBatch writes the entries from the provided batch into the entry bundle files of the log.
+//
+// This func starts filling entries bundles at the next available slot in the log, ensuring that the
+// sequenced entries are contiguous from the zeroth entry (i.e left-hand dense).
+// We try to minimise the number of partially complete entry bundles by writing entries in chunks rather
+// than one-by-one.
+func (s *Storage) sequenceBatch(ctx context.Context, batch writer.Batch) (uint64, error) {
+	// Double locking:
+	// - The mutex `Lock()` ensures that multiple concurrent calls to this function within a task are serialised.
+	// - The POSIX `LockCP()` ensures that distinct tasks are serialised.
+	s.Lock()
+	if err := s.lockCP(); err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := s.unlockCP(); err != nil {
+			panic(err)
+		}
+		s.Unlock()
+	}()
+
+	size, _, err := s.curTree()
+	if err != nil {
+		return 0, err
+	}
+	s.curSize = size
+
+	if len(batch.Entries) == 0 {
+		return 0, nil
+	}
+	seq := s.curSize
+	bundleIndex, entriesInBundle := seq/uint64(s.params.EntryBundleSize), seq%uint64(s.params.EntryBundleSize)
+	bundle := &bytes.Buffer{}
+	if entriesInBundle > 0 {
+		// If the latest bundle is partial, we need to read the data it contains in for our newer, larger, bundle.
+		part, err := s.GetEntryBundle(ctx, bundleIndex, entriesInBundle)
+		if err != nil {
+			return 0, err
+		}
+		bundle.Write(part)
+	}
+	// Add new entries to the bundle
+	for _, e := range batch.Entries {
+		bundle.WriteString(base64.StdEncoding.EncodeToString(e))
+		bundle.WriteString("\n")
+		entriesInBundle++
+		if entriesInBundle == uint64(s.params.EntryBundleSize) {
+			//  This bundle is full, so we need to write it out...
+			bd, bf := layout.SeqPath(s.path, bundleIndex)
+			if err := os.MkdirAll(bd, dirPerm); err != nil {
+				return 0, fmt.Errorf("failed to make seq directory structure: %w", err)
+			}
+			if err := createExclusive(filepath.Join(bd, bf), bundle.Bytes()); err != nil {
+				if !errors.Is(os.ErrExist, err) {
+					return 0, err
+				}
+			}
+			// ... and prepare the next entry bundle for any remaining entries in the batch
+			bundleIndex++
+			entriesInBundle = 0
+			bundle = &bytes.Buffer{}
+		}
+	}
+	// If we have a partial bundle remaining once we've added all the entries from the batch,
+	// this needs writing out too.
+	if entriesInBundle > 0 {
+		bd, bf := layout.SeqPath(s.path, bundleIndex)
+		bf = fmt.Sprintf("%s.%d", bf, entriesInBundle)
+		if err := os.MkdirAll(bd, dirPerm); err != nil {
+			return 0, fmt.Errorf("failed to make seq directory structure: %w", err)
+		}
+		if err := createExclusive(filepath.Join(bd, bf), bundle.Bytes()); err != nil {
+			if !errors.Is(os.ErrExist, err) {
+				return 0, err
+			}
+		}
+	}
+
+	// For simplicitly, well in-line the integration of these new entries into the Merkle structure too.
+	return seq, s.doIntegrate(ctx, seq, batch.Entries)
+}
+
+// doIntegrate handles integrating new entries into the log, and updating the checkpoint.
+func (s *Storage) doIntegrate(ctx context.Context, from uint64, batch [][]byte) error {
+	newSize, newRoot, err := writer.Integrate(ctx, from, batch, s, rfc6962.DefaultHasher)
+	if err != nil {
+		klog.Errorf("Failed to integrate: %v", err)
+		return err
+	}
+	if err := s.newTree(newSize, newRoot); err != nil {
+		return fmt.Errorf("newTree: %v", err)
+	}
+	return nil
+}
+
+// GetTile returns the tile at the given tile-level and tile-index.
+// If no complete tile exists at that location, it will attempt to find a
+// partial tile for the given tree size at that location.
+func (s *Storage) GetTile(_ context.Context, level, index, logSize uint64) (*api.Tile, error) {
+	tileSize := layout.PartialTileSize(level, index, logSize)
+	p := filepath.Join(layout.TilePath(s.path, level, index, tileSize))
+	t, err := os.ReadFile(p)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("failed to read tile at %q: %w", p, err)
+		}
+		return nil, err
+	}
+
+	var tile api.Tile
+	if err := tile.UnmarshalText(t); err != nil {
+		return nil, fmt.Errorf("failed to parse tile: %w", err)
+	}
+	return &tile, nil
+}
+
+// StoreTile writes a tile out to disk.
+// Fully populated tiles are stored at the path corresponding to the level &
+// index parameters, partially populated (i.e. right-hand edge) tiles are
+// stored with a .xx suffix where xx is the number of "tile leaves" in hex.
+func (s *Storage) StoreTile(_ context.Context, level, index uint64, tile *api.Tile) error {
+	tileSize := uint64(tile.NumLeaves)
+	klog.V(2).Infof("StoreTile: level %d index %x ts: %x", level, index, tileSize)
+	if tileSize == 0 || tileSize > 256 {
+		return fmt.Errorf("tileSize %d must be > 0 and <= 256", tileSize)
+	}
+	t, err := tile.MarshalText()
+	if err != nil {
+		return fmt.Errorf("failed to marshal tile: %w", err)
+	}
+
+	tDir, tFile := layout.TilePath(s.path, level, index, tileSize%256)
+	tPath := filepath.Join(tDir, tFile)
+
+	if err := os.MkdirAll(tDir, dirPerm); err != nil {
+		return fmt.Errorf("failed to create directory %q: %w", tDir, err)
+	}
+
+	// TODO(al): use unlinked temp file
+	temp := fmt.Sprintf("%s.temp", tPath)
+	if err := os.WriteFile(temp, t, filePerm); err != nil {
+		return fmt.Errorf("failed to write temporary tile file: %w", err)
+	}
+	if err := os.Rename(temp, tPath); err != nil {
+		if !errors.Is(os.ErrExist, err) {
+			return fmt.Errorf("failed to rename temporary tile file: %w", err)
+		}
+		os.Remove(temp)
+	}
+
+	if tileSize == 256 {
+		partials, err := filepath.Glob(fmt.Sprintf("%s.*", tPath))
+		if err != nil {
+			return fmt.Errorf("failed to list partial tiles for clean up; %w", err)
+		}
+		// Clean up old partial tiles by symlinking them to the new full tile.
+		for _, p := range partials {
+			klog.V(2).Infof("relink partial %s to %s", p, tPath)
+			// We have to do a little dance here to get POSIX atomicity:
+			// 1. Create a new temporary symlink to the full tile
+			// 2. Rename the temporary symlink over the top of the old partial tile
+			tmp := fmt.Sprintf("%s.link", tPath)
+			_ = os.Remove(tmp)
+			if err := os.Symlink(tPath, tmp); err != nil {
+				return fmt.Errorf("failed to create temp link to full tile: %w", err)
+			}
+			if err := os.Rename(tmp, p); err != nil {
+				return fmt.Errorf("failed to rename temp link over partial tile: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// WriteCheckpoint stores a raw log checkpoint on disk.
+func WriteCheckpoint(path string, newCPRaw []byte) error {
+	if err := createExclusive(filepath.Join(path, layout.CheckpointPath), newCPRaw); err != nil {
+		return fmt.Errorf("failed to create checkpoint file: %w", err)
+	}
+	return nil
+}
+
+// Readcheckpoint returns the latest stored checkpoint.
+func ReadCheckpoint(path string) ([]byte, error) {
+	return os.ReadFile(filepath.Join(path, layout.CheckpointPath))
+}
+
+// createExclusive creates a file at the given path and name before writing the data in d to it.
+// It will error if the file already exists, or it's unable to fully write the
+// data & close the file.
+func createExclusive(f string, d []byte) error {
+	tmpFile, err := os.CreateTemp(filepath.Dir(f), "")
+	if err != nil {
+		return fmt.Errorf("unable to create temporary file: %w", err)
+	}
+	tmpName := tmpFile.Name()
+	n, err := tmpFile.Write(d)
+	if err != nil {
+		return fmt.Errorf("unable to write leafdata to temporary file: %w", err)
+	}
+	if got, want := n, len(d); got != want {
+		return fmt.Errorf("short write on leaf, wrote %d expected %d", got, want)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, f); err != nil {
+		return err
+	}
+	return nil
+}

--- a/storage/posix/integrate.go
+++ b/storage/posix/integrate.go
@@ -1,0 +1,181 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/compact"
+	"github.com/transparency-dev/serverless-log/api"
+	"github.com/transparency-dev/serverless-log/api/layout"
+	"github.com/transparency-dev/serverless-log/client"
+	"k8s.io/klog/v2"
+)
+
+// IntegrateStorage represents the set of functions needed by the integrate function.
+type IntegrateStorage interface {
+	// GetTile returns the tile at the given level & index.
+	GetTile(ctx context.Context, level, index, logSize uint64) (*api.Tile, error)
+
+	// StoreTile stores the tile at the given level & index.
+	StoreTile(ctx context.Context, level, index uint64, tile *api.Tile) error
+
+	GetEntryBundle(ctx context.Context, index uint64, size uint64) ([]byte, error)
+}
+
+var (
+	// ErrDupeLeaf is returned by the Sequence method of storage implementations to
+	// indicate that a leaf has already been sequenced.
+	ErrDupeLeaf = errors.New("duplicate leaf")
+
+	// ErrSeqAlreadyAssigned is returned by the Assign method of storage implementations
+	// to indicate that the provided sequence number is already in use.
+	ErrSeqAlreadyAssigned = errors.New("sequence number already assigned")
+)
+
+// Integrate adds all sequenced entries greater than fromSize into the tree.
+// Returns an updated Checkpoint, or an error.
+func Integrate(ctx context.Context, fromSize uint64, batch [][]byte, st IntegrateStorage, h merkle.LogHasher) (uint64, []byte, error) {
+	getTile := func(l, i uint64) (*api.Tile, error) {
+		return st.GetTile(ctx, l, i, fromSize)
+	}
+
+	hashes, err := client.FetchRangeNodes(ctx, fromSize, func(_ context.Context, l, i uint64) (*api.Tile, error) {
+		return getTile(l, i)
+	})
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to fetch compact range nodes: %w", err)
+	}
+
+	rf := compact.RangeFactory{Hash: h.HashChildren}
+	baseRange, err := rf.NewRange(0, fromSize, hashes)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to create range covering existing log: %w", err)
+	}
+
+	// Initialise a compact range representation, and verify the stored state.
+	r, err := baseRange.GetRootHash(nil)
+	if err != nil {
+		return 0, nil, fmt.Errorf("invalid log state, unable to recalculate root: %w", err)
+	}
+
+	klog.V(1).Infof("Loaded state with roothash %x", r)
+
+	// Create a new compact range which represents the update to the tree
+	newRange := rf.NewEmptyRange(fromSize)
+	tc := tileCache{m: make(map[tileKey]*api.Tile), getTile: getTile}
+	if len(batch) == 0 {
+		klog.V(1).Infof("Nothing to do.")
+		// Nothing to do, nothing done.
+		return fromSize, r, nil
+	}
+	for _, e := range batch {
+		lh := h.HashLeaf(e)
+		// Update range and set nodes
+		if err := newRange.Append(lh, tc.Visit); err != nil {
+			return 0, nil, fmt.Errorf("newRange.Append(): %v", err)
+		}
+
+	}
+
+	// Merge the update range into the old tree
+	if err := baseRange.AppendRange(newRange, tc.Visit); err != nil {
+		return 0, nil, fmt.Errorf("failed to merge new range onto existing log: %w", err)
+	}
+
+	// Calculate the new root hash - don't pass in the tileCache visitor here since
+	// this will construct any ephemeral nodes and we do not want to store those.
+	newRoot, err := baseRange.GetRootHash(nil)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to calculate new root hash: %w", err)
+	}
+
+	// All calculation is now complete, all that remains is to store the new
+	// tiles and updated log state.
+	klog.V(1).Infof("New log state: size 0x%x hash: %x", baseRange.End(), newRoot)
+
+	for k, t := range tc.m {
+		if err := st.StoreTile(ctx, k.level, k.index, t); err != nil {
+			return 0, nil, fmt.Errorf("failed to store tile at level %d index %d: %w", k.level, k.index, err)
+		}
+	}
+
+	return baseRange.End(), newRoot, nil
+}
+
+// tileKey is a level/index key for the tile cache below.
+type tileKey struct {
+	level uint64
+	index uint64
+}
+
+// tileCache is a simple cache for storing the newly created tiles produced by
+// the integration of new leaves into the tree.
+//
+// Calls to Visit will cause the map of tiles to become filled with the set of
+// `dirty` tiles which need to be flushed back to disk to preserve the updated
+// tree state.
+//
+// Note that by itself, this cache does not update any on-disk state.
+type tileCache struct {
+	m map[tileKey]*api.Tile
+
+	getTile func(level, index uint64) (*api.Tile, error)
+}
+
+// Visit should be called once for each newly set non-ephemeral node in the
+// tree.
+//
+// If the tile containing id has not been seen before, this method will fetch
+// it from disk (or create a new empty in-memory tile if it doesn't exist), and
+// update it by setting the node corresponding to id to the value hash.
+func (tc tileCache) Visit(id compact.NodeID, hash []byte) {
+	tileLevel, tileIndex, nodeLevel, nodeIndex := layout.NodeCoordsToTileAddress(uint64(id.Level), uint64(id.Index))
+	tileKey := tileKey{level: tileLevel, index: tileIndex}
+	tile := tc.m[tileKey]
+	if tile == nil {
+		// We haven't see this tile before, so try to fetch it from disk
+		created := false
+
+		var err error
+		tile, err = tc.getTile(tileLevel, tileIndex)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				panic(err)
+			}
+			// This is a brand new tile.
+			created = true
+			tile = &api.Tile{
+				Nodes: make([][]byte, 0, 256*2),
+			}
+		}
+		klog.V(2).Infof("GetTile: %v new: %v", tileKey, created)
+		tc.m[tileKey] = tile
+	}
+	// Update the tile with the new node hash.
+	idx := api.TileNodeKey(nodeLevel, nodeIndex)
+	if l := uint(len(tile.Nodes)); idx >= l {
+		tile.Nodes = append(tile.Nodes, make([][]byte, idx-l+1)...)
+	}
+	tile.Nodes[idx] = hash
+	// Update the number of 'tile leaves', if necessary.
+	if nodeLevel == 0 && nodeIndex >= uint64(tile.NumLeaves) {
+		tile.NumLeaves = uint(nodeIndex + 1)
+	}
+}

--- a/storage/posix/writer.go
+++ b/storage/posix/writer.go
@@ -1,0 +1,91 @@
+package writer
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type Batch struct {
+	Entries [][]byte
+}
+
+// SequenceFunc knows how to assign contiguous sequence numbers to the entries in Batch.
+// Returns the sequence number of the first entry, or an error.
+// Must not return successfully until the assigned sequence numbers are durably stored.
+type SequenceFunc func(context.Context, Batch) (uint64, error)
+
+func NewPool(bufferSize int, maxAge time.Duration, s SequenceFunc) *Pool {
+	return &Pool{
+		current: &batch{
+			Done: make(chan struct{}),
+		},
+		bufferSize: bufferSize,
+		seq:        s,
+		maxAge:     maxAge,
+	}
+}
+
+// Pool is a helper for adding entries to a log.
+type Pool struct {
+	sync.Mutex
+	current    *batch
+	bufferSize int
+	maxAge     time.Duration
+	flushTimer *time.Timer
+
+	seq SequenceFunc
+}
+
+// Add adds an entry to the tree.
+// Returns the assigned sequence number, or an error.
+func (p *Pool) Add(e []byte) (uint64, error) {
+	p.Lock()
+	b := p.current
+	// If this is the first entry in a batch, set a flush timer so we attempt to sequence it within maxAge.
+	if len(b.Entries) == 0 {
+		p.flushTimer = time.AfterFunc(p.maxAge, func() {
+			p.Lock()
+			defer p.Unlock()
+			p.flushWithLock()
+		})
+	}
+	n := b.Add(e)
+	// If the batch is full, then attempt to sequence it immediately.
+	if n >= p.bufferSize {
+		p.flushWithLock()
+	}
+	p.Unlock()
+	<-b.Done
+	return b.FirstSeq + uint64(n), b.Err
+}
+
+func (p *Pool) flushWithLock() {
+	// timer can be nil if a batch was flushed because it because full at about the same time as it hit maxAge.
+	// In this case we can just return.
+	if p.flushTimer == nil {
+		return
+	}
+	p.flushTimer.Stop()
+	p.flushTimer = nil
+	b := p.current
+	p.current = &batch{
+		Done: make(chan struct{}),
+	}
+	go func() {
+		b.FirstSeq, b.Err = p.seq(context.TODO(), Batch{Entries: b.Entries})
+		close(b.Done)
+	}()
+}
+
+type batch struct {
+	Entries  [][]byte
+	Done     chan struct{}
+	FirstSeq uint64
+	Err      error
+}
+
+func (b *batch) Add(e []byte) int {
+	b.Entries = append(b.Entries, e)
+	return len(b.Entries)
+}

--- a/storage/posix/writer.go
+++ b/storage/posix/writer.go
@@ -1,4 +1,17 @@
-package writer
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package posix
 
 import (
 	"context"
@@ -15,14 +28,14 @@ type Batch struct {
 // Must not return successfully until the assigned sequence numbers are durably stored.
 type SequenceFunc func(context.Context, Batch) (uint64, error)
 
-func NewPool(bufferSize int, maxAge time.Duration, s SequenceFunc) *Pool {
+func NewPool(s SequenceFunc) *Pool {
 	return &Pool{
 		current: &batch{
 			Done: make(chan struct{}),
 		},
-		bufferSize: bufferSize,
+		bufferSize: 256,
 		seq:        s,
-		maxAge:     maxAge,
+		maxAge:     1 * time.Second,
 	}
 }
 

--- a/testdata/build_log.sh
+++ b/testdata/build_log.sh
@@ -4,14 +4,11 @@
 
 set -e # exit on any error codes from sub-commands
 
-echo https://github.com/mhutchinson/trillian-tessera/tree/log-posix needs to be merged before test data can be regenerated
-exit 1
-
 DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
 export LOG=${DIR}/log/
-export SERVERLESS_LOG_PRIVATE_KEY="PRIVATE+KEY+example.com/log/testdata+33d7b496+AeymY/SZAX0jZcJ8enZ5FY1Dz+wTML2yWSkK+9DSF3eg"
-export SERVERLESS_LOG_PUBLIC_KEY="example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
+export LOG_PRIVATE_KEY="PRIVATE+KEY+example.com/log/testdata+33d7b496+AeymY/SZAX0jZcJ8enZ5FY1Dz+wTML2yWSkK+9DSF3eg"
+export LOG_PUBLIC_KEY="example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
 export ORIGIN="example.com/log/testdata"
 
 cd ${DIR}


### PR DESCRIPTION
This is largely a copy and paste job from both the experimental Betty repo and from serverless. The primary motivation to have this posix implementation right now is to generate test data, such as that used in #49.

There has been little in the way of optimization. The primary concern was minimal code changes in order to get a working posix log to generate test data.


Towards #22