### PR TITLE
Don't break integration on error

### DIFF
--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -145,12 +145,16 @@ func New(ctx context.Context, cfg Config, opts ...func(*tessera.StorageOptions))
 				return
 			case <-t.C:
 			}
-			// Don't quicklook for now, it causes issues updating checkpoint too frequently.
-			cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-			defer cancel()
-			if _, err := r.sequencer.consumeEntries(cctx, DefaultIntegrationSizeLimit, r.integrate); err != nil {
-				klog.Errorf("integrate: %v", err)
-			}
+
+			func() {
+				// Don't quicklook for now, it causes issues updating checkpoint too frequently.
+				cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+				defer cancel()
+
+				if _, err := r.sequencer.consumeEntries(cctx, DefaultIntegrationSizeLimit, r.integrate); err != nil {
+					klog.Errorf("integrate: %v", err)
+				}
+			}()
 		}
 	}()
 

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -147,7 +147,7 @@ func New(ctx context.Context, cfg Config, opts ...func(*tessera.StorageOptions))
 			}
 
 			func() {
-				// Don't quicklook for now, it causes issues updating checkpoint too frequently.
+				// Don't quickloop for now, it causes issues updating checkpoint too frequently.
 				cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 				defer cancel()
 

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -150,7 +150,6 @@ func New(ctx context.Context, cfg Config, opts ...func(*tessera.StorageOptions))
 			defer cancel()
 			if _, err := r.sequencer.consumeEntries(cctx, DefaultIntegrationSizeLimit, r.integrate); err != nil {
 				klog.Errorf("integrate: %v", err)
-				break
 			}
 		}
 	}()


### PR DESCRIPTION
This PR corrects a bug introduced in #109 which causes the GCP integration loop to exit if there's an error during an integration run.