### PR TITLE
Fix broken link in README.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,4 +9,4 @@
 # Please keep the list sorted.
 
 Google LLC
-
+Internet Security Research Group

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Tessera goals:
 *   Broadly similar write-throughput and write-availability, and potentially _far_ higher read-throughput
     and read-availability compared to Trillian v1 (dependent on underlying infrastructure)
 *   Enable building of arbitrary log personalities, including support for the peculiarities of a
-    [CT Tiles](https://github.com/C2SP/C2SP/blob/main/static-ct-api.md) compliant log.
+    [Static CT API](https://c2sp.org/static-ct-api) compliant log.
 
 ### Status
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Tessera goals:
 *   Broadly similar write-throughput and write-availability, and potentially _far_ higher read-throughput
     and read-availability compared to Trillian v1 (dependent on underlying infrastructure)
 *   Enable building of arbitrary log personalities, including support for the peculiarities of a
-    [CT Tiles](https://github.com/C2SP/C2SP/blob/main/sunlight.md) compliant log.
+    [CT Tiles](https://github.com/C2SP/C2SP/blob/main/static-ct-api.md) compliant log.
 
 ### Status
 


### PR DESCRIPTION
Fixes broken link to the [CT-Tiles] api spec document that was renamed.