### PR TITLE
CT static API support

### DIFF
--- a/api/state.go
+++ b/api/state.go
@@ -67,9 +67,11 @@ type EntryBundle struct {
 }
 
 // MarshalText implements encoding/TextMarshaller and writes out an EntryBundle
-// instance as sequences of big-endian uint16 length-prefixed log entries,
-// as specified by the tlog-tiles spec.
-// TODO(#41): this _may_ need to be changed to support CT
+// instance as sequences of serialised Entries.
+//
+// Entries must serialise to a "stream"-ready format (i.e. they should be self-describing
+// enough to allow correct deserialisation of multiple concatenated entries without
+// the need for any further demarcation.
 func (t EntryBundle) MarshalText() ([]byte, error) {
 	r := &bytes.Buffer{}
 	sizeBs := make([]byte, 2)

--- a/api/state.go
+++ b/api/state.go
@@ -66,25 +66,6 @@ type EntryBundle struct {
 	Entries [][]byte
 }
 
-// MarshalText implements encoding/TextMarshaller and writes out an EntryBundle
-// // instance as sequences of big-endian uint16 length-prefixed log entries,
-// as specified by the tlog-tiles spec.
-// TODO(#41): this _may_ need to be changed to support CT
-func (t EntryBundle) MarshalText() ([]byte, error) {
-	r := &bytes.Buffer{}
-	sizeBs := make([]byte, 2)
-	for _, n := range t.Entries {
-		binary.BigEndian.PutUint16(sizeBs, uint16(len(n)))
-		if _, err := r.Write(sizeBs); err != nil {
-			return nil, err
-		}
-		if _, err := r.Write(n); err != nil {
-			return nil, err
-		}
-	}
-	return r.Bytes(), nil
-}
-
 // UnmarshalText implements encoding/TextUnmarshaler and reads EntryBundles
 // which are encoded using the tlog-tiles spec.
 func (t *EntryBundle) UnmarshalText(raw []byte) error {

--- a/api/state.go
+++ b/api/state.go
@@ -67,11 +67,9 @@ type EntryBundle struct {
 }
 
 // MarshalText implements encoding/TextMarshaller and writes out an EntryBundle
-// instance as sequences of serialised Entries.
-//
-// Entries must serialise to a "stream"-ready format (i.e. they should be self-describing
-// enough to allow correct deserialisation of multiple concatenated entries without
-// the need for any further demarcation.
+// // instance as sequences of big-endian uint16 length-prefixed log entries,
+// as specified by the tlog-tiles spec.
+// TODO(#41): this _may_ need to be changed to support CT
 func (t EntryBundle) MarshalText() ([]byte, error) {
 	r := &bytes.Buffer{}
 	sizeBs := make([]byte, 2)

--- a/api/state.go
+++ b/api/state.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 )
 
@@ -64,6 +65,10 @@ func (t *HashTile) UnmarshalText(raw []byte) error {
 type EntryBundle struct {
 	// Entries stores the leaf entries of the log, in order.
 	Entries [][]byte
+}
+
+func (t *EntryBundle) MarshalText() ([]byte, error) {
+	return nil, errors.New("unimplemented")
 }
 
 // UnmarshalText implements encoding/TextUnmarshaler and reads EntryBundles

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -90,9 +90,7 @@ func TestLeafBundle_MarshalTileRoundtrip(t *testing.T) {
 				if _, err := rand.Read(want[i]); err != nil {
 					t.Error(err)
 				}
-				if err := tessera.NewEntry(want[i]).WriteBundleEntry(bundleRaw); err != nil {
-					t.Fatalf("Write: %v", err)
-				}
+				_, _ = bundleRaw.Write(tessera.NewEntry(want[i]).MarshalBundleData(uint64(i)))
 			}
 
 			tile2 := api.EntryBundle{}

--- a/ct_only.go
+++ b/ct_only.go
@@ -24,7 +24,7 @@ import (
 type Storage interface {
 	// Add should duably assign an index to the provided Entry, and return it.
 	//
-	// Implementations MUST call MarshalBundleData method on the entry before marshaling and persisting it.
+	// Implementations MUST call MarshalBundleData method on the entry before persisting/integrating it.
 	Add(context.Context, *Entry) (uint64, error)
 }
 

--- a/ct_only.go
+++ b/ct_only.go
@@ -15,9 +15,6 @@
 package tessera
 
 import (
-	"fmt"
-	"io"
-
 	"github.com/transparency-dev/trillian-tessera/ctonly"
 )
 
@@ -38,13 +35,8 @@ func convertCTEntry(e ctonly.Entry) Entry {
 		r.internal.LeafHash = e.MerkleLeafHash(idx)
 		r.internal.Data = e.LeafData(idx)
 	}
-	r.writeBundleEntry = func(w io.Writer) error {
-		if n, err := w.Write(r.internal.Data); err != nil {
-			return err
-		} else if l := len(r.internal.Data); n != l {
-			return fmt.Errorf("short write % bytes, want %d", n, l)
-		}
-		return nil
+	r.marshalBundle = func() []byte {
+		return r.internal.Data
 	}
 
 	return r

--- a/ct_only.go
+++ b/ct_only.go
@@ -48,11 +48,9 @@ func NewCertificateTransparencySequencedWriter(s Storage) func(context.Context, 
 func convertCTEntry(e *ctonly.Entry) *Entry {
 	r := &Entry{}
 	r.internal.Identity = e.Identity()
-	r.indexFunc = func(idx uint64) {
+	r.marshalBundle = func(idx uint64) []byte {
 		r.internal.LeafHash = e.MerkleLeafHash(idx)
 		r.internal.Data = e.LeafData(idx)
-	}
-	r.marshalBundle = func() []byte {
 		return r.internal.Data
 	}
 

--- a/ct_only.go
+++ b/ct_only.go
@@ -24,7 +24,7 @@ import (
 type Storage interface {
 	// Add should duably assign an index to the provided Entry, and return it.
 	//
-	// Implementations MUST call the AssignIndex() method on the entry before marshaling and persisting it.
+	// Implementations MUST call MarshalBundleData method on the entry before marshaling and persisting it.
 	Add(context.Context, *Entry) (uint64, error)
 }
 

--- a/ct_only.go
+++ b/ct_only.go
@@ -15,21 +15,38 @@
 package tessera
 
 import (
+	"context"
+
 	"github.com/transparency-dev/trillian-tessera/ctonly"
 )
 
+// Storage described the expected functions from Tessera storage implementations.
 type Storage interface {
-	Add(Entry) (uint64, error)
+	// Add should duably assign an index to the provided Entry, and return it.
+	//
+	// Implementations MUST call the AssignIndex() method on the entry before marshaling and persisting it.
+	Add(context.Context, *Entry) (uint64, error)
 }
 
-func NewCertificateTransparencySequencedWriter(s Storage) func(e ctonly.Entry) (uint64, error) {
-	return func(e ctonly.Entry) (uint64, error) {
-		return s.Add(convertCTEntry(e))
+// NewCertificateTransparencySequencedWriter returns a function which knows how to add a CT-specific entry type to the log.
+//
+// This entry point MUST ONLY be used for CT logs participating in the CT ecosystem.
+// It should not be used as the basis for any other/new transparency application as this protocol:
+// a) embodies some techniques which are not considered to be best practice (it does this to retain backawards-compatibility with RFC6962)
+// b) is not compatible with the https://c2sp.org/tlog-tiles API which we _very strongly_ encourage you to use instead.
+//
+// Returns the assigned index in the log, or an error.
+func NewCertificateTransparencySequencedWriter(s Storage) func(context.Context, *ctonly.Entry) (uint64, error) {
+	return func(ctx context.Context, e *ctonly.Entry) (uint64, error) {
+		return s.Add(ctx, convertCTEntry(e))
 	}
 }
 
-func convertCTEntry(e ctonly.Entry) Entry {
-	r := Entry{}
+// convertCTEntry returns an Entry struct which will do the right thing for CT Static API logs.
+//
+// This MUST NOT be used for any other purpose.
+func convertCTEntry(e *ctonly.Entry) *Entry {
+	r := &Entry{}
 	r.internal.Identity = e.Identity()
 	r.indexFunc = func(idx uint64) {
 		r.internal.LeafHash = e.MerkleLeafHash(idx)

--- a/ct_only.go
+++ b/ct_only.go
@@ -48,7 +48,7 @@ func NewCertificateTransparencySequencedWriter(s Storage) func(context.Context, 
 func convertCTEntry(e *ctonly.Entry) *Entry {
 	r := &Entry{}
 	r.internal.Identity = e.Identity()
-	r.marshalBundle = func(idx uint64) []byte {
+	r.marshalForBundle = func(idx uint64) []byte {
 		r.internal.LeafHash = e.MerkleLeafHash(idx)
 		r.internal.Data = e.LeafData(idx)
 		return r.internal.Data

--- a/ct_only.go
+++ b/ct_only.go
@@ -1,0 +1,51 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tessera
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/transparency-dev/trillian-tessera/ctonly"
+)
+
+type Storage interface {
+	Add(Entry) (uint64, error)
+}
+
+func NewCertificateTransparencySequencedWriter(s Storage) func(e ctonly.Entry) (uint64, error) {
+	return func(e ctonly.Entry) (uint64, error) {
+		return s.Add(convertCTEntry(e))
+	}
+}
+
+func convertCTEntry(e ctonly.Entry) Entry {
+	r := Entry{}
+	r.internal.Identity = e.Identity()
+	r.indexFunc = func(idx uint64) {
+		r.internal.LeafHash = e.MerkleLeafHash(idx)
+		r.internal.Data = e.LeafData(idx)
+	}
+	r.writeBundleEntry = func(w io.Writer) error {
+		if n, err := w.Write(r.internal.Data); err != nil {
+			return err
+		} else if l := len(r.internal.Data); n != l {
+			return fmt.Errorf("short write % bytes, want %d", n, l)
+		}
+		return nil
+	}
+
+	return r
+}

--- a/ctonly/ct.go
+++ b/ctonly/ct.go
@@ -1,0 +1,169 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+// Original source: https://github.com/FiloSottile/sunlight/blob/main/tile.go
+//
+// # Copyright 2023 The Sunlight Authors
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// Package ctonly has support for CT Tiles API.
+//
+// This code should not be reused outside of CT.
+// Most of this code came from Filipo's Sunlight implementation of https://c2sp.org/ct-static-api.
+package ctonly
+
+import (
+	"crypto/sha256"
+	"errors"
+
+	"github.com/transparency-dev/merkle/rfc6962"
+	"golang.org/x/crypto/cryptobyte"
+)
+
+// Entry represents a CT log entry.
+type Entry struct {
+	Timestamp          uint64
+	IsPrecert          bool
+	Certificate        []byte
+	Precertificate     []byte
+	PrecertSigningCert []byte
+	IssuerKeyHash      []byte
+}
+
+// LeafData returns the data which should be added to an entry bundle for this entry.
+//
+// Note that this will include data which IS NOT directly committed to by the entry's
+// MerkleLeafHash.
+func (c Entry) LeafData(idx uint64) []byte {
+	b := cryptobyte.NewBuilder([]byte{})
+	b.AddUint64(uint64(c.Timestamp))
+	if !c.IsPrecert {
+		b.AddUint16(0 /* entry_type = x509_entry */)
+		b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
+			b.AddBytes(c.Certificate)
+		})
+	} else {
+		b.AddUint16(1 /* entry_type = precert_entry */)
+		b.AddBytes(c.IssuerKeyHash[:])
+		b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
+			b.AddBytes(c.Certificate)
+		})
+	}
+	addExtensions(b, idx)
+	if c.IsPrecert {
+		b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
+			b.AddBytes(c.Precertificate)
+		})
+		b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
+			b.AddBytes(c.PrecertSigningCert)
+		})
+	}
+	return b.BytesOrPanic()
+}
+
+// MerkleLeafHash returns the RFC6962 leaf hash for this entry.
+//
+// Note that we embed an SCT extension which captures the index of the entry in the log according to
+// the mechanism specified in https://c2sp.org/ct-static-api.
+func (c Entry) MerkleLeafHash(leafIndex uint64) []byte {
+	b := &cryptobyte.Builder{}
+	b.AddUint8(0 /* version = v1 */)
+	b.AddUint8(0 /* leaf_type = timestamped_entry */)
+	b.AddUint64(uint64(c.Timestamp))
+	if !c.IsPrecert {
+		b.AddUint16(0 /* entry_type = x509_entry */)
+		b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
+			b.AddBytes(c.Certificate)
+		})
+	} else {
+		b.AddUint16(1 /* entry_type = precert_entry */)
+		b.AddBytes(c.IssuerKeyHash[:])
+		b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
+			b.AddBytes(c.Certificate)
+		})
+	}
+	addExtensions(b, leafIndex)
+	return rfc6962.DefaultHasher.HashLeaf(b.BytesOrPanic())
+}
+
+func (c Entry) Identity() []byte {
+	var r [sha256.Size]byte
+	if c.IsPrecert {
+		r = sha256.Sum256(c.Precertificate)
+	} else {
+		r = sha256.Sum256(c.Certificate)
+	}
+	return r[:]
+}
+
+func addExtensions(b *cryptobyte.Builder, leafIndex uint64) {
+	b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
+		ext, err := extensions{LeafIndex: leafIndex}.Marshal()
+		if err != nil {
+			b.SetError(err)
+			return
+		}
+		b.AddBytes(ext)
+	})
+}
+
+// extensions is the CTExtensions field of SignedCertificateTimestamp and
+// TimestampedEntry, according to c2sp.org/static-ct-api.
+type extensions struct {
+	LeafIndex uint64
+}
+
+func (c extensions) Marshal() ([]byte, error) {
+	// enum {
+	//     leaf_index(0), (255)
+	// } ExtensionType;
+	//
+	// struct {
+	//     ExtensionType extension_type;
+	//     opaque extension_data<0..2^16-1>;
+	// } Extension;
+	//
+	// Extension CTExtensions<0..2^16-1>;
+	//
+	// uint8 uint40[5];
+	// uint40 LeafIndex;
+
+	b := &cryptobyte.Builder{}
+	b.AddUint8(0 /* extension_type = leaf_index */)
+	b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
+		if c.LeafIndex >= 1<<40 {
+			b.SetError(errors.New("leaf_index out of range"))
+			return
+		}
+		addUint40(b, uint64(c.LeafIndex))
+	})
+	return b.Bytes()
+}
+
+// addUint40 appends a big-endian, 40-bit value to the byte string.
+func addUint40(b *cryptobyte.Builder, v uint64) {
+	b.AddBytes([]byte{byte(v >> 32), byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)})
+}

--- a/entry.go
+++ b/entry.go
@@ -35,8 +35,8 @@ type Entry struct {
 		Index    *uint64
 	}
 
-	// marshalBundle knows how to convert this entry's Data into a marshalled bundle entry.
-	marshalBundle func(index uint64) []byte
+	// marshalForBundle knows how to convert this entry's Data into a marshalled bundle entry.
+	marshalForBundle func(index uint64) []byte
 }
 
 // Data returns the raw entry bytes which will form the entry in the log.
@@ -59,7 +59,7 @@ func (e Entry) Index() *uint64 { return e.internal.Index }
 // be considered final until the storage Add method has returned successfully with the durably assigned index.
 func (e *Entry) MarshalBundleData(index uint64) []byte {
 	e.internal.Index = &index
-	return e.marshalBundle(index)
+	return e.marshalForBundle(index)
 }
 
 // NewEntry creates a new Entry object with leaf data.
@@ -76,10 +76,10 @@ func NewEntry(data []byte, opts ...EntryOpt) *Entry {
 	if e.internal.LeafHash == nil {
 		e.internal.LeafHash = rfc6962.DefaultHasher.HashLeaf(e.internal.Data)
 	}
-	if e.marshalBundle == nil {
+	if e.marshalForBundle == nil {
 		// By default we will marshal ourselves into a bundle using the mechanism described
 		// by https://c2sp.org/tlog-tiles:
-		e.marshalBundle = func(_ uint64) []byte {
+		e.marshalForBundle = func(_ uint64) []byte {
 			r := make([]byte, 0, 2+len(e.internal.Data))
 			r = binary.BigEndian.AppendUint16(r, uint16(len(e.internal.Data)))
 			r = append(r, e.internal.Data...)

--- a/entry_test.go
+++ b/entry_test.go
@@ -25,7 +25,7 @@ func TestEntryMarshalBundleDelegates(t *testing.T) {
 	wantBundle := []byte(fmt.Sprintf("Yes %d", wantIdx))
 
 	e := NewEntry([]byte("this is data"))
-	e.marshalBundle = func(gotIdx uint64) []byte {
+	e.marshalForBundle = func(gotIdx uint64) []byte {
 		if gotIdx != wantIdx {
 			t.Fatalf("Got idx %d, want %d", gotIdx, wantIdx)
 		}

--- a/entry_test.go
+++ b/entry_test.go
@@ -33,7 +33,7 @@ func TestEntryMarshalRoundTrip(t *testing.T) {
 		t.Fatalf("UnmarshalBinary: %v", err)
 	}
 
-	if !reflect.DeepEqual(e, e2) {
+	if !reflect.DeepEqual(e.internal, e2.internal) {
 		t.Fatalf("got %+v, want %+v", e2, e)
 	}
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -25,8 +25,8 @@ func TestEntryMarshalBundleDelegates(t *testing.T) {
 	wantBundle := []byte(fmt.Sprintf("Yes %d", wantIdx))
 
 	e := NewEntry([]byte("this is data"))
-	e.marshalBundle = func() []byte {
-		if gotIdx := *e.internal.Index; gotIdx != wantIdx {
+	e.marshalBundle = func(gotIdx uint64) []byte {
+		if gotIdx != wantIdx {
 			t.Fatalf("Got idx %d, want %d", gotIdx, wantIdx)
 		}
 		return wantBundle

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -483,10 +483,10 @@ func (s *spannerSequencer) assignEntries(ctx context.Context, entries []*tessera
 	})
 
 	if err != nil {
-		return 0, fmt.Errorf("failed to flush batch: %v", err)
+		return fmt.Errorf("failed to flush batch: %v", err)
 	}
 
-	return uint64(next), nil
+	return nil
 }
 
 // consumeEntries calls f with previously sequenced entries.

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -185,13 +185,16 @@ func TestTileRoundtrip(t *testing.T) {
 	}
 }
 
-func makeBundle(t *testing.T, size uint64) *api.EntryBundle {
+func makeBundle(t *testing.T, size uint64) []byte {
 	t.Helper()
-	r := &api.EntryBundle{Entries: make([][]byte, size)}
+	r := &bytes.Buffer{}
 	for i := uint64(0); i < size; i++ {
-		r.Entries[i] = []byte(fmt.Sprintf("%d", i))
+		e := tessera.NewEntry([]byte(fmt.Sprintf("%d", i)))
+		if err := e.WriteBundleEntry(r); err != nil {
+			t.Fatalf("WriteBundleEntry: %v", err)
+		}
 	}
-	return r
+	return r.Bytes()
 }
 
 func TestBundleRoundtrip(t *testing.T) {

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -70,7 +70,7 @@ func TestSpannerSequencerAssignEntries(t *testing.T) {
 
 	want := uint64(0)
 	for chunks := 0; chunks < 10; chunks++ {
-		entries := []tessera.Entry{}
+		entries := []*tessera.Entry{}
 		for i := 0; i < 10+chunks; i++ {
 			entries = append(entries, tessera.NewEntry([]byte(fmt.Sprintf("item %d/%d", chunks, i))))
 		}
@@ -97,7 +97,7 @@ func TestSpannerSequencerRoundTrip(t *testing.T) {
 
 	seq := 0
 	for chunks := 0; chunks < 10; chunks++ {
-		entries := []tessera.Entry{}
+		entries := []*tessera.Entry{}
 		for i := 0; i < 10+chunks; i++ {
 			entries = append(entries, tessera.NewEntry([]byte(fmt.Sprintf("item %d", seq))))
 			seq++
@@ -108,7 +108,7 @@ func TestSpannerSequencerRoundTrip(t *testing.T) {
 	}
 
 	seenIdx := uint64(0)
-	f := func(_ context.Context, fromSeq uint64, entries []tessera.Entry) error {
+	f := func(_ context.Context, fromSeq uint64, entries []*tessera.Entry) error {
 		if fromSeq != seenIdx {
 			return fmt.Errorf("f called with fromSeq %d, want %d", fromSeq, seenIdx)
 		}

--- a/storage/integrate.go
+++ b/storage/integrate.go
@@ -87,7 +87,7 @@ func (t *TreeBuilder) newRange(ctx context.Context, treeSize uint64) (*compact.R
 	return t.rf.NewRange(0, treeSize, hashes)
 }
 
-func (t *TreeBuilder) Integrate(ctx context.Context, fromSize uint64, entries []tessera.Entry) (newSize uint64, rootHash []byte, tiles map[TileID]*api.HashTile, err error) {
+func (t *TreeBuilder) Integrate(ctx context.Context, fromSize uint64, entries []*tessera.Entry) (newSize uint64, rootHash []byte, tiles map[TileID]*api.HashTile, err error) {
 	baseRange, err := t.newRange(ctx, fromSize)
 	if err != nil {
 		return 0, nil, nil, fmt.Errorf("failed to create range covering existing log: %w", err)

--- a/storage/integrate.go
+++ b/storage/integrate.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/transparency-dev/merkle/compact"
 	"github.com/transparency-dev/merkle/rfc6962"
-	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
 	"golang.org/x/exp/maps"
@@ -87,7 +86,15 @@ func (t *TreeBuilder) newRange(ctx context.Context, treeSize uint64) (*compact.R
 	return t.rf.NewRange(0, treeSize, hashes)
 }
 
-func (t *TreeBuilder) Integrate(ctx context.Context, fromSize uint64, entries []*tessera.Entry) (newSize uint64, rootHash []byte, tiles map[TileID]*api.HashTile, err error) {
+// SequencedEntry represents a log entry which has already been sequenced.
+type SequencedEntry struct {
+	// BundleData is the entry's data serialised into the correct format for appending to an entry bundle.
+	BundleData []byte
+	// LeafHash is the entry's Merkle leaf hash.
+	LeafHash []byte
+}
+
+func (t *TreeBuilder) Integrate(ctx context.Context, fromSize uint64, entries []SequencedEntry) (newSize uint64, rootHash []byte, tiles map[TileID]*api.HashTile, err error) {
 	baseRange, err := t.newRange(ctx, fromSize)
 	if err != nil {
 		return 0, nil, nil, fmt.Errorf("failed to create range covering existing log: %w", err)
@@ -111,7 +118,7 @@ func (t *TreeBuilder) Integrate(ctx context.Context, fromSize uint64, entries []
 	visitor := tc.Visitor(ctx)
 	for _, e := range entries {
 		// Update range and set nodes
-		if err := newRange.Append(e.LeafHash(), visitor); err != nil {
+		if err := newRange.Append(e.LeafHash, visitor); err != nil {
 			return 0, nil, nil, fmt.Errorf("newRange.Append(): %v", err)
 		}
 

--- a/storage/integrate_test.go
+++ b/storage/integrate_test.go
@@ -131,7 +131,7 @@ func TestIntegrate(t *testing.T) {
 	seq := uint64(0)
 	for chunk := 0; chunk < numChunks; chunk++ {
 		oldSeq := seq
-		c := make([]tessera.Entry, chunkSize)
+		c := make([]*tessera.Entry, chunkSize)
 		for i := range c {
 			leaf := []byte{byte(seq)}
 			c[i] = tessera.NewEntry(leaf)

--- a/storage/integrate_test.go
+++ b/storage/integrate_test.go
@@ -131,10 +131,14 @@ func TestIntegrate(t *testing.T) {
 	seq := uint64(0)
 	for chunk := 0; chunk < numChunks; chunk++ {
 		oldSeq := seq
-		c := make([]*tessera.Entry, chunkSize)
+		c := make([]SequencedEntry, chunkSize)
 		for i := range c {
 			leaf := []byte{byte(seq)}
-			c[i] = tessera.NewEntry(leaf)
+			entry := tessera.NewEntry(leaf)
+			c[i] = SequencedEntry{
+				BundleData: entry.MarshalBundleData(seq),
+				LeafHash:   entry.LeafHash(),
+			}
 			if err := cr.Append(rfc6962.DefaultHasher.HashLeaf(leaf), nil); err != nil {
 				t.Fatalf("compact Append: %v", err)
 			}

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -173,11 +173,10 @@ func newEntry(data *tessera.Entry) *entry {
 // to be given the values provided here.
 func (e *entry) notify(err error) {
 	e.c <- func() (uint64, error) {
-		idx := uint64(0)
 		if err != nil {
-			idx = *e.data.Index()
+			return 0, err
 		}
-		return idx, err
+		return *e.data.Index(), nil
 	}
 	close(e.c)
 }

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -47,8 +47,10 @@ type Queue struct {
 type IndexFunc func() (idx uint64, err error)
 
 // FlushFunc is the signature of a function which will receive the slice of queued entries.
-// It should return call AssignIndex to each entry with its assigned index *before* durably
-// persisting the assignment.
+// Normally, this function would be provided by storage implementations. It's important to note
+// that the implementation MUST call each entry's MarshalBundleData function before attempting
+// to integrate it into the tree.
+// See the comment on Entry.MarshalBundleData for further info.
 type FlushFunc func(ctx context.Context, entries []*tessera.Entry) error
 
 // NewQueue creates a new queue with the specified maximum age and size.

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -17,6 +17,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -141,6 +142,9 @@ func (q *Queue) doFlush(ctx context.Context, entries []*entry) {
 	defer q.inFlightMu.Unlock()
 
 	for _, e := range entries {
+		if e.data.Index() == nil {
+			panic(errors.New("Logic error: flush complete, but entry was not assigned an index - did storage fail to call entry.MarshalBundleData?"))
+		}
 		e.notify(err)
 		k := string(e.data.Identity())
 		delete(q.inFlight, k)

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -74,7 +74,7 @@ func TestQueue(t *testing.T) {
 			q := storage.NewQueue(ctx, test.maxWait, uint(test.maxEntries), flushFunc)
 
 			// Now submit a bunch of entries
-			adds := make([]storage.IndexFunc, test.numItems)
+			adds := make([]storage.Future, test.numItems)
 			wantEntries := make([]*tessera.Entry, test.numItems)
 			for i := uint64(0); i < test.numItems; i++ {
 				d := []byte(fmt.Sprintf("item %d", i))
@@ -109,7 +109,7 @@ func TestDedup(t *testing.T) {
 	})
 
 	numEntries := 10
-	adds := []storage.IndexFunc{}
+	adds := []storage.Future{}
 	for i := 0; i < numEntries; i++ {
 		adds = append(adds, q.Add(ctx, tessera.NewEntry([]byte("Have I seen this before?"))))
 	}

--- a/storage/queue_test.go
+++ b/storage/queue_test.go
@@ -63,7 +63,7 @@ func TestQueue(t *testing.T) {
 				defer assignMu.Unlock()
 
 				for _, e := range entries {
-					e.AssignIndex(assignedIndex)
+					_ = e.MarshalBundleData(assignedIndex)
 					assignedItems[assignedIndex] = e
 					assignedIndex++
 				}
@@ -102,7 +102,7 @@ func TestDedup(t *testing.T) {
 
 	q := storage.NewQueue(ctx, time.Second, 10 /*maxSize*/, func(ctx context.Context, entries []*tessera.Entry) error {
 		for _, e := range entries {
-			e.AssignIndex(idx)
+			_ = e.MarshalBundleData(idx)
 			idx++
 		}
 		return nil


### PR DESCRIPTION
This PR enables Tessera to support a [CT Static API](https://c2sp.org/ct-static-api) personality.

There's broadly two things which are necessary to be able to support that personality:
1. Formatting of `EntryBundle` is different and incompatible
   [tlog-tiles](https://c2sp.org/tlog-tiles) specifies a `length/value` scheme, whereas CT Static API specifies just `value` and relies on the fact that `value` in this case is self-describing.
2. Each log entry _contains its own index in the log_.
   The SCT returned to the submitter contains the sequence number of the entry in the log in the `CtExtensions` field of the SCT struct. What's not obvious from the spec is that this must also be part of the Merkle leaf (otherwise compatibility with RFC6962 would be broken).
   This means that we don't actually know the `LeafData` or its `MerkleLeafHash` until we've sequenced it.
 
Beyond enabling a CT Static API personality to be built, other large goals for this PR are:
1. To make it hard/impossible to build new transparency log ecosystems which attempt to use these patterns outside of CT.
2. Avoid "overly invasive" changes spreading throughout Tessera, instead containing them as close as possible to the personality: 
3. Non-CT logs shouldn't have to pay a performance cost simply because the support exists
4. Contain changes to the sequencing side, leaving integration concerned only with managing Merkle specifics.

Toward #41 
