### PR TITLE
Run hammer against MySQL in CI

### DIFF
--- a/.github/workflows/benchmark_mysql.yml
+++ b/.github/workflows/benchmark_mysql.yml
@@ -1,0 +1,21 @@
+name: Benchmark MySQL
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark-mysql:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Start Tessera
+        run: docker compose -f ./cmd/example-mysql/docker/compose.yaml up --build --detach
+      - name: Run integration test 
+        run: go run ./hammer --log_public_key=Test-Betty+df84580a+AQQASqPUZoIHcJAF5mBOryctwFdTV1E0GRY4kEAtTzwB --log_url=http://localhost:2024 --max_read_ops=0 --num_writers=512 --max_write_ops=512 --max_runtime=1m --leaf_write_goal=2500 --show_ui=false
+      - name: Stop Tessera
+        if: ${{ always() }}
+        run: docker compose -f ./cmd/example-mysql/docker/compose.yaml down


### PR DESCRIPTION
This ensures a basic level of write performance. It isn't a perfect performance benchmark because the job could be run on different specs of machine, but it's a first foray into getting the hammer running in CI.
