### PR TITLE
Simplify issuer storage 

### DIFF
--- a/personalities/sctfe/storage.go
+++ b/personalities/sctfe/storage.go
@@ -103,17 +103,17 @@ func cachedStoreIssuers(s IssuerStorage) func(context.Context, []KV) error {
 			_, ok := m[string(kv.K)]
 			mu.RUnlock()
 			if ok {
-				klog.V(2).Infof("Exists: found %q in local key cache", kv.K)
+				klog.V(2).Infof("cachedStoreIssuers wrapper: found %q in local key cache", kv.K)
 				continue
 			}
 			req = append(req, kv)
 		}
 		if err := s.AddIssuersIfNotExist(ctx, req); err != nil {
-			return fmt.Errorf("AddIssuers: error storing issuer data in the underlying IssuerStorage: %v", err)
+			return fmt.Errorf("AddIssuersIfNotExist()s: error storing issuer data in the underlying IssuerStorage: %v", err)
 		}
 		for _, kv := range req {
 			if len(m) >= maxCachedIssuerKeys {
-				klog.V(2).Infof("Add: local issuer cache full, will stop caching issuers.")
+				klog.V(2).Infof("cachedStoreIssuers wrapper: local issuer cache full, will stop caching issuers.")
 				return nil
 			}
 			mu.Lock()

--- a/personalities/sctfe/storage.go
+++ b/personalities/sctfe/storage.go
@@ -89,7 +89,7 @@ func (cts *CTStorage) AddIssuerChain(ctx context.Context, chain []*x509.Certific
 	return nil
 }
 
-// cachedStoreIssuers returns a caching wrapper for and IssuerStorage
+// cachedStoreIssuers returns a caching wrapper for an IssuerStorage
 //
 // This is intended to make querying faster. It does not keep a copy of the certs, only sha256.
 // Only up to maxCachedIssuerKeys keys will be stored locally.

--- a/personalities/sctfe/storage/gcp/issuers.go
+++ b/personalities/sctfe/storage/gcp/issuers.go
@@ -101,6 +101,7 @@ func (s *IssuersStorage) AddIssuersIfNotExist(ctx context.Context, kv []sctfe.KV
 
 			return fmt.Errorf("failed to close write on %q: %v", objName, err)
 		}
+
 		klog.V(2).Infof("AddIssuersIfNotExist: added %q in bucket %q", objName, s.bucket.BucketName())
 	}
 	return nil


### PR DESCRIPTION
#88 

- Inline calls to Exists and simplify the API
- Write directly doing a read first: we're talking about saving cents here for 15k entries, it's not worth the complexity
-  crack open the precondition errors to make sure it's really failing because of the precondition we pass