### PR TITLE
Ensure that storage implementations meet the same contract

### DIFF
--- a/integration/storage_uniformity_test.go
+++ b/integration/storage_uniformity_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// integration_test ensures that all storage implementations have a consistent contract.
+package integration_test
+
+import (
+	"context"
+
+	tessera "github.com/transparency-dev/trillian-tessera"
+	"github.com/transparency-dev/trillian-tessera/storage/gcp"
+	"github.com/transparency-dev/trillian-tessera/storage/mysql"
+)
+
+type StorageContract interface {
+	Add(ctx context.Context, entry *tessera.Entry) (uint64, error)
+}
+
+var (
+	_ StorageContract = &mysql.Storage{}
+	_ StorageContract = &gcp.Storage{}
+)


### PR DESCRIPTION
This is a basic check that they support the same contract for Add. More methods can be added later.
