### PR TITLE
Terraform for GCP CI base

### DIFF
--- a/deployment/live/gcp/example-gcp/README.md
+++ b/deployment/live/gcp/example-gcp/README.md
@@ -19,6 +19,6 @@ export TESSERA_BASE_NAME={VALUE}
 ```
 
 Terraforming the project can be done by:
- 1. `cd` to the relevant `live` directory for the environment to deploy/change
+ 1. `cd` to the relevant directory for the environment to deploy/change (e.g. `ci`)
  2. Run `terragrunt apply`
 

--- a/deployment/live/gcp/example-gcp/ci/terragrunt.hcl
+++ b/deployment/live/gcp/example-gcp/ci/terragrunt.hcl
@@ -10,6 +10,6 @@ include "root" {
 inputs = merge(
   include.root.locals,
   {
-    example_gcp_docker_image = "todo"
+    example_gcp_docker_image = "us-central1-docker.pkg.dev/trillian-tessera/docker-prod/example-gcp:latest"
   }
 )

--- a/deployment/live/gcp/example-gcp/ci/terragrunt.hcl
+++ b/deployment/live/gcp/example-gcp/ci/terragrunt.hcl
@@ -11,5 +11,6 @@ inputs = merge(
   include.root.locals,
   {
     example_gcp_docker_image = "us-central1-docker.pkg.dev/trillian-tessera/docker-prod/example-gcp:latest"
+    log_origin = "example-gcp"
   }
 )

--- a/deployment/live/gcp/example-gcp/ci/terragrunt.hcl
+++ b/deployment/live/gcp/example-gcp/ci/terragrunt.hcl
@@ -1,0 +1,15 @@
+terraform {
+  source = "${get_repo_root()}/deployment/modules/gcp//example-gcp"
+}
+
+include "root" {
+  path   = find_in_parent_folders()
+  expose = true
+}
+
+inputs = merge(
+  include.root.locals,
+  {
+    example_gcp_docker_image = "todo"
+  }
+)

--- a/deployment/live/gcp/example-gcp/terragrunt.hcl
+++ b/deployment/live/gcp/example-gcp/terragrunt.hcl
@@ -6,7 +6,7 @@ locals {
   env         = path_relative_to_include()
   project_id = get_env("GOOGLE_PROJECT", "trillian-tessera")
   location   = get_env("GOOGLE_REGION", "us-central1")
-  base_name   = get_env("TESSERA_BASE_NAME", "${path_relative_to_include()}-example-gcp")
+  base_name   = get_env("TESSERA_BASE_NAME", "${local.env}-example-gcp")
 }
 
 remote_state {
@@ -16,7 +16,7 @@ remote_state {
     project  = local.project_id
     location = local.location
     bucket   = "${local.project_id}-${local.base_name}-terraform-state"
-    prefix   = "${path_relative_to_include()}/terraform.tfstate"
+    prefix   = "${local.env}/terraform.tfstate"
 
     gcs_bucket_labels = {
       name  = "terraform_state_storage"

--- a/deployment/live/gcp/example-gcp/terragrunt.hcl
+++ b/deployment/live/gcp/example-gcp/terragrunt.hcl
@@ -4,8 +4,8 @@ terraform {
 
 locals {
   env         = path_relative_to_include()
-  project_id = get_env("GOOGLE_PROJECT", "trillian-tessera")
-  location   = get_env("GOOGLE_REGION", "us-central1")
+  project_id  = get_env("GOOGLE_PROJECT", "trillian-tessera")
+  location    = get_env("GOOGLE_REGION", "us-central1")
   base_name   = get_env("TESSERA_BASE_NAME", "${local.env}-example-gcp")
 }
 

--- a/deployment/live/gcp/example-gcp/terragrunt.hcl
+++ b/deployment/live/gcp/example-gcp/terragrunt.hcl
@@ -1,17 +1,13 @@
 terraform {
-  source = "${get_repo_root()}/deployment/modules/gcp/gcs"
+  source = "${get_repo_root()}/deployment/modules/gcp//example-gcp"
 }
 
 locals {
+  env         = path_relative_to_include()
   project_id = get_env("GOOGLE_PROJECT", "trillian-tessera")
   location   = get_env("GOOGLE_REGION", "us-central1")
-  base_name   = get_env("TESSERA_BASE_NAME", "example-gcp")
+  base_name   = get_env("TESSERA_BASE_NAME", "${path_relative_to_include()}-example-gcp")
 }
-
-inputs = merge(
-  local,
-  {}
-)
 
 remote_state {
   backend = "gcs"
@@ -20,6 +16,7 @@ remote_state {
     project  = local.project_id
     location = local.location
     bucket   = "${local.project_id}-${local.base_name}-terraform-state"
+    prefix   = "${path_relative_to_include()}/terraform.tfstate"
 
     gcs_bucket_labels = {
       name  = "terraform_state_storage"

--- a/deployment/modules/gcp/example-gcp/main.tf
+++ b/deployment/modules/gcp/example-gcp/main.tf
@@ -1,0 +1,106 @@
+terraform {
+  backend "gcs" {}
+}
+
+## Call the Tessera GCP module
+##
+## This will configure all the storage infrastructure required to run a Tessera log on GCP.
+module "gcs" {
+  source = "..//gcs"
+
+  base_name  = var.base_name
+  env        = var.env
+  location   = var.location
+  project_id = var.project_id
+}
+
+# Enable Cloud Run API
+resource "google_project_service" "cloudrun_api" {
+  service            = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+###
+### Set up Cloud Run service
+###
+resource "google_service_account" "cloudrun_service_account" {
+  account_id   = "cloudrun-${var.env}-sa"
+  display_name = "Service Account for Cloud Run (${var.env})"
+}
+
+resource "google_project_iam_member" "iam_act_as" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.cloudrun_service_account.email}"
+}
+resource "google_project_iam_member" "iam_metrics_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.cloudrun_service_account.email}"
+}
+resource "google_spanner_database_iam_binding" "iam_spanner_database_user" {
+  project  = var.project_id
+  instance = module.gcs.log_spanner_instance.name
+  database = module.gcs.log_spanner_db.name
+  role     = "roles/spanner.databaseUser"
+
+  members = [
+    "serviceAccount:${google_service_account.cloudrun_service_account.email}"
+  ]
+}
+resource "google_project_iam_member" "iam_service_agent" {
+  project = var.project_id
+  role    = "roles/run.serviceAgent"
+  member  = "serviceAccount:${google_service_account.cloudrun_service_account.email}"
+}
+
+resource "google_cloud_run_v2_service" "default" {
+  name         = "example-service-${var.env}"
+  location     = var.location
+  launch_stage = "GA"
+
+  template {
+    service_account = google_service_account.cloudrun_service_account.email
+    containers {
+      image = var.example_gcp_docker_image
+      name  = "example-gcp"
+      args = [
+        "--logtostderr",
+        "--v=1",
+        "--bucket=${module.gcs.log_bucket.id}",
+        "--spanner=projects/${var.project_id}/instances/${module.gcs.log_spanner_instance.name}/databases/${module.gcs.log_spanner_db.name}",
+        "--project=${var.project_id}",
+        "--listen=:8080",
+        "--signer=./testgcp.sec",
+      ]
+      ports {
+        container_port = 8080
+      }
+
+      startup_probe {
+        initial_delay_seconds = 1
+        timeout_seconds       = 1
+        period_seconds        = 10
+        failure_threshold     = 3
+        tcp_socket {
+          port = 8080
+        }
+      }
+    }
+    containers {
+      image      = "us-docker.pkg.dev/cloud-ops-agents-artifacts/cloud-run-gmp-sidecar/cloud-run-gmp-sidecar:1.0.0"
+      name       = "collector"
+      depends_on = ["example-gcp"]
+    }
+  }
+  client = "terraform"
+  depends_on = [
+    module.gcs,
+    google_project_service.cloudrun_api,
+    google_project_iam_member.iam_act_as,
+    google_project_iam_member.iam_metrics_writer,
+    google_project_iam_member.iam_service_agent,
+    google_spanner_database_iam_binding.iam_spanner_database_user,
+  ]
+}
+

--- a/deployment/modules/gcp/example-gcp/variables.tf
+++ b/deployment/modules/gcp/example-gcp/variables.tf
@@ -22,3 +22,8 @@ variable "example_gcp_docker_image" {
   description = "The full image URL (path & tag) for the example-gcp Docker image to deploy"
   type        = string
 }
+
+variable "log_origin" {
+  description = "The origin string for the example log"
+  type        = string
+}

--- a/deployment/modules/gcp/example-gcp/variables.tf
+++ b/deployment/modules/gcp/example-gcp/variables.tf
@@ -14,6 +14,11 @@ variable "location" {
 }
 
 variable "env" {
-  description = "Unique identifier for the env, e.g. ci or prod"
+  description = "Environment name, e.g ci, prod, etc."
+  type        = string
+}
+
+variable "example_gcp_docker_image" {
+  description = "The full image URL (path & tag) for the example-gcp Docker image to deploy"
   type        = string
 }

--- a/deployment/modules/gcp/gcs/main.tf
+++ b/deployment/modules/gcp/gcs/main.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "gcs" {}
-}
-
 # Services
 resource "google_project_service" "serviceusage_googleapis_com" {
   service            = "serviceusage.googleapis.com"
@@ -52,7 +48,7 @@ resource "google_storage_bucket_iam_binding" "log_bucket_writer" {
 resource "google_spanner_instance" "log_spanner" {
   name             = var.base_name
   config           = "regional-${var.location}"
-  display_name     = "${var.base_name} Spanner Instance"
+  display_name     = var.base_name
   processing_units = 100
 }
 

--- a/deployment/modules/gcp/gcs/outputs.tf
+++ b/deployment/modules/gcp/gcs/outputs.tf
@@ -3,9 +3,14 @@ output "log_bucket" {
   value       = google_storage_bucket.log_bucket
 }
 
-output "log_spanner" {
+output "log_spanner_db" {
   description = "Log Spanner database"
   value       = google_spanner_database.log_db
+}
+
+output "log_spanner_instance" {
+  description = "Log Spanner instance"
+  value       = google_spanner_instance.log_spanner
 }
 
 output "service_account_name" {


### PR DESCRIPTION
This PR adds support for spinning up an instance of the example personality on GCP.

This is intended to be used for CI tests.

Towards #7 