### PR TITLE
Add MySQL Go test to GitHub workflows

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -24,8 +24,8 @@ jobs:
   test-mysql:
     env:
       DB_DATABASE: test_tessera
-      DB_USER: test_tessera
-      DB_PASSWORD: test_tessera
+      DB_USER: root
+      DB_PASSWORD: root
 
     runs-on: ubuntu-latest
     

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -1,7 +1,10 @@
-on: [push, pull_request]
 name: Test Go
+
+on: [push, pull_request]
+
 permissions:
   contents: read
+
 jobs:
   test:
     strategy:
@@ -9,10 +12,29 @@ jobs:
         go-version: [1.22.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
+
     steps:
-    - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-      with:
-        go-version: ${{ matrix.go-version }}
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3.1.0
-    - run: go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
-    - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3.1.0
+      - run: go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
+      - uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+
+  test-mysql:
+    env:
+      DB_DATABASE: test_tessera
+      DB_USER: test_tessera
+      DB_PASSWORD: test_tessera
+
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v3.1.0
+      - name: Start MySQL
+        run: |
+          sudo /etc/init.d/mysql start
+          mysql -e "CREATE DATABASE IF NOT EXISTS $DB_DATABASE;" -u$DB_USER -p$DB_PASSWORD
+      - name: Test with Go
+        run: go test -v -race ./storage/mysql/...

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -1,0 +1,32 @@
+package mysql_test
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"os"
+	"testing"
+
+	"k8s.io/klog/v2"
+)
+
+var mysqlURI = flag.String("mysql_uri", "root:root@tcp(db:3306)/test_tessera", "Connection string for a MySQL database")
+
+func TestMain(m *testing.M) {
+	klog.InitFlags(nil)
+	flag.Parse()
+	ctx := context.Background()
+
+	db, err := sql.Open("mysql", *mysqlURI)
+	if err != nil {
+		klog.Errorf("MySQL not available, skipping all MySQL storage tests")
+		return
+	}
+	if err := db.PingContext(ctx); err != nil {
+		klog.Errorf("MySQL not available, skipping all MySQL storage tests")
+		return
+	}
+	klog.Info("Successfully connected to MySQL test database")
+
+	os.Exit(m.Run())
+}

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var mysqlURI = flag.String("mysql_uri", "root:root@tcp(db:3306)/test_tessera", "Connection string for a MySQL database")
+var mysqlURI = flag.String("mysql_uri", "root:root@tcp(localhost:3306)/test_tessera", "Connection string for a MySQL database")
 
 func TestMain(m *testing.M) {
 	klog.InitFlags(nil)


### PR DESCRIPTION
#21 

The Go test can successfully connect to the GitHub workflow's MySQL test database.

```
Run go test -v -race ./storage/mysql/...
go: downloading go1.22.5 (linux/amd64)
go: downloading github.com/go-sql-driver/mysql v1.[8](https://github.com/transparency-dev/trillian-tessera/actions/runs/10197078592/job/28209161789#step:4:9).1
go: downloading github.com/transparency-dev/merkle v0.0.2
go: downloading k8s.io/klog/v2 v2.130.1
go: downloading github.com/transparency-dev/formats v0.0.0-20240715203801-[9](https://github.com/transparency-dev/trillian-tessera/actions/runs/10197078592/job/28209161789#step:4:10)ff9b9e3905f
go: downloading golang.org/x/mod v0.19.0
go: downloading github.com/globocom/go-buffer v1.2.2
go: downloading golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
go: downloading golang.org/x/crypto v0.25.0
go: downloading filippo.io/edwards25519 v1.1.0
go: downloading github.com/go-logr/logr v1.4.2
I0801 [11](https://github.com/transparency-dev/trillian-tessera/actions/runs/10197078592/job/28209161789#step:4:12):03:45.426821    4239 mysql_test.go:29] Successfully connected to MySQL test database
testing: warning: no tests to run
PASS
ok  	github.com/transparency-dev/trillian-tessera/storage/mysql	1.011s [no tests to run]
```