### PR TITLE
Fix GH action warning by swapping checkout and setup-go

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: ${{ matrix.go-version }}
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - run: go test -v -race ./...
 
   test-mysql:


### PR DESCRIPTION
There are warnings complaining "Restore cache failed: Dependencies file is not found in /home/runner/work/trillian-tessera/trillian-tessera. Supported file pattern: go.sum". This is caused by setting up Go repository without checking out the source code.

<img width="1058" alt="image" src="https://github.com/user-attachments/assets/d4017c12-0ea3-4c91-b079-ef520a75737e">
