### PR TITLE
Add Dockerfile for example-gcp

### DIFF
--- a/cmd/example-gcp/Dockerfile
+++ b/cmd/example-gcp/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.23.0-alpine3.19@sha256:fe8f9c7d418d3ac91787f11c31071c4814b6da5f9aae55bc581a7aacc264c395 AS builder
+
+ARG GOFLAGS="-trimpath -buildvcs=false -buildmode=exe"
+ENV GOFLAGS=$GOFLAGS
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build -o bin/example-gcp ./cmd/example-gcp
+
+# Build release image
+FROM alpine:3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
+
+COPY --from=builder /build/bin/example-gcp /bin/example-gcp
+ENTRYPOINT ["/bin/example-gcp"]


### PR DESCRIPTION
This PR adds a simple Dockerfile for building the `example-gcp` binary.

Eventually, this can be used for CI/CD testing on GCP.

Towards #7.