### PR TITLE
GCS terraform: output the writer service account

### DIFF
--- a/deployment/modules/gcs/outputs.tf
+++ b/deployment/modules/gcs/outputs.tf
@@ -7,3 +7,8 @@ output "log_spanner" {
   description = "Log Spanner database"
   value       = google_spanner_database.log_db
 }
+
+output "service_account_name" {
+  description = "Name of the service account with write permission for storage"
+  value       = google_service_account.log_writer.member
+}


### PR DESCRIPTION
Any code using this will need the name of the writer service account in order to run the writing code as the service account.
