### PR TITLE
Fix link per spec name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Tessera goals:
 *   Broadly similar write-throughput and write-availability, and potentially _far_ higher read-throughput
     and read-availability compared to Trillian v1 (dependent on underlying infrastructure)
 *   Enable building of arbitrary log personalities, including support for the peculiarities of a
-    [CT Tiles](https://github.com/C2SP/C2SP/blob/main/sunlight.md) compliant log.
+    [Static CT API](https://github.com/C2SP/C2SP/blob/main/static-ct-api.md) compliant log.
 
 ### Status
 


### PR DESCRIPTION
Both the spec and initial implementation were called Sunlight, but the spec was
renamed to Static CT API to better disambugate the two, especially with
projects like this one also implementing the spec.
