### PR TITLE
Explicitly Set content types on tiles and leaves

### DIFF
--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -325,7 +325,7 @@ func (m *memObjStore) getObject(_ context.Context, obj string) ([]byte, int64, e
 	return d, 1, nil
 }
 
-func (m *memObjStore) setObject(_ context.Context, obj string, data []byte, cond *gcs.Conditions) error {
+func (m *memObjStore) setObject(_ context.Context, obj string, data []byte, cond *gcs.Conditions, _ string) error {
 	m.Lock()
 	defer m.Unlock()
 

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -325,6 +325,7 @@ func (m *memObjStore) getObject(_ context.Context, obj string) ([]byte, int64, e
 	return d, 1, nil
 }
 
+// TODO(phboneff): add content type tests
 func (m *memObjStore) setObject(_ context.Context, obj string, data []byte, cond *gcs.Conditions, _ string) error {
 	m.Lock()
 	defer m.Unlock()


### PR DESCRIPTION
If not specified, GCS automatically detects the content type, so let's be explicit and avoid unfortunate divergence outside of our control.

I haven't added tests, but since there was some divergence before https://github.com/C2SP/C2SP/pull/92, it proves that it can happen, and doesn't sound crazy to add some. I can do this in a later PR but we'd also need to modify the getObject signature, which sounds a bit cumbersome. 