### PR TITLE
GCP: Don't scan buckets

### DIFF
--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -621,19 +621,6 @@ type gcsStorage struct {
 //
 // The specified bucket must exist or an error will be returned.
 func newGCSStorage(ctx context.Context, c *gcs.Client, projectID string, bucket string) (*gcsStorage, error) {
-	it := c.Buckets(ctx, projectID)
-	for {
-		bAttrs, err := it.Next()
-		if err == iterator.Done {
-			return nil, fmt.Errorf("bucket %q does not exist, please create it", bucket)
-		}
-		if err != nil {
-			return nil, fmt.Errorf("error scanning buckets: %v", err)
-		}
-		if bAttrs.Name == bucket {
-			break
-		}
-	}
 	r := &gcsStorage{
 		gcsClient: c,
 		bucket:    bucket,


### PR DESCRIPTION
This PR stops the GCP storage implementation from scanning all the buckets at startup.

It did this to try to provide an early/helpful error message, but doing this requires extra IAM permissions which are completely unnecessary for running the log, and so should not be granted.

In reality the log instance will detect the missing bucket and start erroring out as soon as writes are attempted anyway.