### PR TITLE
Add FingerprintsChain to leaf data

### DIFF
--- a/ctonly/ct.go
+++ b/ctonly/ct.go
@@ -51,6 +51,7 @@ type Entry struct {
 	Precertificate     []byte
 	PrecertSigningCert []byte
 	IssuerKeyHash      []byte
+	FingerprintsChain  [][32]byte
 }
 
 // LeafData returns the data which should be added to an entry bundle for this entry.
@@ -77,10 +78,12 @@ func (c Entry) LeafData(idx uint64) []byte {
 		b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
 			b.AddBytes(c.Precertificate)
 		})
-		b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
-			b.AddBytes(c.PrecertSigningCert)
-		})
 	}
+	b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
+		for _, f := range c.FingerprintsChain {
+			b.AddBytes(f[:])
+		}
+	})
 	return b.BytesOrPanic()
 }
 

--- a/personalities/sctfe/handlers.go
+++ b/personalities/sctfe/handlers.go
@@ -445,6 +445,15 @@ func entryFromChain(chain []*x509.Certificate, isPrecert bool, timestamp uint64)
 		IsPrecert: isPrecert,
 		Timestamp: timestamp,
 	}
+
+	if len(chain) > 1 {
+		issuersChain := make([][32]byte, len(chain)-1)
+		for i, c := range chain[1:] {
+			issuersChain[i] = sha256.Sum256(c.Raw)
+		}
+		leaf.FingerprintsChain = issuersChain
+	}
+
 	if !isPrecert {
 		leaf.Certificate = chain[0].Raw
 		return &leaf, nil


### PR DESCRIPTION
https://github.com/transparency-dev/trillian-tessera/issues/88

See specs here: https://github.com/C2SP/C2SP/blob/main/static-ct-api.md#log-entries, the issuer fingerprints are be at the end of a leaf.

I also had to fix `TestAddChainWhitespace`, and took that as an opportunity to abstract some testing function.