### PR TITLE
Add support for using GCP KMS in example-gcp

### DIFF
--- a/cmd/example-gcp/kms.go
+++ b/cmd/example-gcp/kms.go
@@ -84,12 +84,12 @@ type Signer struct {
 	kmsKeyName string
 }
 
-// New creates a signer which uses an Ed25519 key in GCP KMS.
+// NewKMSSigner creates a signer which uses an Ed25519 key in GCP KMS.
 // See https://cloud.google.com/kms/docs/algorithms#elliptic_curve_signing_algorithms
 //
 // kmsKeyName is the GCP KMS name of the key to be used.
 // noteKeyName is the value used as the signer name in the note signature.
-func New(ctx context.Context, c *kms.KeyManagementClient, kmsKeyName, noteKeyName string) (*Signer, error) {
+func NewKMSSigner(ctx context.Context, c *kms.KeyManagementClient, kmsKeyName, noteKeyName string) (*Signer, error) {
 	s := &Signer{}
 
 	s.client = c

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/transparency-dev/trillian-tessera
 go 1.22.5
 
 require (
+	cloud.google.com/go/kms v1.18.4
 	cloud.google.com/go/spanner v1.67.0
 	cloud.google.com/go/storage v1.43.0
 	github.com/RobinUS2/golang-moving-average v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -340,6 +340,8 @@ cloud.google.com/go/kms v1.8.0/go.mod h1:4xFEhYFqvW+4VMELtZyxomGSYtSQKzM178ylFW4
 cloud.google.com/go/kms v1.9.0/go.mod h1:qb1tPTgfF9RQP8e1wq4cLFErVuTJv7UsSC915J8dh3w=
 cloud.google.com/go/kms v1.10.0/go.mod h1:ng3KTUtQQU9bPX3+QGLsflZIHlkbn8amFAMY63m8d24=
 cloud.google.com/go/kms v1.10.1/go.mod h1:rIWk/TryCkR59GMC3YtHtXeLzd634lBbKenvyySAyYI=
+cloud.google.com/go/kms v1.18.4 h1:dYN3OCsQ6wJLLtOnI8DGUwQ5shMusXsWCCC+s09ATsk=
+cloud.google.com/go/kms v1.18.4/go.mod h1:SG1bgQ3UWW6/KdPo9uuJnzELXY5YTTMJtDYvajiQ22g=
 cloud.google.com/go/language v1.4.0/go.mod h1:F9dRpNFQmJbkaop6g0JhSBXCNlO90e1KWx5iDdxbWic=
 cloud.google.com/go/language v1.6.0/go.mod h1:6dJ8t3B+lUYfStgls25GusK04NLh3eDLQnWM3mdEbhI=
 cloud.google.com/go/language v1.7.0/go.mod h1:DJ6dYN/W+SQOjF8e1hLQXMF21AkH2w9wiPzPCJa2MIE=


### PR DESCRIPTION
This PR enables `example-gcp` to use GCP's KMS support for Ed25519 signatures.