### PR TITLE
Fix partial tile clean up

### DIFF
--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -331,7 +331,7 @@ func (s *Storage) StoreTile(_ context.Context, level, index, logSize uint64, til
 	}
 
 	if tileSize == 256 {
-		partials, err := filepath.Glob(fmt.Sprintf("%s.*", tPath))
+		partials, err := filepath.Glob(fmt.Sprintf("%s.p/*", tPath))
 		if err != nil {
 			return fmt.Errorf("failed to list partial tiles for clean up; %w", err)
 		}


### PR DESCRIPTION
This PR fixes an error in the partial tile clean up code.

Previously the code expected to find partial tiles named as `<tileID>.<size>`, but the `tlog-tiles` spec requires partial tiles to be stored in a directory named `<tileID>.p/`. This resulted in errors like the one below when the storage implementation completed a full tile:

```
E0830 11:39:00.756914  239314 files.go:225] Integrate failed: failed to set tile({0 0}): failed to rename temp link over partial tile: rename /tmp/mylog/tile/0/000.link /tmp/mylog/tile/0/000.p: file exists
```

This PR fixes the incorrect path assumption.
