### PR TITLE
move c-t-go/util/timesource.go to sctfe package

### DIFF
--- a/personalities/sctfe/handlers.go
+++ b/personalities/sctfe/handlers.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/tls"
-	"github.com/google/certificate-transparency-go/trillian/util"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/google/trillian/monitoring"
@@ -196,8 +195,8 @@ func NewCertValidationOpts(trustedRoots *x509util.PEMCertPool, currentTime time.
 type logInfo struct {
 	// LogOrigin identifies the log, as per https://c2sp.org/static-ct-api
 	LogOrigin string
-	// TimeSource is a util.TimeSource that can be injected for testing
-	TimeSource util.TimeSource
+	// TimeSource is a TimeSource that can be injected for testing
+	TimeSource TimeSource
 	// RequestLog is a logger for various request / processing / response debug
 	// information.
 	RequestLog RequestLog
@@ -217,7 +216,7 @@ func newLogInfo(
 	instanceOpts InstanceOptions,
 	validationOpts CertValidationOpts,
 	signer crypto.Signer,
-	timeSource util.TimeSource,
+	timeSource TimeSource,
 ) *logInfo {
 	vCfg := instanceOpts.Validated
 	cfg := vCfg.Config

--- a/personalities/sctfe/handlers_test.go
+++ b/personalities/sctfe/handlers_test.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/certificate-transparency-go/trillian/util"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/google/go-cmp/cmp"
@@ -54,7 +53,7 @@ var fakeTimeMillis = uint64(fakeTime.UnixNano() / millisPerNano)
 
 // The deadline should be the above bumped by 500ms
 var fakeDeadlineTime = time.Date(2016, 7, 22, 11, 01, 13, 500*1000*1000, time.UTC)
-var fakeTimeSource = util.NewFixedTimeSource(fakeTime)
+var fakeTimeSource = NewFixedTimeSource(fakeTime)
 
 type handlerTestInfo struct {
 	mockCtrl *gomock.Controller

--- a/personalities/sctfe/instance.go
+++ b/personalities/sctfe/instance.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/google/certificate-transparency-go/asn1"
 	"github.com/google/certificate-transparency-go/trillian/ctfe/cache"
-	"github.com/google/certificate-transparency-go/trillian/util"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/google/trillian/crypto/keys"
@@ -147,7 +146,7 @@ func setUpLogInfo(ctx context.Context, opts InstanceOptions) (*logInfo, error) {
 		return nil, fmt.Errorf("failed to parse RejectExtensions: %v", err)
 	}
 
-	logInfo := newLogInfo(opts, validationOpts, signer, new(util.SystemTimeSource))
+	logInfo := newLogInfo(opts, validationOpts, signer, new(SystemTimeSource))
 	return logInfo, nil
 }
 

--- a/personalities/sctfe/timesource.go
+++ b/personalities/sctfe/timesource.go
@@ -1,0 +1,48 @@
+// Copyright 2016 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sctfe
+
+import "time"
+
+// TimeSource can provide the current time, or be replaced by a mock in tests to return
+// specific values.
+type TimeSource interface {
+	// Now returns the current time in real implementations or a suitable value in others
+	Now() time.Time
+}
+
+// SystemTimeSource provides the current system local time
+type SystemTimeSource struct{}
+
+// Now returns the true current local time.
+func (s SystemTimeSource) Now() time.Time {
+	return time.Now()
+}
+
+// FixedTimeSource provides a fixed time for use in tests.
+// It should not be used in production code.
+type FixedTimeSource struct {
+	fakeTime time.Time
+}
+
+// NewFixedTimeSource creates a FixedTimeSource instance
+func NewFixedTimeSource(t time.Time) *FixedTimeSource {
+	return &FixedTimeSource{fakeTime: t}
+}
+
+// Now returns the time value this instance contains
+func (f *FixedTimeSource) Now() time.Time {
+	return f.fakeTime
+}

--- a/personalities/sctfe/timesource_export_test.go
+++ b/personalities/sctfe/timesource_export_test.go
@@ -16,17 +16,18 @@ package sctfe
 
 import "time"
 
-// TimeSource can provide the current time, or be replaced by a mock in tests to return
-// specific values.
-type TimeSource interface {
-	// Now returns the current time in real implementations or a suitable value in others
-	Now() time.Time
+// FixedTimeSource provides a fixed time for use in tests.
+// It should not be used in production code.
+type FixedTimeSource struct {
+	fakeTime time.Time
 }
 
-// SystemTimeSource provides the current system local time
-type SystemTimeSource struct{}
+// NewFixedTimeSource creates a FixedTimeSource instance
+func NewFixedTimeSource(t time.Time) *FixedTimeSource {
+	return &FixedTimeSource{fakeTime: t}
+}
 
-// Now returns the true current local time.
-func (s SystemTimeSource) Now() time.Time {
-	return time.Now()
+// Now returns the time value this instance contains
+func (f *FixedTimeSource) Now() time.Time {
+	return f.fakeTime
 }


### PR DESCRIPTION
I don't see any reason why it would be in its own package. Packages named util are discouraged, https://go.dev/blog/package-names#bad-package-names, let's get rid of it.