### PR TITLE
Pass a signer to Tessera

### DIFF
--- a/personalities/sctfe/ct_server_gcp/main.go
+++ b/personalities/sctfe/ct_server_gcp/main.go
@@ -41,9 +41,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 	"github.com/tomasen/realip"
+	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/personalities/sctfe"
 	"github.com/transparency-dev/trillian-tessera/personalities/sctfe/configpb"
 	"github.com/transparency-dev/trillian-tessera/storage/gcp"
+	"golang.org/x/mod/sumdb/note"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/klog/v2"
 )
@@ -283,14 +285,14 @@ func setupAndRegister(ctx context.Context, deadline time.Duration, vCfg *sctfe.V
 	return inst, nil
 }
 
-func newGCPStorage(ctx context.Context, vCfg *sctfe.ValidatedLogConfig) (*sctfe.CTStorage, error) {
+func newGCPStorage(ctx context.Context, vCfg *sctfe.ValidatedLogConfig, signer note.Signer) (*sctfe.CTStorage, error) {
 	cfg := vCfg.Config.GetGcp()
 	gcpCfg := gcp.Config{
 		ProjectID: cfg.ProjectId,
 		Bucket:    cfg.Bucket,
 		Spanner:   cfg.SpannerDbPath,
 	}
-	storage, err := gcp.New(ctx, gcpCfg)
+	storage, err := gcp.New(ctx, gcpCfg, tessera.WithCheckpointSignerVerifier(signer, nil))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to initialize GCP storage: %v", err)
 	}

--- a/personalities/sctfe/ct_server_gcp/main.go
+++ b/personalities/sctfe/ct_server_gcp/main.go
@@ -267,11 +267,8 @@ func setupAndRegister(ctx context.Context, deadline time.Duration, vCfg *sctfe.V
 
 	switch vCfg.Config.StorageConfig.(type) {
 	case *configpb.LogConfig_Gcp:
-		storage, err := newGCPStorage(ctx, vCfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize GCP storage: %v", err)
-		}
-		opts.Storage = storage
+		klog.Info("Found GCP storage config, will set up GCP tessera storage")
+		opts.CreateStorage = newGCPStorage
 	default:
 		return nil, fmt.Errorf("unrecognized storage config")
 	}

--- a/personalities/sctfe/ct_server_gcp/main.go
+++ b/personalities/sctfe/ct_server_gcp/main.go
@@ -267,7 +267,7 @@ func setupAndRegister(ctx context.Context, deadline time.Duration, vCfg *sctfe.V
 
 	switch vCfg.Config.StorageConfig.(type) {
 	case *configpb.LogConfig_Gcp:
-		storage, err := newGCPStorage(ctx, vCfg.Config.GetGcp())
+		storage, err := newGCPStorage(ctx, vCfg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize GCP storage: %v", err)
 		}
@@ -286,7 +286,8 @@ func setupAndRegister(ctx context.Context, deadline time.Duration, vCfg *sctfe.V
 	return inst, nil
 }
 
-func newGCPStorage(ctx context.Context, cfg *configpb.GCPConfig) (*sctfe.CTStorage, error) {
+func newGCPStorage(ctx context.Context, vCfg *sctfe.ValidatedLogConfig) (*sctfe.CTStorage, error) {
+	cfg := vCfg.Config.GetGcp()
 	gcpCfg := gcp.Config{
 		ProjectID: cfg.ProjectId,
 		Bucket:    cfg.Bucket,

--- a/personalities/sctfe/handlers.go
+++ b/personalities/sctfe/handlers.go
@@ -217,13 +217,14 @@ func newLogInfo(
 	validationOpts CertValidationOpts,
 	signer crypto.Signer,
 	timeSource TimeSource,
+	storage Storage,
 ) *logInfo {
 	vCfg := instanceOpts.Validated
 	cfg := vCfg.Config
 
 	li := &logInfo{
 		LogOrigin:      cfg.Origin,
-		storage:        instanceOpts.Storage,
+		storage:        storage,
 		signer:         signer,
 		TimeSource:     timeSource,
 		instanceOpts:   instanceOpts,

--- a/personalities/sctfe/handlers_test.go
+++ b/personalities/sctfe/handlers_test.go
@@ -78,8 +78,8 @@ func setupTest(t *testing.T, pemRoots []string, signer crypto.Signer) handlerTes
 
 	cfg := &configpb.LogConfig{Origin: "example.com"}
 	vCfg := &ValidatedLogConfig{Config: cfg}
-	iOpts := InstanceOptions{Validated: vCfg, Storage: info.storage, Deadline: time.Millisecond * 500, MetricFactory: monitoring.InertMetricFactory{}, RequestLog: new(DefaultRequestLog)}
-	info.li = newLogInfo(iOpts, vOpts, signer, fakeTimeSource)
+	iOpts := InstanceOptions{Validated: vCfg, Deadline: time.Millisecond * 500, MetricFactory: monitoring.InertMetricFactory{}, RequestLog: new(DefaultRequestLog)}
+	info.li = newLogInfo(iOpts, vOpts, signer, fakeTimeSource, info.storage)
 
 	for _, pemRoot := range pemRoots {
 		if !info.roots.AppendCertsFromPEM([]byte(pemRoot)) {

--- a/personalities/sctfe/instance.go
+++ b/personalities/sctfe/instance.go
@@ -147,7 +147,7 @@ func setUpLogInfo(ctx context.Context, opts InstanceOptions) (*logInfo, error) {
 		return nil, fmt.Errorf("failed to get logID for signing: %v", err)
 	}
 	timeSource := new(SystemTimeSource)
-	ctSigner := NewCTSigner(signer, vCfg.Config.Origin, logID, timeSource)
+	ctSigner := NewCpSigner(signer, vCfg.Config.Origin, logID, timeSource)
 
 	if opts.CreateStorage == nil {
 		return nil, fmt.Errorf("failed to initiate storage backend: nil createStorage")

--- a/personalities/sctfe/instance.go
+++ b/personalities/sctfe/instance.go
@@ -149,9 +149,12 @@ func setUpLogInfo(ctx context.Context, opts InstanceOptions) (*logInfo, error) {
 	timeSource := new(SystemTimeSource)
 	ctSigner := NewCTSigner(signer, vCfg.Config.Origin, logID, timeSource)
 
+	if opts.CreateStorage == nil {
+		return nil, fmt.Errorf("failed to initiate storage backend: nil createStorage")
+	}
 	storage, err := opts.CreateStorage(ctx, opts.Validated, ctSigner)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create storage backend: %v", err)
+		return nil, fmt.Errorf("failed to initiate storage backend: %v", err)
 	}
 
 	logInfo := newLogInfo(opts, validationOpts, signer, timeSource, storage)

--- a/personalities/sctfe/instance_test.go
+++ b/personalities/sctfe/instance_test.go
@@ -275,7 +275,7 @@ func TestSetUpInstanceSetsValidationOpts(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ValidateLogConfig(): %v", err)
 			}
-			opts := InstanceOptions{Validated: vCfg, Deadline: time.Second, MetricFactory: monitoring.InertMetricFactory{}}
+			opts := InstanceOptions{Validated: vCfg, Deadline: time.Second, MetricFactory: monitoring.InertMetricFactory{}, CreateStorage: fakeCTStorage}
 
 			inst, err := SetUpInstance(ctx, opts)
 			if err != nil {

--- a/personalities/sctfe/instance_test.go
+++ b/personalities/sctfe/instance_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/monitoring"
 	"github.com/transparency-dev/trillian-tessera/personalities/sctfe/configpb"
+	"golang.org/x/mod/sumdb/note"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -37,7 +38,7 @@ func init() {
 	keys.RegisterHandler(&keyspb.PEMKeyFile{}, pem.FromProto)
 }
 
-func fakeCTStorage(_ context.Context, _ *ValidatedLogConfig) (*CTStorage, error) {
+func fakeCTStorage(_ context.Context, _ *ValidatedLogConfig, _ note.Signer) (*CTStorage, error) {
 	return &CTStorage{}, nil
 }
 

--- a/personalities/sctfe/instance_test.go
+++ b/personalities/sctfe/instance_test.go
@@ -37,6 +37,10 @@ func init() {
 	keys.RegisterHandler(&keyspb.PEMKeyFile{}, pem.FromProto)
 }
 
+func fakeCTStorage(_ context.Context, _ *ValidatedLogConfig) (*CTStorage, error) {
+	return &CTStorage{}, nil
+}
+
 func TestSetUpInstance(t *testing.T) {
 	ctx := context.Background()
 
@@ -146,7 +150,7 @@ func TestSetUpInstance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ValidateLogConfig(): %v", err)
 			}
-			opts := InstanceOptions{Validated: vCfg, Deadline: time.Second, MetricFactory: monitoring.InertMetricFactory{}}
+			opts := InstanceOptions{Validated: vCfg, Deadline: time.Second, MetricFactory: monitoring.InertMetricFactory{}, CreateStorage: fakeCTStorage}
 
 			if _, err := SetUpInstance(ctx, opts); err != nil {
 				if test.wantErr == "" {

--- a/personalities/sctfe/serialize.go
+++ b/personalities/sctfe/serialize.go
@@ -133,8 +133,7 @@ func (cts *CpSigner) Sign(msg []byte) ([]byte, error) {
 		return nil, fmt.Errorf("checkpoint contains trailing data: %s", string(rest))
 	} else if err != nil {
 		return nil, fmt.Errorf("ckpt.Unmarshal: %v", err)
-	}
-	if ckpt.Origin != cts.origin {
+	} else if ckpt.Origin != cts.origin {
 		return nil, fmt.Errorf("checkpoint's origin %s doesn't match signer's origin %s", ckpt.Origin, cts.origin)
 	}
 

--- a/personalities/sctfe/serialize.go
+++ b/personalities/sctfe/serialize.go
@@ -18,9 +18,12 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 
 	"github.com/google/certificate-transparency-go/tls"
+	"github.com/transparency-dev/formats/log"
+	"golang.org/x/mod/sumdb/note"
 
 	ct "github.com/google/certificate-transparency-go"
 )
@@ -63,4 +66,111 @@ func buildV1SCT(signer crypto.Signer, leaf *ct.MerkleTreeLeaf) (*ct.SignedCertif
 		Extensions: sctInput.Extensions,
 		Signature:  digitallySigned,
 	}, nil
+}
+
+type RFC6962NoteSignature struct {
+	timestamp uint64
+	signature ct.DigitallySigned
+}
+
+// buildCTCheckpoints builds a https://c2sp.org/static-ct-api checkpoint.
+// TODO(phboneff): add tests
+func buildCTCheckpoint(signer crypto.Signer, size uint64, timeMilli uint64, hash []byte) ([]byte, error) {
+	sth := ct.SignedTreeHead{
+		Version:   ct.V1,
+		TreeSize:  size,
+		Timestamp: timeMilli,
+	}
+	copy(sth.SHA256RootHash[:], hash)
+
+	sthBytes, err := ct.SerializeSTHSignatureInput(sth)
+	if err != nil {
+		return nil, fmt.Errorf("ct.SerializeSTHSignatureInput(): %v", err)
+	}
+
+	h := sha256.New()
+	h.Write(sthBytes)
+	signature, err := signer.Sign(rand.Reader, h.Sum(nil), crypto.SHA256)
+	if err != nil {
+		return nil, err
+	}
+
+	rfc6962Note := RFC6962NoteSignature{
+		timestamp: sth.Timestamp,
+		signature: ct.DigitallySigned{
+			Algorithm: tls.SignatureAndHashAlgorithm{
+				Hash:      tls.SHA256,
+				Signature: tls.SignatureAlgorithmFromPubKey(signer.Public()),
+			},
+			Signature: signature,
+		},
+	}
+
+	sig, err := tls.Marshal(rfc6962Note)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't encode RFC6962NoteSignature: %w", err)
+	}
+
+	return sig, nil
+}
+
+type CTSigner struct {
+	sthSigner  crypto.Signer
+	origin     string
+	keyHash    uint32
+	timeSource TimeSource
+}
+
+// Sign takes an unsigned checkpoint, and signs it with a https://c2sp.org/static-ct-api signature.
+// Returns an error if the message doesn't parse as a checkpoint, or if the
+// checkpoint origin doesn't match with the Signer's origin.
+// TODO(phboneff): add tests
+func (cts *CTSigner) Sign(msg []byte) ([]byte, error) {
+	ckpt := &log.Checkpoint{}
+	rest, err := ckpt.Unmarshal(msg)
+
+	if len(rest) != 0 {
+		return nil, fmt.Errorf("checkpoint contains trailing data: %s", string(rest))
+	} else if err != nil {
+		return nil, fmt.Errorf("ckpt.Unmarshal: %v", err)
+	}
+	if ckpt.Origin != cts.origin {
+		return nil, fmt.Errorf("checkpoint's origin %s doesn't match signer's origin %s", ckpt.Origin, cts.origin)
+	}
+
+	// TODO(phboneff): make sure that it's ok to generate the timestamp here
+	t := uint64(cts.timeSource.Now().UnixMilli())
+	sig, err := buildCTCheckpoint(cts.sthSigner, ckpt.Size, t, ckpt.Hash[:])
+	if err != nil {
+		return nil, fmt.Errorf("coudn't sign CT checkpoint: %v", err)
+	}
+	return sig, nil
+}
+
+func (cts *CTSigner) Name() string {
+	return cts.origin
+}
+
+func (cts *CTSigner) KeyHash() uint32 {
+	return cts.keyHash
+}
+
+// NewCTSigner returns a new note signer that can sign static-ct-api checkpoints
+// according to https://c2sp.org/static-ct-api.
+// TODO(phboneff): add tests
+func NewCTSigner(signer crypto.Signer, origin string, logID [32]byte, timeSource TimeSource) note.Signer {
+	h := sha256.New()
+	h.Write([]byte(origin))
+	h.Write([]byte{0x0A}) // newline
+	h.Write([]byte{0x05}) // signature type
+	h.Write(logID[:])
+	sum := h.Sum(nil)
+
+	ctSigner := &CTSigner{
+		sthSigner:  signer,
+		origin:     origin,
+		keyHash:    binary.BigEndian.Uint32(sum),
+		timeSource: timeSource,
+	}
+	return ctSigner
 }

--- a/personalities/sctfe/serialize.go
+++ b/personalities/sctfe/serialize.go
@@ -88,9 +88,8 @@ func buildCp(signer crypto.Signer, size uint64, timeMilli uint64, hash []byte) (
 		return nil, fmt.Errorf("ct.SerializeSTHSignatureInput(): %v", err)
 	}
 
-	h := sha256.New()
-	h.Write(sthBytes)
-	signature, err := signer.Sign(rand.Reader, h.Sum(nil), crypto.SHA256)
+	h := sha256.Sum256(sthBytes)
+	signature, err := signer.Sign(rand.Reader, h[:], crypto.SHA256)
 	if err != nil {
 		return nil, err
 	}

--- a/personalities/sctfe/serialize.go
+++ b/personalities/sctfe/serialize.go
@@ -113,6 +113,7 @@ func buildCp(signer crypto.Signer, size uint64, timeMilli uint64, hash []byte) (
 	return sig, nil
 }
 
+// CpSigner implements note.Signer. It can generate https://c2sp.org/static-ct-api checkpoints.
 type CpSigner struct {
 	sthSigner  crypto.Signer
 	origin     string
@@ -153,8 +154,7 @@ func (cts *CpSigner) KeyHash() uint32 {
 	return cts.keyHash
 }
 
-// NewCpSigner returns a new note signer that can sign static-ct-api checkpoints
-// according to https://c2sp.org/static-ct-api.
+// NewCpSigner returns a new note signer that can sign https://c2sp.org/static-ct-api checkpoints.
 // TODO(phboneff): add tests
 func NewCpSigner(signer crypto.Signer, origin string, logID [32]byte, timeSource TimeSource) note.Signer {
 	h := sha256.New()


### PR DESCRIPTION
This PR makes it possible to sign https://c2sp.org/static-ct-api checkpoints, and passes a signer to Tessera.

Before we can pass a Checkpoint signer to Tessera, we need to initiate the time source and crypto.signer, so I had to re-architecture the code a bit before that.