### PR TITLE
Complete instructions to deploy Tessera GCP

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -26,7 +26,7 @@ export GOOGLE_PROJECT={VALUE}
 ```
 
 Eventually, customize the region (defaults to "us-east1"), and bucket name prefix
-(defaults to "trillian-tessera"):
+(defaults to "tessera"):
 ```bash
 export GOOGLE_REGION={VALUE}
 export TESSERA_BASE_NAME={VALUE}

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -14,25 +14,5 @@ Deploying these examples requires installation of:
 
 ## Deploying
 
-First authenticate via `gcloud` as a principle with sufficient ACLs for
-the project:
-```bash
-gcloud auth application-default login
-```
-
-Then, specify your Google Cloud project ID:
-```bash
-export GOOGLE_PROJECT={VALUE}
-```
-
-Eventually, customize the region (defaults to "us-east1"), and bucket name prefix
-(defaults to "tessera"):
-```bash
-export GOOGLE_REGION={VALUE}
-export TESSERA_BASE_NAME={VALUE}
-```
-
-Terraforming the project can be done by:
- 1. `cd` to the relevant `live` directory for the environment to deploy/change
- 2. Run `terragrunt apply`
+See individual `live` subdirectories.
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -20,6 +20,18 @@ the project:
 gcloud auth application-default login
 ```
 
+Then, specify your Google Cloud project ID:
+```bash
+export GOOGLE_PROJECT={VALUE}
+```
+
+Eventually, customize the region (defaults to "us-east1"), and bucket name prefix
+(defaults to "trillian-tessera"):
+```bash
+export GOOGLE_REGION={VALUE}
+export TESSERA_BASE_NAME={VALUE}
+```
+
 Terraforming the project can be done by:
  1. `cd` to the relevant `live` directory for the environment to deploy/change
  2. Run `terragrunt apply`

--- a/deployment/live/example-gcp/README.md
+++ b/deployment/live/example-gcp/README.md
@@ -6,13 +6,13 @@ the project:
 gcloud auth application-default login
 ```
 
-Then, specify your Google Cloud project ID:
+Set your GCP project ID with:
 ```bash
 export GOOGLE_PROJECT={VALUE}
 ```
 
-Eventually, customize the region (defaults to "us-central1"), and bucket name prefix
-(defaults to "tessera-example"):
+Eventually, customize the GCP region (defaults to "us-central1"),
+and bucket name prefix (defaults to "example-gcp"):
 ```bash
 export GOOGLE_REGION={VALUE}
 export TESSERA_BASE_NAME={VALUE}

--- a/deployment/live/example-gcp/README.md
+++ b/deployment/live/example-gcp/README.md
@@ -1,0 +1,24 @@
+## Deployment 
+
+First authenticate via `gcloud` as a principle with sufficient ACLs for
+the project:
+```bash
+gcloud auth application-default login
+```
+
+Then, specify your Google Cloud project ID:
+```bash
+export GOOGLE_PROJECT={VALUE}
+```
+
+Eventually, customize the region (defaults to "us-east1"), and bucket name prefix
+(defaults to "tessera-example"):
+```bash
+export GOOGLE_REGION={VALUE}
+export TESSERA_BASE_NAME={VALUE}
+```
+
+Terraforming the project can be done by:
+ 1. `cd` to the relevant `live` directory for the environment to deploy/change
+ 2. Run `terragrunt apply`
+

--- a/deployment/live/example-gcp/README.md
+++ b/deployment/live/example-gcp/README.md
@@ -11,7 +11,7 @@ Set your GCP project ID with:
 export GOOGLE_PROJECT={VALUE}
 ```
 
-Eventually, customize the GCP region (defaults to "us-central1"),
+Optionally, customize the GCP region (defaults to "us-central1"),
 and bucket name prefix (defaults to "example-gcp"):
 ```bash
 export GOOGLE_REGION={VALUE}

--- a/deployment/live/example-gcp/README.md
+++ b/deployment/live/example-gcp/README.md
@@ -11,7 +11,7 @@ Then, specify your Google Cloud project ID:
 export GOOGLE_PROJECT={VALUE}
 ```
 
-Eventually, customize the region (defaults to "us-east1"), and bucket name prefix
+Eventually, customize the region (defaults to "us-central1"), and bucket name prefix
 (defaults to "tessera-example"):
 ```bash
 export GOOGLE_REGION={VALUE}

--- a/deployment/live/example-gcp/terragrunt.hcl
+++ b/deployment/live/example-gcp/terragrunt.hcl
@@ -5,7 +5,7 @@ terraform {
 locals {
   project_id = get_env("GOOGLE_PROJECT")
   location   = get_env("GOOGLE_REGION", "us-central1")
-  base_name   = get_env("TESSERA_BASE_NAME", "tessera")
+  base_name   = get_env("TESSERA_BASE_NAME", "tessera-example")
 }
 
 inputs = merge(

--- a/deployment/live/example-gcp/terragrunt.hcl
+++ b/deployment/live/example-gcp/terragrunt.hcl
@@ -3,9 +3,9 @@ terraform {
 }
 
 locals {
-  project_id = get_env("GOOGLE_PROJECT")
+  project_id = get_env("GOOGLE_PROJECT", "trillian-example")
   location   = get_env("GOOGLE_REGION", "us-central1")
-  base_name   = get_env("TESSERA_BASE_NAME", "tessera-example")
+  base_name   = get_env("TESSERA_BASE_NAME", "example-gcp")
 }
 
 inputs = merge(

--- a/deployment/live/example-gcp/terragrunt.hcl
+++ b/deployment/live/example-gcp/terragrunt.hcl
@@ -5,7 +5,7 @@ terraform {
 locals {
   project_id = get_env("GOOGLE_PROJECT")
   location   = get_env("GOOGLE_REGION", "us-central1")
-  base_name   = get_env("TESSERA_BASE_NAME", "trillian-tessera")
+  base_name   = get_env("TESSERA_BASE_NAME", "tessera")
 }
 
 inputs = merge(

--- a/deployment/live/example-gcp/terragrunt.hcl
+++ b/deployment/live/example-gcp/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 locals {
-  project_id = get_env("GOOGLE_PROJECT", "trillian-example")
+  project_id = get_env("GOOGLE_PROJECT", "trillian-tessera")
   location   = get_env("GOOGLE_REGION", "us-central1")
   base_name   = get_env("TESSERA_BASE_NAME", "example-gcp")
 }

--- a/deployment/live/example-gcp/terragrunt.hcl
+++ b/deployment/live/example-gcp/terragrunt.hcl
@@ -3,9 +3,9 @@ terraform {
 }
 
 locals {
-  project_id = "trillian-tessera"
-  location   = "us-central1"
-  base_name   = "example-gcp"
+  project_id = get_env("GOOGLE_PROJECT")
+  location   = get_env("GOOGLE_REGION", "us-central1")
+  base_name   = get_env("TESSERA_BASE_NAME", "trillian-tessera")
 }
 
 inputs = merge(

--- a/deployment/modules/gcs/main.tf
+++ b/deployment/modules/gcs/main.tf
@@ -52,7 +52,7 @@ resource "google_storage_bucket_iam_binding" "log_bucket_writer" {
 resource "google_spanner_instance" "log_spanner" {
   name             = var.base_name
   config           = "regional-${var.location}"
-  display_name     = "${var.base_name} Spanner Instance"
+  display_name     = "${var.base_name}"
   processing_units = 100
 }
 

--- a/deployment/modules/gcs/main.tf
+++ b/deployment/modules/gcs/main.tf
@@ -52,7 +52,7 @@ resource "google_storage_bucket_iam_binding" "log_bucket_writer" {
 resource "google_spanner_instance" "log_spanner" {
   name             = var.base_name
   config           = "regional-${var.location}"
-  display_name     = "${var.base_name}"
+  display_name     = "${var.base_name} Spanner Instance"
   processing_units = 100
 }
 


### PR DESCRIPTION
This PR also changes the base name from "example-gcp" to "trillian-tessera" since I think it makes more sense as a default value. I'd rather fix this sooner rather than later, but happy to revert this change if you think it's too disruptive.