### PR TITLE
Force MySQL Go test to fail on GitHub workflow if the MySQL test database is not available

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -37,4 +37,4 @@ jobs:
           sudo /etc/init.d/mysql start
           mysql -e "CREATE DATABASE IF NOT EXISTS $DB_DATABASE;" -u$DB_USER -p$DB_PASSWORD
       - name: Test with Go
-        run: go test -v -race ./storage/mysql/...
+        run: go test -v -race ./storage/mysql/... -is_mysql_test_optional=false

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -10,7 +10,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var mysqlURI = flag.String("mysql_uri", "root:root@tcp(localhost:3306)/test_tessera", "Connection string for a MySQL database")
+var (
+	mysqlURI            = flag.String("mysql_uri", "root:root@tcp(localhost:3306)/test_tessera", "Connection string for a MySQL database")
+	isMySQLTestOptional = flag.Bool("is_mysql_test_optional", true, "Boolean value to control whether the MySQL test is optional")
+)
 
 func TestMain(m *testing.M) {
 	klog.InitFlags(nil)
@@ -19,12 +22,18 @@ func TestMain(m *testing.M) {
 
 	db, err := sql.Open("mysql", *mysqlURI)
 	if err != nil {
-		klog.Errorf("MySQL not available, skipping all MySQL storage tests")
-		return
+		if *isMySQLTestOptional {
+			klog.Warning("MySQL not available, skipping all MySQL storage tests")
+			return
+		}
+		klog.Fatalf("Failed to open MySQL test db: %v", err)
 	}
 	if err := db.PingContext(ctx); err != nil {
-		klog.Errorf("MySQL not available, skipping all MySQL storage tests")
-		return
+		if *isMySQLTestOptional {
+			klog.Warning("MySQL not available, skipping all MySQL storage tests")
+			return
+		}
+		klog.Fatalf("Failed to ping MySQL test db: %v", err)
 	}
 	klog.Info("Successfully connected to MySQL test database")
 


### PR DESCRIPTION
#21 

```sh
Run go test -v -race ./storage/mysql/... -is_mysql_test_optional=false
  go test -v -race ./storage/mysql/... -is_mysql_test_optional=false
  shell: /usr/bin/bash -e {0}
  env:
    DB_DATABASE: test_tessera
    DB_USER: root
    DB_PASSWORD: root
go: downloading go1.22.5 (linux/amd64)
go: downloading github.com/go-sql-driver/mysql v1.8.1
go: downloading github.com/transparency-dev/merkle v0.0.2
go: downloading k8s.io/klog/v2 v2.130.1
go: downloading github.com/transparency-dev/formats v0.0.0-20240715203801-9ff9b9e3905f
go: downloading golang.org/x/mod v0.19.0
go: downloading github.com/globocom/go-buffer v1.2.2
go: downloading golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
go: downloading golang.org/x/crypto v0.25.0
go: downloading filippo.io/edwards25519 v1.1.0
go: downloading github.com/go-logr/logr v1.4.2
I0801 14:54:00.601791    4259 mysql_test.go:38] Successfully connected to MySQL test database
testing: warning: no tests to run
PASS
ok  	github.com/transparency-dev/trillian-tessera/storage/mysql	1.010s [no tests to run]
```