### PR TITLE
GCP: temporary hack to proxy read requests to GCS

### DIFF
--- a/cmd/example-gcp/main.go
+++ b/cmd/example-gcp/main.go
@@ -80,11 +80,10 @@ func main() {
 		if err != nil {
 			klog.V(1).Infof("Get: %v", err)
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(fmt.Sprintf("Get: %v", err)))
+			_, _ = w.Write([]byte(fmt.Sprintf("Get: %v", err)))
 			return
 		}
-		w.Write(b)
-		return
+		_, _ = w.Write(b)
 	}
 	http.HandleFunc("GET /checkpoint", serveGCS)
 	http.HandleFunc("GET /tile/", serveGCS)

--- a/cmd/example-gcp/main.go
+++ b/cmd/example-gcp/main.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/storage/gcp"
@@ -71,6 +72,22 @@ func main() {
 		}
 		_, _ = w.Write([]byte(fmt.Sprintf("%d", idx)))
 	})
+
+	// TODO: remove this proxy
+	serveGCS := func(w http.ResponseWriter, r *http.Request) {
+		resource := strings.TrimLeft(r.URL.Path, "/")
+		b, err := storage.Get(r.Context(), resource)
+		if err != nil {
+			klog.V(1).Infof("Get: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(fmt.Sprintf("Get: %v", err)))
+			return
+		}
+		w.Write(b)
+		return
+	}
+	http.HandleFunc("GET /checkpoint", serveGCS)
+	http.HandleFunc("GET /tile/", serveGCS)
 
 	if err := http.ListenAndServe(*listen, http.DefaultServeMux); err != nil {
 		klog.Exitf("ListenAndServe: %v", err)

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -159,7 +159,17 @@ func (s *Storage) Add(ctx context.Context, e tessera.Entry) (uint64, error) {
 	return s.queue.Add(ctx, e)()
 }
 
+// Get returns the requested object.
+//
+// This is indended to be used to proxy read requests through the personality for debug/testing purposes.
+func (s *Storage) Get(ctx context.Context, path string) ([]byte, error) {
+	d, _, err := s.objStore.getObject(ctx, path)
+	return d, err
+}
+
 // setTile idempotently stores the provided tile at the location implied by the given level, index, and treeSize.
+//
+// The location to which the tile is written is defined by the tile layout spec.
 func (s *Storage) setTile(ctx context.Context, level, index, logSize uint64, tile *api.HashTile) error {
 	data, err := tile.MarshalText()
 	if err != nil {


### PR DESCRIPTION
This PR allows an easy way for the hammer to get access to the log static resources by proxying read requests into GCS reads.
