### PR TITLE
Performance tweaks for GCP

### DIFF
--- a/cmd/example-gcp/main.go
+++ b/cmd/example-gcp/main.go
@@ -55,6 +55,7 @@ func main() {
 	storage, err := gcp.New(ctx, gcpCfg,
 		tessera.WithCheckpointSignerVerifier(signerFromFlags(), nil),
 		tessera.WithBatching(1024, time.Second),
+		tessera.WithPushback(10*4096),
 	)
 	if err != nil {
 		klog.Exitf("Failed to create new GCP storage: %v", err)


### PR DESCRIPTION
This PR adjusts behaviour of the GCP storage implementation slightly to improve performance, and avoid having to redo work due to GCS update limits.

#23 