### PR TITLE
Hammer stats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.5
 require (
 	cloud.google.com/go/spanner v1.65.0
 	cloud.google.com/go/storage v1.43.0
+	github.com/RobinUS2/golang-moving-average v1.0.0
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/globocom/go-buffer v1.2.2
 	github.com/google/go-cmp v0.6.0
@@ -17,8 +18,6 @@ require (
 	google.golang.org/grpc v1.65.0
 	k8s.io/klog/v2 v2.130.1
 )
-
-require github.com/RobinUS2/golang-moving-average v1.0.0
 
 require (
 	cel.dev/expr v0.15.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 )
 
-require github.com/RobinUS2/golang-moving-average v1.0.0 // indirect
+require github.com/RobinUS2/golang-moving-average v1.0.0
 
 require (
 	cel.dev/expr v0.15.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/globocom/go-buffer v1.2.2
 	github.com/google/go-cmp v0.6.0
+	github.com/mxmCherry/movavg v1.1.0
 	github.com/rivo/tview v0.0.0-20240625185742-b0a7293b8130
 	github.com/transparency-dev/formats v0.0.0-20240715203801-9ff9b9e3905f
 	github.com/transparency-dev/merkle v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/globocom/go-buffer v1.2.2
 	github.com/google/go-cmp v0.6.0
-	github.com/mxmCherry/movavg v1.1.0
 	github.com/rivo/tview v0.0.0-20240625185742-b0a7293b8130
 	github.com/transparency-dev/formats v0.0.0-20240715203801-9ff9b9e3905f
 	github.com/transparency-dev/merkle v0.0.2
@@ -18,6 +17,8 @@ require (
 	google.golang.org/grpc v1.65.0
 	k8s.io/klog/v2 v2.130.1
 )
+
+require github.com/RobinUS2/golang-moving-average v1.0.0 // indirect
 
 require (
 	cel.dev/expr v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -869,6 +869,8 @@ github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
+github.com/mxmCherry/movavg v1.1.0 h1:92Ye8RKXcIaELZJH1pKSdDdh3k7+6tD6Yr+Azxwy3v8=
+github.com/mxmCherry/movavg v1.1.0/go.mod h1:8Jn4ovhDwtfTnwqxAEKKHTbKXLgnozsIRg+/Ge6EoJI=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go.sum
+++ b/go.sum
@@ -621,6 +621,8 @@ github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.0 h1:oVLqHXhnYtUwM89y9T1
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.0/go.mod h1:dppbR7CwXD4pgtV9t3wD1812RaLDcBjtblcDF5f1vI0=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/RobinUS2/golang-moving-average v1.0.0 h1:PD7DDZNt+UFb9XlsBbTIu/DtXqqaD/MD86DYnk3mwvA=
+github.com/RobinUS2/golang-moving-average v1.0.0/go.mod h1:MdzhY+KoEvi+OBygTPH0OSaKrOJzvILWN2SPQzaKVsY=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -869,8 +871,6 @@ github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
-github.com/mxmCherry/movavg v1.1.0 h1:92Ye8RKXcIaELZJH1pKSdDdh3k7+6tD6Yr+Azxwy3v8=
-github.com/mxmCherry/movavg v1.1.0/go.mod h1:8Jn4ovhDwtfTnwqxAEKKHTbKXLgnozsIRg+/Ge6EoJI=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/hammer/hammer.go
+++ b/hammer/hammer.go
@@ -124,7 +124,7 @@ func NewHammer(tracker *client.LogStateTracker, f client.Fetcher, w LeafWriter) 
 		tracker:         tracker,
 		errChan:         errChan,
 		leafSampleChan:  leafSampleChan,
-		integrationTime: movingaverage.New(10),
+		integrationTime: movingaverage.New(30),
 	}
 }
 
@@ -326,7 +326,7 @@ func hostUI(ctx context.Context, hammer *Hammer) {
 	ticker := time.NewTicker(interval)
 	go func() {
 		lastSize := hammer.tracker.LatestConsistent.Size
-		maSlots := 10
+		maSlots := int((30 * time.Second) / interval)
 		growth := movingaverage.New(maSlots)
 		for {
 			select {

--- a/hammer/workers.go
+++ b/hammer/workers.go
@@ -207,6 +207,7 @@ func (w *LogWriter) Run(ctx context.Context) {
 		lt.idx, lt.assignedAt = index, time.Now()
 		// See if we can send a leaf sample
 		select {
+		// TODO: we might want to count dropped samples, and/or make sampling a bit more statistical.
 		case w.leafChan <- lt:
 		default:
 		}


### PR DESCRIPTION
this PR adds a few (hopefully) useful stats lines to the top pane: 
- checkpoint size & growth-per-second averaged over the last 30s,
- a "sampled" min-avg-max of how long entries wait to have indices assigned (i.e. `Add()` latency)
- a "sampled" total-time-to-integrate (i.e latency from calling `Add()` to a checkpoint committing to the entry.

```
│Read: Current max: 10/s. Oversupply in last second: 0
│Write: Current max: 10000/s. Oversupply in last second: 1018
│TreeSize: 179489419 (Δ 957qps over 30s)
│Time-in-queue: 981ms/1863ms/3031ms (min/avg/max)
│Total-time-to-integrate: 1399ms/2432ms/4055ms (min/avg/max)
```