### PR TITLE
Add Checkpoint option & batch options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/storage v1.43.0
 	github.com/globocom/go-buffer v1.2.2
 	github.com/google/go-cmp v0.6.0
-	github.com/transparency-dev/formats v0.0.0-20240708083310-9b0b58067af6
+	github.com/transparency-dev/formats v0.0.0-20240715203801-9ff9b9e3905f
 	github.com/transparency-dev/merkle v0.0.2
 	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	golang.org/x/mod v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -910,8 +910,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/transparency-dev/formats v0.0.0-20240708083310-9b0b58067af6 h1:3HfNa+Pc/u/v6DGaMSzDHq9hDkhSS58qc4SEFDaeF1w=
-github.com/transparency-dev/formats v0.0.0-20240708083310-9b0b58067af6/go.mod h1:D/QMvgv1kz9Q1TfUcDnUcDPsiSbtLV8q8LvTCdcvygw=
+github.com/transparency-dev/formats v0.0.0-20240715203801-9ff9b9e3905f h1:NKx8BtgVYeC75VJqlsdn1DAcbmSSDQCeDw8by0m6sbA=
+github.com/transparency-dev/formats v0.0.0-20240715203801-9ff9b9e3905f/go.mod h1:D/QMvgv1kz9Q1TfUcDnUcDPsiSbtLV8q8LvTCdcvygw=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/log.go
+++ b/log.go
@@ -1,0 +1,67 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tessera
+
+import (
+	"fmt"
+	"time"
+
+	f_log "github.com/transparency-dev/formats/log"
+	"golang.org/x/mod/sumdb/note"
+)
+
+type NewCPFunc func(size uint64, hash []byte) ([]byte, error)
+
+type StorageOptions struct {
+	NewCP NewCPFunc
+
+	BatchMaxAge  time.Duration
+	BatchMaxSize uint
+}
+
+func ResolveStorageOptions(defaults *StorageOptions, opts ...func(*StorageOptions)) *StorageOptions {
+	if defaults == nil {
+		defaults = &StorageOptions{}
+	}
+	for _, opt := range opts {
+		opt(defaults)
+	}
+	return defaults
+}
+
+func WithCheckpointSigner(s note.Signer) func(*StorageOptions) {
+	return func(o *StorageOptions) {
+		o.NewCP = func(size uint64, hash []byte) ([]byte, error) {
+			cpRaw := f_log.Checkpoint{
+				Origin: s.Name(),
+				Size:   size,
+				Hash:   hash,
+			}.Marshal()
+
+			n, err := note.Sign(&note.Note{Text: string(cpRaw)}, s)
+			if err != nil {
+				return nil, fmt.Errorf("Sign: %v", err)
+			}
+			return n, nil
+		}
+	}
+}
+
+func WithBatching(maxSize uint, maxAge time.Duration) func(*StorageOptions) {
+	return func(o *StorageOptions) {
+		o.BatchMaxAge = maxAge
+		o.BatchMaxSize = maxSize
+	}
+}

--- a/log.go
+++ b/log.go
@@ -22,8 +22,10 @@ import (
 	"golang.org/x/mod/sumdb/note"
 )
 
+// NewCPFunc is the signature of a function which knows how to format and sign checkpoints.
 type NewCPFunc func(size uint64, hash []byte) ([]byte, error)
 
+// StorageOptions holds optional settings for all storage implementations.
 type StorageOptions struct {
 	NewCP NewCPFunc
 
@@ -31,6 +33,7 @@ type StorageOptions struct {
 	BatchMaxSize uint
 }
 
+// ResolveStorageOptions turns a variadic array of storage options into a StorageOptions instance.
 func ResolveStorageOptions(defaults *StorageOptions, opts ...func(*StorageOptions)) *StorageOptions {
 	if defaults == nil {
 		defaults = &StorageOptions{}
@@ -41,6 +44,10 @@ func ResolveStorageOptions(defaults *StorageOptions, opts ...func(*StorageOption
 	return defaults
 }
 
+// WithCheckpointSigner is an option for setting the note signer to use when creating checkpoints.
+//
+// Checkpoints signed by this signer will be standard checkpoints as defined by https://c2sp.org/tlog-checkpoint.
+// The provided signer's name will be used as the Origin line on the checkpoint.
 func WithCheckpointSigner(s note.Signer) func(*StorageOptions) {
 	return func(o *StorageOptions) {
 		o.NewCP = func(size uint64, hash []byte) ([]byte, error) {
@@ -59,6 +66,7 @@ func WithCheckpointSigner(s note.Signer) func(*StorageOptions) {
 	}
 }
 
+// WithBatching enables batching of write requests.
 func WithBatching(maxSize uint, maxAge time.Duration) func(*StorageOptions) {
 	return func(o *StorageOptions) {
 		o.BatchMaxAge = maxAge


### PR DESCRIPTION
This PR adds two common storage options:
- one for setting a signer to be used when signing checkpoints
- one for configuring the batching queue.