### PR TITLE
Hammer: exit criteria

### DIFF
--- a/hammer/README.md
+++ b/hammer/README.md
@@ -29,3 +29,18 @@ go run ./hammer \
   --max_write_ops=42
 ```
 
+For a headless write-only example that could be used for integration tests, this command attempts to write 2500 leaves within 1 minute.
+If the target number of leaves is reached then it exits successfully.
+If the timeout of 1 minute is reached first, then it exits with an exit code of 1.
+
+```shell
+go run ./hammer \
+  --log_public_key=Test-Betty+df84580a+AQQASqPUZoIHcJAF5mBOryctwFdTV1E0GRY4kEAtTzwB \
+  --log_url=http://localhost:2024 \
+  --max_read_ops=0 \
+  --num_writers=512 \
+  --max_write_ops=512 \
+  --max_runtime=1m \
+  --leaf_write_goal=2500 \
+  --show_ui=false
+```

--- a/hammer/hammer.go
+++ b/hammer/hammer.go
@@ -113,7 +113,7 @@ func main() {
 					return
 				case <-tick.C:
 					if tracker.LatestConsistent.Size >= goal {
-						elapsed := time.Now().Sub(startTime)
+						elapsed := time.Since(startTime)
 						klog.Infof("Reached tree size goal of %d after %s; exiting", goal, elapsed)
 						cancel()
 						return

--- a/hammer/hammer.go
+++ b/hammer/hammer.go
@@ -98,7 +98,6 @@ func main() {
 
 	gen := newLeafGenerator(tracker.LatestConsistent.Size, *leafMinSize, *dupChance)
 	hammer := NewHammer(&tracker, f.Fetch, w.Write, gen, ha.seqLeafChan, ha.errChan)
-	hammer.Run(ctx)
 
 	exitCode := 0
 	if *leafWriteGoal > 0 {
@@ -138,6 +137,7 @@ func main() {
 			}
 		}()
 	}
+	hammer.Run(ctx)
 
 	if *showUI {
 		c := newController(hammer, ha)


### PR DESCRIPTION
The hammer can be configured to stop successfully if a desired number of leaves are written, and to fail after a max runtime is reached. These two can be used in conjunction to run a headless test for write performance.
