### PR TITLE
Remove default options from ResolveStorageOptions

### DIFF
--- a/log.go
+++ b/log.go
@@ -50,11 +50,9 @@ type StorageOptions struct {
 }
 
 // ResolveStorageOptions turns a variadic array of storage options into a StorageOptions instance.
-func ResolveStorageOptions(defaults *StorageOptions, opts ...func(*StorageOptions)) *StorageOptions {
-	if defaults == nil {
-		defaults = &StorageOptions{
-			BatchMaxSize: DefaultBatchMaxSize,
-		}
+func ResolveStorageOptions(opts ...func(*StorageOptions)) *StorageOptions {
+	defaults := &StorageOptions{
+		BatchMaxSize: DefaultBatchMaxSize,
 	}
 	for _, opt := range opts {
 		opt(defaults)

--- a/log.go
+++ b/log.go
@@ -23,7 +23,10 @@ import (
 	"golang.org/x/mod/sumdb/note"
 )
 
-const DefaultBatchMaxSize = 1
+const (
+	DefaultBatchMaxSize = 256
+	DefaultBatchMaxAge  = 250 * time.Millisecond
+)
 
 // ErrPushback is returned by underlying storage implementations when there are too many
 // entries with indices assigned but which have not yet been integrated into the tree.
@@ -53,6 +56,7 @@ type StorageOptions struct {
 func ResolveStorageOptions(opts ...func(*StorageOptions)) *StorageOptions {
 	defaults := &StorageOptions{
 		BatchMaxSize: DefaultBatchMaxSize,
+		BatchMaxAge:  DefaultBatchMaxAge,
 	}
 	for _, opt := range opts {
 		opt(defaults)

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -110,7 +110,7 @@ type Config struct {
 
 // New creates a new instance of the GCP based Storage.
 func New(ctx context.Context, cfg Config, opts ...func(*tessera.StorageOptions)) (*Storage, error) {
-	opt := tessera.ResolveStorageOptions(nil, opts...)
+	opt := tessera.ResolveStorageOptions(opts...)
 	if opt.PushbackMaxOutstanding == 0 {
 		opt.PushbackMaxOutstanding = DefaultPushbackMaxOutstanding
 	}

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/transparency-dev/merkle/rfc6962"
@@ -41,10 +40,8 @@ const (
 	selectTiledLeavesSQL             = "SELECT `data` FROM `TiledLeaves` WHERE `tile_index` = ?"
 	replaceTiledLeavesSQL            = "REPLACE INTO `TiledLeaves` (`tile_index`, `data`) VALUES (?, ?)"
 
-	checkpointID        = 0
-	entryBundleSize     = 256
-	defaultBatchMaxSize = entryBundleSize
-	defaultQueueMaxAge  = time.Second
+	checkpointID    = 0
+	entryBundleSize = 256
 )
 
 // Storage is a MySQL-based storage implementation for Tessera.

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -59,10 +59,7 @@ type Storage struct {
 // New creates a new instance of the MySQL-based Storage.
 // Note that `tessera.WithCheckpointSignerVerifier()` is mandatory in the `opts` argument.
 func New(ctx context.Context, db *sql.DB, opts ...func(*tessera.StorageOptions)) (*Storage, error) {
-	opt := tessera.ResolveStorageOptions(&tessera.StorageOptions{
-		BatchMaxAge:  defaultQueueMaxAge,
-		BatchMaxSize: defaultBatchMaxSize,
-	}, opts...)
+	opt := tessera.ResolveStorageOptions(opts...)
 	s := &Storage{
 		db:              db,
 		newCheckpoint:   opt.NewCP,

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -63,7 +63,7 @@ func New(ctx context.Context, path string, curTree func() (uint64, []byte, error
 	if err != nil {
 		panic(err)
 	}
-	opt := tessera.ResolveStorageOptions(nil, opts...)
+	opt := tessera.ResolveStorageOptions(opts...)
 
 	r := &Storage{
 		path:    path,


### PR DESCRIPTION
This PR removes the default options param from `ResolveStorageOptions`.

This is an unnecessary source of complexity at the moment.