### PR TITLE
Add support for Static CT API entry bundle paths

### DIFF
--- a/api/layout/paths.go
+++ b/api/layout/paths.go
@@ -49,12 +49,12 @@ func NWithSuffix(l, n, logSize uint64) string {
 // EntriesPath returns the local path for the nth entry bundle. p denotes the partial
 // tile size, or 0 if the tile is complete.
 func EntriesPath(n, logSize uint64) string {
-	return fmt.Sprintf("tile/entries%s", NWithSuffix(0, n, logSize))
+	return fmt.Sprintf("tile/entries/%s", NWithSuffix(0, n, logSize))
 }
 
 // TilePath builds the path to the subtree tile with the given level and index in tile space.
 func TilePath(tileLevel, tileIndex, logSize uint64) string {
-	return fmt.Sprintf("tile/%d%s", tileLevel, NWithSuffix(tileLevel, tileIndex, logSize))
+	return fmt.Sprintf("tile/%d/%s", tileLevel, NWithSuffix(tileLevel, tileIndex, logSize))
 }
 
 // fmtN returns the "N" part of a Tiles-spec path.
@@ -66,10 +66,10 @@ func TilePath(tileLevel, tileIndex, logSize uint64) string {
 //
 // See https://github.com/C2SP/C2SP/blob/main/tlog-tiles.md#:~:text=index%201234067%20will%20be%20encoded%20as%20x001/x234/067
 func fmtN(N uint64) string {
-	n := fmt.Sprintf("/%03d", N%1000)
+	n := fmt.Sprintf("%03d", N%1000)
 	N /= 1000
 	for N > 0 {
-		n = fmt.Sprintf("/x%03d%s", N%1000, n)
+		n = fmt.Sprintf("x%03d/%s", N%1000, n)
 		N /= 1000
 	}
 	return n

--- a/api/layout/paths.go
+++ b/api/layout/paths.go
@@ -37,25 +37,24 @@ func EntriesPathForLogIndex(seq, logSize uint64) string {
 	return EntriesPath(seq/256, logSize)
 }
 
+// NWithSuffix returns a tiles-spec "N" path, with a partial suffix if applicable.
+func NWithSuffix(l, n, logSize uint64) string {
+	suffix := ""
+	if p := partialTileSize(l, n, logSize); p > 0 {
+		suffix = fmt.Sprintf(".p/%d", p)
+	}
+	return fmt.Sprintf("%s%s", fmtN(n), suffix)
+}
+
 // EntriesPath returns the local path for the nth entry bundle. p denotes the partial
 // tile size, or 0 if the tile is complete.
 func EntriesPath(n, logSize uint64) string {
-	suffix := ""
-	if p := partialTileSize(0, n, logSize); p > 0 {
-		suffix = fmt.Sprintf(".p/%d", p)
-	}
-	return fmt.Sprintf("tile/entries%s%s", fmtN(n), suffix)
+	return fmt.Sprintf("tile/entries%s", NWithSuffix(0, n, logSize))
 }
 
 // TilePath builds the path to the subtree tile with the given level and index in tile space.
 func TilePath(tileLevel, tileIndex, logSize uint64) string {
-	suffix := ""
-	p := partialTileSize(tileLevel, tileIndex, logSize)
-	if p > 0 {
-		suffix = fmt.Sprintf(".p/%d", p)
-	}
-
-	return fmt.Sprintf("tile/%d%s%s", tileLevel, fmtN(tileIndex), suffix)
+	return fmt.Sprintf("tile/%d%s", tileLevel, NWithSuffix(tileLevel, tileIndex, logSize))
 }
 
 // fmtN returns the "N" part of a Tiles-spec path.

--- a/api/layout/paths_test.go
+++ b/api/layout/paths_test.go
@@ -169,6 +169,70 @@ func TestTilePath(t *testing.T) {
 	}
 }
 
+func TestNWithSuffix(t *testing.T) {
+	for _, test := range []struct {
+		level    uint64
+		index    uint64
+		logSize  uint64
+		wantPath string
+	}{
+		{
+			level:    0,
+			index:    0,
+			logSize:  256,
+			wantPath: "000",
+		}, {
+			level:    0,
+			index:    0,
+			logSize:  0,
+			wantPath: "000",
+		}, {
+			level:    0,
+			index:    0,
+			logSize:  255,
+			wantPath: "000.p/255",
+		}, {
+			level:    1,
+			index:    0,
+			logSize:  math.MaxUint64,
+			wantPath: "000",
+		}, {
+			level:    1,
+			index:    0,
+			logSize:  256,
+			wantPath: "000.p/1",
+		}, {
+			level:    1,
+			index:    0,
+			logSize:  1024,
+			wantPath: "000.p/4",
+		}, {
+			level:    15,
+			index:    455667,
+			logSize:  math.MaxUint64,
+			wantPath: "x455/667",
+		}, {
+			level:    3,
+			index:    1234567,
+			logSize:  math.MaxUint64,
+			wantPath: "x001/x234/567",
+		}, {
+			level:    15,
+			index:    123456789,
+			logSize:  math.MaxUint64,
+			wantPath: "x123/x456/789",
+		},
+	} {
+		desc := fmt.Sprintf("level %x index %x", test.level, test.index)
+		t.Run(desc, func(t *testing.T) {
+			gotPath := NWithSuffix(test.level, test.index, test.logSize)
+			if gotPath != test.wantPath {
+				t.Errorf("Got path %q want %q", gotPath, test.wantPath)
+			}
+		})
+	}
+}
+
 func TestParseTileLevelIndexWidth(t *testing.T) {
 	for _, test := range []struct {
 		pathLevel string

--- a/ct_only.go
+++ b/ct_only.go
@@ -62,8 +62,10 @@ func convertCTEntry(e *ctonly.Entry) *Entry {
 // WithCTLayout instructs the underlying storage to use a Static CT API compatible scheme for layout.
 func WithCTLayout() func(*StorageOptions) {
 	return func(opts *StorageOptions) {
-		opts.EntriesPath = func(n, logSize uint64) string {
-			return fmt.Sprintf("tile/data/%s", layout.NWithSuffix(0, n, logSize))
-		}
+		opts.EntriesPath = ctEntriesPath
 	}
+}
+
+func ctEntriesPath(n, logSize uint64) string {
+	return fmt.Sprintf("tile/data/%s", layout.NWithSuffix(0, n, logSize))
 }

--- a/ct_only.go
+++ b/ct_only.go
@@ -63,7 +63,7 @@ func convertCTEntry(e *ctonly.Entry) *Entry {
 func WithCTLayout() func(*StorageOptions) {
 	return func(opts *StorageOptions) {
 		opts.EntriesPath = func(n, logSize uint64) string {
-			return fmt.Sprintf("tile/data%s", layout.NWithSuffix(0, n, logSize))
+			return fmt.Sprintf("tile/data/%s", layout.NWithSuffix(0, n, logSize))
 		}
 	}
 }

--- a/ct_only.go
+++ b/ct_only.go
@@ -63,7 +63,7 @@ func convertCTEntry(e *ctonly.Entry) *Entry {
 func WithCTLayout() func(*StorageOptions) {
 	return func(opts *StorageOptions) {
 		opts.EntriesPath = func(n, logSize uint64) string {
-			return fmt.Sprintf("tile/entries%s", layout.NWithSuffix(0, n, logSize))
+			return fmt.Sprintf("tile/data%s", layout.NWithSuffix(0, n, logSize))
 		}
 	}
 }

--- a/ct_only.go
+++ b/ct_only.go
@@ -16,7 +16,9 @@ package tessera
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/transparency-dev/trillian-tessera/api/layout"
 	"github.com/transparency-dev/trillian-tessera/ctonly"
 )
 
@@ -55,4 +57,13 @@ func convertCTEntry(e *ctonly.Entry) *Entry {
 	}
 
 	return r
+}
+
+// WithCTLayout instructs the underlying storage to use a Static CT API compatible scheme for layout.
+func WithCTLayout() func(*StorageOptions) {
+	return func(opts *StorageOptions) {
+		opts.EntriesPath = func(n, logSize uint64) string {
+			return fmt.Sprintf("tile/entries%s", layout.NWithSuffix(0, n, logSize))
+		}
+	}
 }

--- a/ct_only_test.go
+++ b/ct_only_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tessera
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestCTEntriesPath(t *testing.T) {
+	for _, test := range []struct {
+		N        uint64
+		logSize  uint64
+		wantPath string
+	}{
+		{
+			N:        0,
+			logSize:  289,
+			wantPath: "tile/data/000",
+		},
+		{
+			N:        0,
+			logSize:  8,
+			wantPath: "tile/data/000.p/8",
+		}, {
+			N:        255,
+			logSize:  256 * 256,
+			wantPath: "tile/data/255",
+		}, {
+			N:        255,
+			logSize:  255*256 - 3,
+			wantPath: "tile/data/255.p/253",
+		}, {
+			N:        256,
+			logSize:  257 * 256,
+			wantPath: "tile/data/256",
+		}, {
+			N:        123456789000,
+			logSize:  math.MaxUint64,
+			wantPath: "tile/data/x123/x456/x789/000",
+		},
+	} {
+		desc := fmt.Sprintf("N %d", test.N)
+		t.Run(desc, func(t *testing.T) {
+			gotPath := ctEntriesPath(test.N, test.logSize)
+			if gotPath != test.wantPath {
+				t.Errorf("got file %q want %q", gotPath, test.wantPath)
+			}
+		})
+	}
+}

--- a/log.go
+++ b/log.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	f_log "github.com/transparency-dev/formats/log"
+	"github.com/transparency-dev/trillian-tessera/api/layout"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -41,6 +42,9 @@ type NewCPFunc func(size uint64, hash []byte) ([]byte, error)
 // ParseCPFunc is the signature of a function which knows how to verify and parse checkpoints.
 type ParseCPFunc func(raw []byte) (*f_log.Checkpoint, error)
 
+// EntriesPathFunc is the signature of a function which knows how to format entry bundle paths.
+type EntriesPathFunc func(n, logSize uint64) string
+
 // StorageOptions holds optional settings for all storage implementations.
 type StorageOptions struct {
 	NewCP   NewCPFunc
@@ -50,6 +54,8 @@ type StorageOptions struct {
 	BatchMaxSize uint
 
 	PushbackMaxOutstanding uint
+
+	EntriesPath EntriesPathFunc
 }
 
 // ResolveStorageOptions turns a variadic array of storage options into a StorageOptions instance.
@@ -57,6 +63,7 @@ func ResolveStorageOptions(opts ...func(*StorageOptions)) *StorageOptions {
 	defaults := &StorageOptions{
 		BatchMaxSize: DefaultBatchMaxSize,
 		BatchMaxAge:  DefaultBatchMaxAge,
+		EntriesPath:  layout.EntriesPath,
 	}
 	for _, opt := range opts {
 		opt(defaults)

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -264,7 +264,8 @@ func TestBundleRoundtrip(t *testing.T) {
 	ctx := context.Background()
 	m := newMemObjStore()
 	s := &Storage{
-		objStore: m,
+		objStore:    m,
+		entriesPath: layout.EntriesPath,
 	}
 
 	for _, test := range []struct {


### PR DESCRIPTION
This PR adds support to Tessera for storing CT entry bundles in under `data`.

The [Static CT API](https://c2sp.org/static-ct-api) defines leaf entry bundles as being stored under a `tiles/data` path. This is incompatible with the [tlog-tiles spec](https://c2sp.org/tlog-tiles) which defines that path as `tiles/entries`.

This PR adds a CT-only storage option, `WithCTLayout`, which instructs storage implementations to use the Static CT API path.

A strong goal of this PR was to make it impossible for users of Tessera to implement arbitrary layout schemes, or accidentally use the CT layout without a clear signal that this is what they are doing. 

Fixes #171 