### PR TITLE
Reintroduce sync for flushing

### DIFF
--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -126,7 +126,7 @@ func New(ctx context.Context, cfg Config, opts ...func(*tessera.StorageOptions))
 		newCP:     opt.NewCP,
 	}
 	// TODO(al): make queue options configurable:
-	r.queue = storage.NewQueue(time.Second, 256, r.sequencer.assignEntries)
+	r.queue = storage.NewQueue(ctx, time.Second, 256, r.sequencer.assignEntries)
 
 	go func() {
 		t := time.NewTicker(1 * time.Second)

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -82,7 +82,7 @@ func NewQueue(ctx context.Context, maxAge time.Duration, maxSize uint, f FlushFu
 		buffer.WithFlusher(buffer.FlusherFunc(toWork)),
 	)
 
-	// This will allow
+	// Spin off a worker thread to write the queue flushes to storage.
 	go func(ctx context.Context) {
 		for {
 			select {

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -120,7 +120,6 @@ func (q *Queue) Add(ctx context.Context, e tessera.Entry) IndexFunc {
 	}
 	if err := q.buf.Push(entry); err != nil {
 		entry.assign(0, err)
-		close(entry.c)
 	}
 	return entry.index
 }

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -63,7 +63,7 @@ func NewQueue(ctx context.Context, maxAge time.Duration, maxSize uint, f FlushFu
 
 	// The underlying queue implementation blocks additions during a flush.
 	// This blocks the filling of the next batch unnecessarily, so we'll
-	// decouple the queue flush and storage write by handling the later in
+	// decouple the queue flush and storage write by handling the latter in
 	// a worker goroutine.
 	// This same worker thread will also handle the callbacks to f.
 	work := make(chan []*entry, 1)
@@ -125,9 +125,6 @@ func (q *Queue) Add(ctx context.Context, e tessera.Entry) IndexFunc {
 }
 
 // doFlush handles the queue flush, and sending notifications of assigned log indices.
-//
-// To prevent blocking the queue longer than necessary, the notifications happen in a
-// separate goroutine.
 func (q *Queue) doFlush(ctx context.Context, entries []*entry) {
 	entriesData := make([]tessera.Entry, 0, len(entries))
 	for _, e := range entries {


### PR DESCRIPTION
This PR reintroduces a single-threaded nature for queue flushing.

Given the strictly serialised nature of assigning sequence numbers without gaps it's unlikely that storage implementations would be able to increase performance by taking multiple flushes in parallel.

Toward #6 