### PR TITLE
Deduplicate add-chain requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/rs/cors v1.11.1
 	github.com/transparency-dev/formats v0.0.0-20240826204810-ad21d25a1c7f
 	github.com/transparency-dev/merkle v0.0.2
+	go.etcd.io/bbolt v1.3.11
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	golang.org/x/mod v0.20.0
 	google.golang.org/api v0.194.0
@@ -43,6 +44,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cisco/go-tls-syntax v0.0.0-20200617162716-46b0cfb76b9b // indirect
 	github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b // indirect
 	github.com/envoyproxy/go-control-plane v0.12.1-0.20240621013728-1eb8caab5155 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,6 @@ require (
 	k8s.io/klog/v2 v2.130.1
 )
 
-require github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
-
 require (
 	cel.dev/expr v0.15.0 // indirect
 	cloud.google.com/go v0.115.1 // indirect
@@ -66,11 +64,13 @@ require (
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/prometheus/prometheus v0.51.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	go.etcd.io/bbolt v1.3.11 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.52.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/prometheus/client_golang v1.20.2
 	github.com/rivo/tview v0.0.0-20240625185742-b0a7293b8130
 	github.com/rs/cors v1.11.1
-	github.com/transparency-dev/formats v0.0.0-20240715203801-9ff9b9e3905f
+	github.com/transparency-dev/formats v0.0.0-20240826204810-ad21d25a1c7f
 	github.com/transparency-dev/merkle v0.0.2
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 	golang.org/x/mod v0.20.0

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.4.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cisco/go-tls-syntax v0.0.0-20200617162716-46b0cfb76b9b // indirect
 	github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b // indirect
 	github.com/envoyproxy/go-control-plane v0.12.1-0.20240621013728-1eb8caab5155 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
@@ -72,7 +71,6 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/prometheus/prometheus v0.51.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	go.etcd.io/bbolt v1.3.11 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.52.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -978,8 +978,6 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/transparency-dev/formats v0.0.0-20240715203801-9ff9b9e3905f h1:NKx8BtgVYeC75VJqlsdn1DAcbmSSDQCeDw8by0m6sbA=
-github.com/transparency-dev/formats v0.0.0-20240715203801-9ff9b9e3905f/go.mod h1:D/QMvgv1kz9Q1TfUcDnUcDPsiSbtLV8q8LvTCdcvygw=
 github.com/transparency-dev/formats v0.0.0-20240826204810-ad21d25a1c7f h1:FiuOzJItmOKrUNVfjWTbEurV9/vYyop2zoR4s8qp80c=
 github.com/transparency-dev/formats v0.0.0-20240826204810-ad21d25a1c7f/go.mod h1:Iso3Bhsif9xUGQdI3TF3IiM3F3IKfNHG4LnDgbk+1zg=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=

--- a/go.sum
+++ b/go.sum
@@ -658,8 +658,6 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cisco/go-tls-syntax v0.0.0-20200617162716-46b0cfb76b9b h1:Ves2turKTX7zruivAcUOQg155xggcbv3suVdbKCBQNM=
-github.com/cisco/go-tls-syntax v0.0.0-20200617162716-46b0cfb76b9b/go.mod h1:0AZAV7lYvynZQ5ErHlGMKH+4QYMyNCFd+AiL9MlrCYA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/go.sum
+++ b/go.sum
@@ -989,6 +989,8 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
+go.etcd.io/bbolt v1.3.11 h1:yGEzV1wPz2yVCLsD8ZAiGHhHVlczyC9d1rP43/VCRJ0=
+go.etcd.io/bbolt v1.3.11/go.mod h1:dksAq7YMXoljX0xu6VF5DMZGbhYYoLUalEiSySYAS4I=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/go.sum
+++ b/go.sum
@@ -658,6 +658,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cisco/go-tls-syntax v0.0.0-20200617162716-46b0cfb76b9b h1:Ves2turKTX7zruivAcUOQg155xggcbv3suVdbKCBQNM=
+github.com/cisco/go-tls-syntax v0.0.0-20200617162716-46b0cfb76b9b/go.mod h1:0AZAV7lYvynZQ5ErHlGMKH+4QYMyNCFd+AiL9MlrCYA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -978,6 +980,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/transparency-dev/formats v0.0.0-20240715203801-9ff9b9e3905f h1:NKx8BtgVYeC75VJqlsdn1DAcbmSSDQCeDw8by0m6sbA=
 github.com/transparency-dev/formats v0.0.0-20240715203801-9ff9b9e3905f/go.mod h1:D/QMvgv1kz9Q1TfUcDnUcDPsiSbtLV8q8LvTCdcvygw=
+github.com/transparency-dev/formats v0.0.0-20240826204810-ad21d25a1c7f h1:FiuOzJItmOKrUNVfjWTbEurV9/vYyop2zoR4s8qp80c=
+github.com/transparency-dev/formats v0.0.0-20240826204810-ad21d25a1c7f/go.mod h1:Iso3Bhsif9xUGQdI3TF3IiM3F3IKfNHG4LnDgbk+1zg=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/personalities/sctfe/ct_server_gcp/main.go
+++ b/personalities/sctfe/ct_server_gcp/main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
-	tdnote "github.com/transparency-dev/formats/note"
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/personalities/sctfe"
 	"github.com/transparency-dev/trillian-tessera/personalities/sctfe/configpb"
@@ -301,18 +300,7 @@ func newGCPStorage(ctx context.Context, vCfg *sctfe.ValidatedLogConfig, signer n
 		return nil, fmt.Errorf("failed to get a log fetcher")
 	}
 
-	verifierString, err := tdnote.RFC6962VerifierString(vCfg.Config.Origin, vCfg.PubKey)
-	if err != nil {
-		return nil, fmt.Errorf("error creating static-ct-api checkpoint verifier string: %v", err)
-
-	}
-	verifier, err := tdnote.NewRFC6962Verifier(verifierString)
-	if err != nil {
-		return nil, fmt.Errorf("error creating static-ct-api checkpoint verifier: %v", err)
-
-	}
-
-	localDedup := dedup.NewLocalBestEffortDedup(ctx, dedupStorage, time.Second, fetcher, verifier, vCfg.Config.Origin, sctfe.DedupFromBundle)
+	localDedup := dedup.NewLocalBestEffortDedup(ctx, dedupStorage, time.Second, fetcher, sctfe.DedupFromBundle)
 
 	return sctfe.NewCTSTorage(tesseraStorage, issuerStorage, localDedup)
 }

--- a/personalities/sctfe/ct_server_gcp/main.go
+++ b/personalities/sctfe/ct_server_gcp/main.go
@@ -290,8 +290,8 @@ func newGCPStorage(ctx context.Context, vCfg *sctfe.ValidatedLogConfig, signer n
 		return nil, fmt.Errorf("Failed to initialize GCP issuer storage: %v", err)
 	}
 
-	// TODO: repalce with a global dedup storage for GCP
-	dedupStorage, err := bbolt.NewStorage(*dedupPath)
+	// TODO: replace with a global dedup storage for GCP
+	beDedupStorage, err := bbolt.NewStorage(*dedupPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize BBolt deduplication database: %v", err)
 	}
@@ -301,7 +301,7 @@ func newGCPStorage(ctx context.Context, vCfg *sctfe.ValidatedLogConfig, signer n
 		return nil, fmt.Errorf("failed to get a log fetcher: %v", err)
 	}
 
-	localDedup := dedup.NewLocalBestEffortDedup(ctx, dedupStorage, time.Second, fetcher, sctfe.DedupFromBundle)
+	go dedup.UpdateFromLog(ctx, beDedupStorage, time.Second, fetcher, sctfe.DedupFromBundle)
 
-	return sctfe.NewCTSTorage(tesseraStorage, issuerStorage, localDedup)
+	return sctfe.NewCTSTorage(tesseraStorage, issuerStorage, beDedupStorage)
 }

--- a/personalities/sctfe/ct_server_gcp/main.go
+++ b/personalities/sctfe/ct_server_gcp/main.go
@@ -208,6 +208,7 @@ func main() {
 		shutdownWG.Add(1)
 		defer shutdownWG.Done()
 		// Allow 60s for any pending requests to finish then terminate any stragglers
+		// TODO(phboneff): may be wait for the sequencer queue to be empty?
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 		defer cancel()
 		klog.Info("Shutting down HTTP server...")

--- a/personalities/sctfe/ct_server_gcp/main.go
+++ b/personalities/sctfe/ct_server_gcp/main.go
@@ -290,6 +290,7 @@ func newGCPStorage(ctx context.Context, vCfg *sctfe.ValidatedLogConfig, signer n
 		return nil, fmt.Errorf("Failed to initialize GCP issuer storage: %v", err)
 	}
 
+	// TODO: repalce with a global dedup storage for GCP
 	dedupStorage, err := bbolt.NewStorage(*dedupPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize BBolt deduplication database: %v", err)

--- a/personalities/sctfe/ct_server_gcp/main.go
+++ b/personalities/sctfe/ct_server_gcp/main.go
@@ -66,6 +66,9 @@ var (
 	tracingProjectID   = flag.String("tracing_project_id", "", "project ID to pass to stackdriver. Can be empty for GCP, consult docs for other platforms.")
 	tracingPercent     = flag.Int("tracing_percent", 0, "Percent of requests to be traced. Zero is a special case to use the DefaultSampler")
 	pkcs11ModulePath   = flag.String("pkcs11_module_path", "", "Path to the PKCS#11 module to use for keys that use the PKCS#11 interface")
+	// This should be specified in the config proto, but this proto is going to go away in favour of flags, so let's put this one here directly.
+	// TODO: remove comment above when the config proto has been deleted.
+	dedupPath = flag.String("dedup_path", "", "Path to the deduplication database")
 )
 
 // nolint:staticcheck
@@ -287,7 +290,7 @@ func newGCPStorage(ctx context.Context, vCfg *sctfe.ValidatedLogConfig, signer n
 		return nil, fmt.Errorf("Failed to initialize GCP issuer storage: %v", err)
 	}
 
-	dedupStorage, err := bbolt.NewStorage("test.db")
+	dedupStorage, err := bbolt.NewStorage(*dedupPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize BBolt deduplication database")
 	}

--- a/personalities/sctfe/ct_server_gcp/main.go
+++ b/personalities/sctfe/ct_server_gcp/main.go
@@ -207,7 +207,7 @@ func main() {
 		shutdownWG.Add(1)
 		defer shutdownWG.Done()
 		// Allow 60s for any pending requests to finish then terminate any stragglers
-		// TODO(phboneff): may be wait for the sequencer queue to be empty?
+		// TODO(phboneff): maybe wait for the sequencer queue to be empty?
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 		defer cancel()
 		klog.Info("Shutting down HTTP server...")
@@ -292,12 +292,12 @@ func newGCPStorage(ctx context.Context, vCfg *sctfe.ValidatedLogConfig, signer n
 
 	dedupStorage, err := bbolt.NewStorage(*dedupPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize BBolt deduplication database")
+		return nil, fmt.Errorf("failed to initialize BBolt deduplication database: %v", err)
 	}
 
 	fetcher, err := gcpSCTFE.GetFetcher(ctx, cfg.Bucket)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get a log fetcher")
+		return nil, fmt.Errorf("failed to get a log fetcher: %v", err)
 	}
 
 	localDedup := dedup.NewLocalBestEffortDedup(ctx, dedupStorage, time.Second, fetcher, sctfe.DedupFromBundle)

--- a/personalities/sctfe/handlers.go
+++ b/personalities/sctfe/handlers.go
@@ -353,6 +353,9 @@ func addChainInternal(ctx context.Context, li *logInfo, w http.ResponseWriter, r
 			}
 			return http.StatusInternalServerError, fmt.Errorf("couldn't store the leaf: %v", err)
 		}
+		// We store the index for this certificate in the deduplication storage immediately.
+		// It might be stored again later, if a local deduplication storage is synced, potentially
+		// with a smaller value.
 		klog.V(2).Infof("%s: %s => storage.AddCertIndex", li.LogOrigin, method)
 		err := li.storage.AddCertIndex(ctx, chain[0], idx)
 		// TODO: block log writes if deduplication breaks

--- a/personalities/sctfe/handlers.go
+++ b/personalities/sctfe/handlers.go
@@ -345,7 +345,7 @@ func addChainInternal(ctx context.Context, li *logInfo, w http.ResponseWriter, r
 		}
 
 		klog.V(2).Infof("%s: %s => storage.Add", li.LogOrigin, method)
-		idx, err = li.storage.Add(ctx, entry)
+		idx, err = li.storage.Add(ctx, entry)()
 		if err != nil {
 			if errors.Is(err, tessera.ErrPushback) {
 				w.Header().Add("Retry-After", "1")

--- a/personalities/sctfe/handlers_test.go
+++ b/personalities/sctfe/handlers_test.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -294,13 +293,10 @@ func TestAddChainWhitespace(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.descr, func(t *testing.T) {
 			if test.want == http.StatusOK {
-				var wg sync.WaitGroup
-				wg.Add(1)
-				defer wg.Wait()
 				info.storage.EXPECT().GetCertIndex(deadlineMatcher(), cmpMatcher{leafChain[0]}).Return(uint64(0), false, nil)
 				info.storage.EXPECT().AddIssuerChain(deadlineMatcher(), cmpMatcher{leafChain[1:]}).Return(nil)
 				info.storage.EXPECT().Add(deadlineMatcher(), cmpMatcher{req}).Return(func() (uint64, error) { return rsp, nil })
-				info.storage.EXPECT().AddCertIndex(deadlineMatcher(), cmpMatcher{leafChain[0]}, uint64(0)).Do(func(_ context.Context, _ *x509.Certificate, _ uint64) { wg.Done() }).Return(nil)
+				info.storage.EXPECT().AddCertIndex(deadlineMatcher(), cmpMatcher{leafChain[0]}, uint64(0)).Return(nil)
 			}
 
 			recorder := httptest.NewRecorder()
@@ -377,10 +373,7 @@ func TestAddChain(t *testing.T) {
 				info.storage.EXPECT().AddIssuerChain(deadlineMatcher(), cmpMatcher{leafChain[1:]}).Return(nil)
 				info.storage.EXPECT().Add(deadlineMatcher(), cmpMatcher{req}).Return(func() (uint64, error) { return rsp, test.err })
 				if test.want == http.StatusOK {
-					var wg sync.WaitGroup
-					wg.Add(1)
-					defer wg.Wait()
-					info.storage.EXPECT().AddCertIndex(deadlineMatcher(), cmpMatcher{leafChain[0]}, uint64(0)).Do(func(_ context.Context, _ *x509.Certificate, _ uint64) { wg.Done() }).Return(nil)
+					info.storage.EXPECT().AddCertIndex(deadlineMatcher(), cmpMatcher{leafChain[0]}, uint64(0)).Return(nil)
 				}
 			}
 
@@ -473,10 +466,7 @@ func TestAddPrechain(t *testing.T) {
 				info.storage.EXPECT().AddIssuerChain(deadlineMatcher(), cmpMatcher{leafChain[1:]}).Return(nil)
 				info.storage.EXPECT().Add(deadlineMatcher(), cmpMatcher{req}).Return(func() (uint64, error) { return rsp, test.err })
 				if test.want == http.StatusOK {
-					var wg sync.WaitGroup
-					wg.Add(1)
-					defer wg.Wait()
-					info.storage.EXPECT().AddCertIndex(deadlineMatcher(), cmpMatcher{leafChain[0]}, uint64(0)).Do(func(_ context.Context, _ *x509.Certificate, _ uint64) { wg.Done() }).Return(nil)
+					info.storage.EXPECT().AddCertIndex(deadlineMatcher(), cmpMatcher{leafChain[0]}, uint64(0)).Return(nil)
 				}
 			}
 

--- a/personalities/sctfe/mockstorage/mock_ct_storage.go
+++ b/personalities/sctfe/mockstorage/mock_ct_storage.go
@@ -51,6 +51,20 @@ func (mr *MockStorageMockRecorder) Add(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockStorage)(nil).Add), arg0, arg1)
 }
 
+// AddCertIndex mocks base method.
+func (m *MockStorage) AddCertIndex(arg0 context.Context, arg1 *x509.Certificate, arg2 uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddCertIndex", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddCertIndex indicates an expected call of AddCertIndex.
+func (mr *MockStorageMockRecorder) AddCertIndex(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCertIndex", reflect.TypeOf((*MockStorage)(nil).AddCertIndex), arg0, arg1, arg2)
+}
+
 // AddIssuerChain mocks base method.
 func (m *MockStorage) AddIssuerChain(arg0 context.Context, arg1 []*x509.Certificate) error {
 	m.ctrl.T.Helper()
@@ -63,4 +77,20 @@ func (m *MockStorage) AddIssuerChain(arg0 context.Context, arg1 []*x509.Certific
 func (mr *MockStorageMockRecorder) AddIssuerChain(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddIssuerChain", reflect.TypeOf((*MockStorage)(nil).AddIssuerChain), arg0, arg1)
+}
+
+// GetCertIndex mocks base method.
+func (m *MockStorage) GetCertIndex(arg0 context.Context, arg1 *x509.Certificate) (uint64, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCertIndex", arg0, arg1)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetCertIndex indicates an expected call of GetCertIndex.
+func (mr *MockStorageMockRecorder) GetCertIndex(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCertIndex", reflect.TypeOf((*MockStorage)(nil).GetCertIndex), arg0, arg1)
 }

--- a/personalities/sctfe/modules/README.md
+++ b/personalities/sctfe/modules/README.md
@@ -1,0 +1,5 @@
+# Modules
+
+This directory contains modules that Tessera Personality can link to get extra functionalities.
+
+TODO: move out of the SCTFE directory once we've sorted out repo structure for personalities

--- a/personalities/sctfe/modules/dedup/dedup.go
+++ b/personalities/sctfe/modules/dedup/dedup.go
@@ -1,0 +1,144 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bbolt implements SCTFE storage systems for deduplication.
+//
+// The interfaces are defined in sctfe/storage.go
+package dedup
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"time"
+
+	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/client"
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/mod/sumdb/note"
+	"k8s.io/klog/v2"
+)
+
+// KV holds a LeafID and an Idx for deduplication
+type KV struct {
+	K []byte
+	V uint64
+}
+
+type DedupStorage interface {
+	Add(kvs []KV) error
+	Get(key []byte) (uint64, bool, error)
+}
+
+type LocalDedupStorage interface {
+	Add(kvs []KV) error
+	Get(key []byte) (uint64, bool, error)
+	LogSize() (uint64, error)
+}
+
+type LocalBEDedup struct {
+	DedupStorage
+	LogSize func() (uint64, error) // returns the largest idx Add has successfully been called with
+	fetcher client.Fetcher
+}
+
+func NewLocalBestEffortDedup(ctx context.Context, lds LocalDedupStorage, t time.Duration, f client.Fetcher, v note.Verifier, origin string) *LocalBEDedup {
+	ret := &LocalBEDedup{DedupStorage: lds, LogSize: lds.LogSize, fetcher: f}
+	go func() {
+		tck := time.NewTicker(t)
+		defer tck.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tck.C:
+				if err := ret.sync(ctx, origin, v); err != nil {
+					klog.Warningf("error updating deduplication data: %v", err)
+				}
+			}
+		}
+	}()
+	return ret
+}
+
+func (d *LocalBEDedup) sync(ctx context.Context, origin string, v note.Verifier) error {
+	ckpt, _, _, err := client.FetchCheckpoint(ctx, d.fetcher, v, origin)
+	if err != nil {
+		return fmt.Errorf("FetchCheckpoint: %v", err)
+	}
+	oldSize, err := d.LogSize()
+	if err != nil {
+		return fmt.Errorf("OldSize(): %v", err)
+	}
+
+	// TODO(phboneff): add parallelism
+	// Greatly inspired by https://github.com/FiloSottile/sunlight/blob/main/tile.go and
+	// https://github.com/transparency-dev/trillian-tessera/blob/main/client/client.go
+	if ckpt.Size > oldSize {
+		for i := oldSize / 256; i <= ckpt.Size/256; i++ {
+			kvs := []KV{}
+			p := layout.EntriesPath(i, ckpt.Size)
+			eRaw, err := d.fetcher(ctx, p)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf("leaf bundle at index %d not found: %v", i, err)
+				}
+				return fmt.Errorf("failed to fetch leaf bundle at index %d: %v", i, err)
+			}
+			s := cryptobyte.String(eRaw)
+
+			for len(s) > 0 {
+				var timestamp uint64
+				var entryType uint16
+				var extensions, fingerprints cryptobyte.String
+				if !s.ReadUint64(&timestamp) || !s.ReadUint16(&entryType) || timestamp > math.MaxInt64 {
+					return fmt.Errorf("invalid data tile")
+				}
+				crt := []byte{}
+				switch entryType {
+				case 0: // x509_entry
+					if !s.ReadUint24LengthPrefixed((*cryptobyte.String)(&crt)) ||
+						// TODO(phboneff): remove below?
+						!s.ReadUint16LengthPrefixed(&extensions) ||
+						!s.ReadUint16LengthPrefixed(&fingerprints) {
+						return fmt.Errorf("invalid data tile x509_entry")
+					}
+				case 1: // precert_entry
+					IssuerKeyHash := [32]byte{}
+					var defangedCrt, extensions cryptobyte.String
+					if !s.CopyBytes(IssuerKeyHash[:]) ||
+						!s.ReadUint24LengthPrefixed(&defangedCrt) ||
+						!s.ReadUint16LengthPrefixed(&extensions) ||
+						!s.ReadUint24LengthPrefixed((*cryptobyte.String)(&crt)) ||
+						// TODO(phboneff): remove below?
+						!s.ReadUint16LengthPrefixed(&fingerprints) {
+						return fmt.Errorf("invalid data tile precert_entry")
+					}
+				default:
+					return fmt.Errorf("invalid data tile: unknown type %d", entryType)
+				}
+				k := sha256.Sum256(crt)
+				kvs = append(kvs, KV{K: k[:], V: i*256 + uint64(len(kvs))})
+			}
+
+			if err := d.Add(kvs); err != nil {
+				return fmt.Errorf("error storing deduplication data for tile %d: %v", i, err)
+			}
+		}
+	}
+	return nil
+}

--- a/personalities/sctfe/modules/dedup/dedup.go
+++ b/personalities/sctfe/modules/dedup/dedup.go
@@ -37,13 +37,13 @@ type KV struct {
 }
 
 type DedupStorage interface {
-	Add(kvs []KV) error
-	Get(key []byte) (uint64, bool, error)
+	Add(ctx context.Context, kvs []KV) error
+	Get(ctx context.Context, key []byte) (uint64, bool, error)
 }
 
 type LocalDedupStorage interface {
-	Add(kvs []KV) error
-	Get(key []byte) (uint64, bool, error)
+	Add(ctx context.Context, kvs []KV) error
+	Get(ctx context.Context, key []byte) (uint64, bool, error)
 	LogSize() (uint64, error)
 }
 
@@ -101,7 +101,7 @@ func (d *LocalBEDedup) sync(ctx context.Context, origin string, v note.Verifier,
 				return fmt.Errorf("parseBundle(): %v", err)
 			}
 
-			if err := d.Add(kvs); err != nil {
+			if err := d.Add(ctx, kvs); err != nil {
 				return fmt.Errorf("error storing deduplication data for tile %d: %v", i, err)
 			}
 			klog.V(3).Infof("LocalBEDEdup.sync(): stored dedup data for entry bundle %d, %d more bundles to go", i, ckpt.Size/256-i)

--- a/personalities/sctfe/modules/dedup/dedup.go
+++ b/personalities/sctfe/modules/dedup/dedup.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package bbolt implements SCTFE storage systems for deduplication.
-//
-// The interfaces are defined in sctfe/storage.go
+// Package dedup limits the number of duplicate entries a personality allows in a Tessera log.
 package dedup
 
 import (
@@ -53,6 +51,7 @@ type LocalBEDedup struct {
 	fetcher client.Fetcher
 }
 
+// NewLocalBestEffortDedup instantiates a local dedup storage and kicks off a synchronisation routine in the background.
 func NewLocalBestEffortDedup(ctx context.Context, lds LocalDedupStorage, t time.Duration, f client.Fetcher, v note.Verifier, origin string, parseBundle func([]byte, uint64) ([]KV, error)) *LocalBEDedup {
 	ret := &LocalBEDedup{DedupStorage: lds, LogSize: lds.LogSize, fetcher: f}
 	go func() {
@@ -72,6 +71,7 @@ func NewLocalBestEffortDedup(ctx context.Context, lds LocalDedupStorage, t time.
 	return ret
 }
 
+// sync synchronises a deduplication storage with the corresponding log content.
 func (d *LocalBEDedup) sync(ctx context.Context, origin string, v note.Verifier, parseBundle func([]byte, uint64) ([]KV, error)) error {
 	ckpt, _, _, err := client.FetchCheckpoint(ctx, d.fetcher, v, origin)
 	if err != nil {

--- a/personalities/sctfe/modules/dedup/dedup.go
+++ b/personalities/sctfe/modules/dedup/dedup.go
@@ -91,7 +91,7 @@ func sync(ctx context.Context, lds LocalBEDedupStorage, pb ParseBundleFunc, f cl
 	if ckptSize > oldSize {
 		klog.V(2).Infof("LocalBEDEdup.sync(): log at size %d, dedup database at size %d, startig to sync", ckptSize, oldSize)
 		for i := oldSize / 256; i <= ckptSize/256; i++ {
-			p := layout.EntriesPath(i, ckptSize)
+			p := fmt.Sprintf("tile/data/%s", layout.NWithSuffix(0, i, ckptSize))
 			eRaw, err := f(ctx, p)
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {

--- a/personalities/sctfe/modules/dedup/dedup.go
+++ b/personalities/sctfe/modules/dedup/dedup.go
@@ -86,6 +86,7 @@ func (d *LocalBEDedup) sync(ctx context.Context, origin string, v note.Verifier,
 	// Greatly inspired by https://github.com/FiloSottile/sunlight/blob/main/tile.go and
 	// https://github.com/transparency-dev/trillian-tessera/blob/main/client/client.go
 	if ckpt.Size > oldSize {
+		klog.V(2).Infof("LocalBEDEdup.sync(): log at size %d, dedup database at size %d, startig to sync", ckpt.Size, oldSize)
 		for i := oldSize / 256; i <= ckpt.Size/256; i++ {
 			p := layout.EntriesPath(i, ckpt.Size)
 			eRaw, err := d.fetcher(ctx, p)
@@ -103,7 +104,9 @@ func (d *LocalBEDedup) sync(ctx context.Context, origin string, v note.Verifier,
 			if err := d.Add(kvs); err != nil {
 				return fmt.Errorf("error storing deduplication data for tile %d: %v", i, err)
 			}
+			klog.V(3).Infof("LocalBEDEdup.sync(): stored dedup data for entry bundle %d, %d more bundles to go", i, ckpt.Size/256-i)
 		}
 	}
+	klog.V(3).Infof("LocalBEDEdup.sync(): dedup data synced to logsize %d", ckpt.Size)
 	return nil
 }

--- a/personalities/sctfe/modules/dedup/dedup.go
+++ b/personalities/sctfe/modules/dedup/dedup.go
@@ -53,7 +53,7 @@ type LocalBEDedup struct {
 	fetcher client.Fetcher
 }
 
-func NewLocalBestEffortDedup(ctx context.Context, lds LocalDedupStorage, t time.Duration, f client.Fetcher, v note.Verifier, origin string, parseBundle func([]byte) []KV) *LocalBEDedup {
+func NewLocalBestEffortDedup(ctx context.Context, lds LocalDedupStorage, t time.Duration, f client.Fetcher, v note.Verifier, origin string, parseBundle func([]byte, uint64) ([]KV, error)) *LocalBEDedup {
 	ret := &LocalBEDedup{DedupStorage: lds, LogSize: lds.LogSize, fetcher: f}
 	go func() {
 		tck := time.NewTicker(t)
@@ -72,7 +72,7 @@ func NewLocalBestEffortDedup(ctx context.Context, lds LocalDedupStorage, t time.
 	return ret
 }
 
-func (d *LocalBEDedup) sync(ctx context.Context, origin string, v note.Verifier, parseBundle func([]byte) []KV) error {
+func (d *LocalBEDedup) sync(ctx context.Context, origin string, v note.Verifier, parseBundle func([]byte, uint64) ([]KV, error)) error {
 	ckpt, _, _, err := client.FetchCheckpoint(ctx, d.fetcher, v, origin)
 	if err != nil {
 		return fmt.Errorf("FetchCheckpoint: %v", err)

--- a/personalities/sctfe/modules/dedup/dedup.go
+++ b/personalities/sctfe/modules/dedup/dedup.go
@@ -48,13 +48,13 @@ type LocalDedupStorage interface {
 
 type LocalBEDedup struct {
 	DedupStorage
-	LogSize func() (uint64, error) // returns the largest contiguous idx Add has successfully been called with
+	logSize func() (uint64, error) // returns the largest contiguous idx Add has successfully been called with
 	fetcher client.Fetcher
 }
 
 // NewLocalBestEffortDedup instantiates a local dedup storage and kicks off a synchronisation routine in the background.
 func NewLocalBestEffortDedup(ctx context.Context, lds LocalDedupStorage, t time.Duration, f client.Fetcher, parseBundle func([]byte, uint64) ([]LeafIdx, error)) *LocalBEDedup {
-	ret := &LocalBEDedup{DedupStorage: lds, LogSize: lds.LogSize, fetcher: f}
+	ret := &LocalBEDedup{DedupStorage: lds, logSize: lds.LogSize, fetcher: f}
 	go func() {
 		tck := time.NewTicker(t)
 		defer tck.Stop()
@@ -87,7 +87,7 @@ func (d *LocalBEDedup) sync(ctx context.Context, parseBundle func([]byte, uint64
 	if err != nil {
 		return fmt.Errorf("invalid checkpoint - can't extract size: %v", err)
 	}
-	oldSize, err := d.LogSize()
+	oldSize, err := d.logSize()
 	if err != nil {
 		return fmt.Errorf("OldSize(): %v", err)
 	}

--- a/personalities/sctfe/modules/dedup/dedup.go
+++ b/personalities/sctfe/modules/dedup/dedup.go
@@ -49,7 +49,7 @@ type LocalDedupStorage interface {
 
 type LocalBEDedup struct {
 	DedupStorage
-	LogSize func() (uint64, error) // returns the largest idx Add has successfully been called with
+	LogSize func() (uint64, error) // returns the largest contiguous idx Add has successfully been called with
 	fetcher client.Fetcher
 }
 
@@ -83,7 +83,7 @@ func (d *LocalBEDedup) sync(ctx context.Context, origin string, v note.Verifier,
 	}
 
 	// TODO(phboneff): add parallelism
-	// Greatly inspired by https://github.com/FiloSottile/sunlight/blob/main/tile.go and
+	// Greatly inspired by
 	// https://github.com/transparency-dev/trillian-tessera/blob/main/client/client.go
 	if ckpt.Size > oldSize {
 		klog.V(2).Infof("LocalBEDEdup.sync(): log at size %d, dedup database at size %d, startig to sync", ckpt.Size, oldSize)

--- a/personalities/sctfe/serialize.go
+++ b/personalities/sctfe/serialize.go
@@ -180,8 +180,8 @@ func NewCpSigner(signer crypto.Signer, origin string, logID [32]byte, timeSource
 //
 // The index of a leaf is computed from its position in the log, instead of parsing SCTs.
 // Greatly inspired by https://github.com/FiloSottile/sunlight/blob/main/tile.go
-func DedupFromBundle(bundle []byte, bundleIdx uint64) ([]dedup.KV, error) {
-	kvs := []dedup.KV{}
+func DedupFromBundle(bundle []byte, bundleIdx uint64) ([]dedup.LeafIdx, error) {
+	kvs := []dedup.LeafIdx{}
 	s := cryptobyte.String(bundle)
 
 	for len(s) > 0 {
@@ -213,7 +213,7 @@ func DedupFromBundle(bundle []byte, bundleIdx uint64) ([]dedup.KV, error) {
 			return nil, fmt.Errorf("invalid data tile: unknown type %d", entryType)
 		}
 		k := sha256.Sum256(crt)
-		kvs = append(kvs, dedup.KV{K: k[:], V: bundleIdx*256 + uint64(len(kvs))})
+		kvs = append(kvs, dedup.LeafIdx{LeafID: k[:], Idx: bundleIdx*256 + uint64(len(kvs))})
 	}
 	return kvs, nil
 }

--- a/personalities/sctfe/serialize.go
+++ b/personalities/sctfe/serialize.go
@@ -178,8 +178,7 @@ func NewCpSigner(signer crypto.Signer, origin string, logID [32]byte, timeSource
 
 // DedupFromBundle converts a bundle into an array of {leafID, idx}.
 //
-// The index of a leaf is computed from its position in the log, instead of parsing
-// the SCT.
+// The index of a leaf is computed from its position in the log, instead of parsing SCTs.
 // Greatly inspired by https://github.com/FiloSottile/sunlight/blob/main/tile.go and
 func DedupFromBundle(bundle []byte, bundleIdx uint64) ([]dedup.KV, error) {
 	kvs := []dedup.KV{}

--- a/personalities/sctfe/serialize.go
+++ b/personalities/sctfe/serialize.go
@@ -20,9 +20,12 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"math"
 
 	"github.com/google/certificate-transparency-go/tls"
 	"github.com/transparency-dev/formats/log"
+	"github.com/transparency-dev/trillian-tessera/personalities/sctfe/modules/dedup"
+	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/mod/sumdb/note"
 
 	ct "github.com/google/certificate-transparency-go"
@@ -171,4 +174,44 @@ func NewCpSigner(signer crypto.Signer, origin string, logID [32]byte, timeSource
 		timeSource: timeSource,
 	}
 	return ctSigner
+}
+
+func DedupFromBundle(bundle []byte, bundleIdx uint64) ([]dedup.KV, error) {
+	kvs := []dedup.KV{}
+	s := cryptobyte.String(bundle)
+
+	for len(s) > 0 {
+		var timestamp uint64
+		var entryType uint16
+		var extensions, fingerprints cryptobyte.String
+		if !s.ReadUint64(&timestamp) || !s.ReadUint16(&entryType) || timestamp > math.MaxInt64 {
+			return nil, fmt.Errorf("invalid data tile")
+		}
+		crt := []byte{}
+		switch entryType {
+		case 0: // x509_entry
+			if !s.ReadUint24LengthPrefixed((*cryptobyte.String)(&crt)) ||
+				// TODO(phboneff): remove below?
+				!s.ReadUint16LengthPrefixed(&extensions) ||
+				!s.ReadUint16LengthPrefixed(&fingerprints) {
+				return nil, fmt.Errorf("invalid data tile x509_entry")
+			}
+		case 1: // precert_entry
+			IssuerKeyHash := [32]byte{}
+			var defangedCrt, extensions cryptobyte.String
+			if !s.CopyBytes(IssuerKeyHash[:]) ||
+				!s.ReadUint24LengthPrefixed(&defangedCrt) ||
+				!s.ReadUint16LengthPrefixed(&extensions) ||
+				!s.ReadUint24LengthPrefixed((*cryptobyte.String)(&crt)) ||
+				// TODO(phboneff): remove below?
+				!s.ReadUint16LengthPrefixed(&fingerprints) {
+				return nil, fmt.Errorf("invalid data tile precert_entry")
+			}
+		default:
+			return nil, fmt.Errorf("invalid data tile: unknown type %d", entryType)
+		}
+		k := sha256.Sum256(crt)
+		kvs = append(kvs, dedup.KV{K: k[:], V: bundleIdx*256 + uint64(len(kvs))})
+	}
+	return kvs, nil
 }

--- a/personalities/sctfe/serialize.go
+++ b/personalities/sctfe/serialize.go
@@ -176,6 +176,11 @@ func NewCpSigner(signer crypto.Signer, origin string, logID [32]byte, timeSource
 	return ctSigner
 }
 
+// DedupFromBundle converts a bundle into an array of {leafID, idx}.
+//
+// The index of a leaf is computed from its position in the log, instead of parsing
+// the SCT.
+// Greatly inspired by https://github.com/FiloSottile/sunlight/blob/main/tile.go and
 func DedupFromBundle(bundle []byte, bundleIdx uint64) ([]dedup.KV, error) {
 	kvs := []dedup.KV{}
 	s := cryptobyte.String(bundle)
@@ -191,7 +196,6 @@ func DedupFromBundle(bundle []byte, bundleIdx uint64) ([]dedup.KV, error) {
 		switch entryType {
 		case 0: // x509_entry
 			if !s.ReadUint24LengthPrefixed((*cryptobyte.String)(&crt)) ||
-				// TODO(phboneff): remove below?
 				!s.ReadUint16LengthPrefixed(&extensions) ||
 				!s.ReadUint16LengthPrefixed(&fingerprints) {
 				return nil, fmt.Errorf("invalid data tile x509_entry")
@@ -203,7 +207,6 @@ func DedupFromBundle(bundle []byte, bundleIdx uint64) ([]dedup.KV, error) {
 				!s.ReadUint24LengthPrefixed(&defangedCrt) ||
 				!s.ReadUint16LengthPrefixed(&extensions) ||
 				!s.ReadUint24LengthPrefixed((*cryptobyte.String)(&crt)) ||
-				// TODO(phboneff): remove below?
 				!s.ReadUint16LengthPrefixed(&fingerprints) {
 				return nil, fmt.Errorf("invalid data tile precert_entry")
 			}

--- a/personalities/sctfe/serialize.go
+++ b/personalities/sctfe/serialize.go
@@ -179,7 +179,7 @@ func NewCpSigner(signer crypto.Signer, origin string, logID [32]byte, timeSource
 // DedupFromBundle converts a bundle into an array of {leafID, idx}.
 //
 // The index of a leaf is computed from its position in the log, instead of parsing SCTs.
-// Greatly inspired by https://github.com/FiloSottile/sunlight/blob/main/tile.go and
+// Greatly inspired by https://github.com/FiloSottile/sunlight/blob/main/tile.go
 func DedupFromBundle(bundle []byte, bundleIdx uint64) ([]dedup.KV, error) {
 	kvs := []dedup.KV{}
 	s := cryptobyte.String(bundle)

--- a/personalities/sctfe/storage.go
+++ b/personalities/sctfe/storage.go
@@ -140,7 +140,7 @@ func (cts CTStorage) AddCertIndex(ctx context.Context, c *x509.Certificate, idx 
 	return nil
 }
 
-// GetCertIndex fetches the index of a give certificate from the deduplication storage.
+// GetCertIndex fetches the index of a given certificate from the deduplication storage.
 func (cts CTStorage) GetCertIndex(ctx context.Context, c *x509.Certificate) (uint64, bool, error) {
 	key := sha256.Sum256(c.Raw)
 	idx, ok, err := cts.dedupStorage.Get(ctx, key[:])

--- a/personalities/sctfe/storage.go
+++ b/personalities/sctfe/storage.go
@@ -134,7 +134,7 @@ func cachedStoreIssuers(s IssuerStorage) func(context.Context, []KV) error {
 // AddCertIndex stores <cert_hash, index> in the deduplication storage.
 func (cts CTStorage) AddCertIndex(ctx context.Context, c *x509.Certificate, idx uint64) error {
 	key := sha256.Sum256(c.Raw)
-	if err := cts.dedupStorage.Add([]dedup.KV{{K: key[:], V: idx}}); err != nil {
+	if err := cts.dedupStorage.Add(ctx, []dedup.KV{{K: key[:], V: idx}}); err != nil {
 		return fmt.Errorf("error storing index %d of %q: %v", idx, hex.EncodeToString(key[:]), err)
 	}
 	return nil
@@ -143,7 +143,7 @@ func (cts CTStorage) AddCertIndex(ctx context.Context, c *x509.Certificate, idx 
 // GetCertIndex fetches the index of a give certificate from the deduplication storage.
 func (cts CTStorage) GetCertIndex(ctx context.Context, c *x509.Certificate) (uint64, bool, error) {
 	key := sha256.Sum256(c.Raw)
-	idx, ok, err := cts.dedupStorage.Get(key[:])
+	idx, ok, err := cts.dedupStorage.Get(ctx, key[:])
 	if err != nil {
 		return 0, false, fmt.Errorf("error fetching index of %q: %v", hex.EncodeToString(key[:]), err)
 	}

--- a/personalities/sctfe/storage.go
+++ b/personalities/sctfe/storage.go
@@ -134,7 +134,7 @@ func cachedStoreIssuers(s IssuerStorage) func(context.Context, []KV) error {
 // AddCertIndex stores <cert_hash, index> in the deduplication storage.
 func (cts CTStorage) AddCertIndex(ctx context.Context, c *x509.Certificate, idx uint64) error {
 	key := sha256.Sum256(c.Raw)
-	if err := cts.dedupStorage.Add(ctx, []dedup.KV{{K: key[:], V: idx}}); err != nil {
+	if err := cts.dedupStorage.Add(ctx, []dedup.LeafIdx{{LeafID: key[:], Idx: idx}}); err != nil {
 		return fmt.Errorf("error storing index %d of %q: %v", idx, hex.EncodeToString(key[:]), err)
 	}
 	return nil

--- a/personalities/sctfe/storage.go
+++ b/personalities/sctfe/storage.go
@@ -41,6 +41,10 @@ type Storage interface {
 	Add(context.Context, *ctonly.Entry) tessera.IndexFuture
 	// AddIssuerChain stores every the chain certificate in a content-addressable store under their sha256 hash.
 	AddIssuerChain(context.Context, []*x509.Certificate) error
+	// AddCertIndex stores the index of certificate in a content-addressable store.
+	AddCertIndex(context.Context, *x509.Certificate, uint64) error
+	// GetCertIndex gets the index of certificate from a content-addressable store.
+	GetCertIndex(context.Context, *x509.Certificate) (uint64, bool, error)
 }
 
 type KV struct {
@@ -61,10 +65,11 @@ type CTStorage struct {
 }
 
 // NewCTStorage instantiates a CTStorage object.
-func NewCTSTorage(logStorage tessera.Storage, issuerStorage IssuerStorage) (*CTStorage, error) {
+func NewCTSTorage(logStorage tessera.Storage, issuerStorage IssuerStorage, dedupStorage dedup.DedupStorage) (*CTStorage, error) {
 	ctStorage := &CTStorage{
 		storeData:    tessera.NewCertificateTransparencySequencedWriter(logStorage),
 		storeIssuers: cachedStoreIssuers(issuerStorage),
+		dedupStorage: dedupStorage,
 	}
 	return ctStorage, nil
 }

--- a/personalities/sctfe/storage.go
+++ b/personalities/sctfe/storage.go
@@ -41,9 +41,9 @@ type Storage interface {
 	Add(context.Context, *ctonly.Entry) tessera.IndexFuture
 	// AddIssuerChain stores every the chain certificate in a content-addressable store under their sha256 hash.
 	AddIssuerChain(context.Context, []*x509.Certificate) error
-	// AddCertIndex stores the index of certificate in a content-addressable store.
+	// AddCertIndex stores the index of certificate in a log under its hash.
 	AddCertIndex(context.Context, *x509.Certificate, uint64) error
-	// GetCertIndex gets the index of certificate from a content-addressable store.
+	// GetCertIndex gets the index of certificate in a log from its hash.
 	GetCertIndex(context.Context, *x509.Certificate) (uint64, bool, error)
 }
 

--- a/personalities/sctfe/storage.go
+++ b/personalities/sctfe/storage.go
@@ -61,11 +61,11 @@ type IssuerStorage interface {
 type CTStorage struct {
 	storeData    func(context.Context, *ctonly.Entry) tessera.IndexFuture
 	storeIssuers func(context.Context, []KV) error
-	dedupStorage dedup.DedupStorage
+	dedupStorage dedup.BEDedupStorage
 }
 
 // NewCTStorage instantiates a CTStorage object.
-func NewCTSTorage(logStorage tessera.Storage, issuerStorage IssuerStorage, dedupStorage dedup.DedupStorage) (*CTStorage, error) {
+func NewCTSTorage(logStorage tessera.Storage, issuerStorage IssuerStorage, dedupStorage dedup.BEDedupStorage) (*CTStorage, error) {
 	ctStorage := &CTStorage{
 		storeData:    tessera.NewCertificateTransparencySequencedWriter(logStorage),
 		storeIssuers: cachedStoreIssuers(issuerStorage),

--- a/personalities/sctfe/storage.go
+++ b/personalities/sctfe/storage.go
@@ -52,6 +52,12 @@ type IssuerStorage interface {
 	AddIssuersIfNotExist(ctx context.Context, kv []KV) error
 }
 
+// LI holds a LeafID and an Idx for deduplication
+type LI struct {
+	L []byte
+	I uint64
+}
+
 // CTStorage implements Storage.
 type CTStorage struct {
 	storeData    func(context.Context, *ctonly.Entry) tessera.IndexFuture

--- a/personalities/sctfe/storage/bbolt/dedup.go
+++ b/personalities/sctfe/storage/bbolt/dedup.go
@@ -166,9 +166,7 @@ func (s *Storage) LogSize() (uint64, error) {
 
 // itob returns an 8-byte big endian representation of idx.
 func itob(idx uint64) []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, uint64(idx))
-	return b
+	return binary.BigEndian.AppendUint64(nil, idx)
 }
 
 // btoi converts a byte array to a uint64

--- a/personalities/sctfe/storage/bbolt/dedup.go
+++ b/personalities/sctfe/storage/bbolt/dedup.go
@@ -107,8 +107,8 @@ func (s *Storage) Add(_ context.Context, kvs []dedup.KV) error {
 			if err := db.Put(kv.K, itob(kv.V)); err != nil {
 				return err
 			}
-			// sizeB is indexes from 1 since it's a size, li.I from 0.
-			// Therefore, if they're equal, li is a new entry.
+			// sizeB is indexes from 1 since it's a size, kv.K from 0.
+			// Therefore, if they're equal, kv is a new entry.
 			if size == kv.V {
 				klog.V(3).Infof("Add(): updating deduped size to %d", size+1)
 				if err := sb.Put([]byte("size"), itob(size+1)); err != nil {

--- a/personalities/sctfe/storage/bbolt/dedup.go
+++ b/personalities/sctfe/storage/bbolt/dedup.go
@@ -116,8 +116,8 @@ func (s *Storage) Add(_ context.Context, lidxs []dedup.LeafIdx) error {
 			} else if err := db.Put(lidx.LeafID, itob(lidx.Idx)); err != nil {
 				return err
 			}
-			// size is a length, kv.V an index, so if they're equal,
-			// kv is a new entry.
+			// size is a length, lidx.I an index, so if they're equal,
+			// lidx is a new entry.
 			if size == lidx.Idx {
 				klog.V(3).Infof("Add(): updating deduped size to %d", size+1)
 				if err := sb.Put([]byte("size"), itob(size+1)); err != nil {

--- a/personalities/sctfe/storage/bbolt/dedup.go
+++ b/personalities/sctfe/storage/bbolt/dedup.go
@@ -18,6 +18,7 @@
 package bbolt
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 
@@ -80,7 +81,7 @@ func NewStorage(path string) (*Storage, error) {
 }
 
 // TODO(phboneff): Make sure that we don't override existing values
-func (s *Storage) Add(kvs []dedup.KV) error {
+func (s *Storage) Add(_ context.Context, kvs []dedup.KV) error {
 	for _, kv := range kvs {
 		err := s.db.Update(func(tx *bolt.Tx) error {
 			db := tx.Bucket([]byte(dedupBucket))
@@ -111,7 +112,7 @@ func (s *Storage) Add(kvs []dedup.KV) error {
 	return nil
 }
 
-func (s *Storage) Get(leafID []byte) (uint64, bool, error) {
+func (s *Storage) Get(_ context.Context, leafID []byte) (uint64, bool, error) {
 	var idx []byte
 	_ = s.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(dedupBucket))

--- a/personalities/sctfe/storage/bbolt/dedup.go
+++ b/personalities/sctfe/storage/bbolt/dedup.go
@@ -1,0 +1,158 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bbolt implements SCTFE storage systems for deduplication.
+//
+// The interfaces are defined in sctfe/storage.go
+package bbolt
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/transparency-dev/trillian-tessera/personalities/sctfe"
+	bolt "go.etcd.io/bbolt"
+	"k8s.io/klog/v2"
+)
+
+var (
+	dedupBucket = "leafIdx"
+	sizeBucket  = "logSize"
+)
+
+type Storage struct {
+	db *bolt.DB
+}
+
+func NewStorage(path string) (*Storage, error) {
+	db, err := bolt.Open(path, 0600, nil)
+	if err != nil {
+		return nil, fmt.Errorf("bolt.Open(): %v", err)
+	}
+	fmt.Println("Created a DB")
+	s := &Storage{db: db}
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		dedupB := tx.Bucket([]byte(dedupBucket))
+		sizeB := tx.Bucket([]byte(sizeBucket))
+		if dedupB == nil && sizeB == nil {
+			klog.V(2).Infof("no pre-existing buckets, will create %q and %q.", dedupBucket, sizeBucket)
+			_, err := tx.CreateBucket([]byte(dedupBucket))
+			if err != nil {
+				return fmt.Errorf("create %q bucket: %v", dedupBucket, err)
+			}
+			sb, err := tx.CreateBucket([]byte(sizeBucket))
+			if err != nil {
+				return fmt.Errorf("create %q bucket: %v", sizeBucket, err)
+			}
+			klog.V(2).Infof("initializing %q with size 0.", sizeBucket)
+			err = sb.Put([]byte("size"), itob(0))
+			if err != nil {
+				return fmt.Errorf("error reading logsize: %v", err)
+			}
+		} else if dedupB == nil && sizeB != nil {
+			return fmt.Errorf("inconsistent deduplication storage state %q is nil but %q it not nil", dedupBucket, sizeBucket)
+		} else if dedupB != nil && sizeB == nil {
+			return fmt.Errorf("inconsistent deduplication storage state, %q is not nil but %q is nil", dedupBucket, sizeBucket)
+		} else {
+			klog.V(2).Infof("found pre-existing %q and %q buckets.", dedupBucket, sizeBucket)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error initializing buckets: %v", err)
+	}
+
+	return s, nil
+}
+
+func (s *Storage) Add(lis []sctfe.LI) error {
+	for _, li := range lis {
+		err := s.db.Update(func(tx *bolt.Tx) error {
+			db := tx.Bucket([]byte(dedupBucket))
+			sb := tx.Bucket([]byte(sizeBucket))
+			sizeB := sb.Get([]byte("size"))
+			if sizeB == nil {
+				return fmt.Errorf("can't find log size in bucket %q", sizeBucket)
+			}
+			size := btoi(sizeB)
+
+			if err := db.Put(li.L, itob(li.I)); err != nil {
+				return err
+			}
+			// sizeB is indexes from 1 since it's a size, li.I from 0.
+			// Therefore, if they're equal, li is a new entry.
+			if size == li.I {
+				if err := sb.Put([]byte("size"), itob(size+1)); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("b.Put(): error writting leaf index %d: err", li.I)
+		}
+	}
+	return nil
+}
+
+func (s *Storage) Get(leafID []byte) (uint64, bool, error) {
+	var idx []byte
+	_ = s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(dedupBucket))
+		v := b.Get(leafID)
+		if v != nil {
+			idx = make([]byte, 8)
+			copy(idx, v)
+		}
+		return nil
+	})
+	if idx == nil {
+		return 0, false, nil
+	}
+	return btoi(idx), true, nil
+}
+
+func (s *Storage) LogSize() (uint64, error) {
+	var size []byte
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(sizeBucket))
+		v := b.Get([]byte("size"))
+		if v != nil {
+			size = make([]byte, 8)
+			copy(size, v)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("error reading from %q: %v", sizeBucket, err)
+	}
+	if size == nil {
+		return 0, fmt.Errorf("can't find log size in bucket %q", sizeBucket)
+	}
+	return btoi(size), nil
+}
+
+// itob returns an 8-byte big endian representation of idx.
+func itob(idx uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, uint64(idx))
+	return b
+}
+
+// btoi converts a byte array to a uint64
+func btoi(b []byte) uint64 {
+	return binary.BigEndian.Uint64(b)
+}

--- a/personalities/sctfe/storage/bbolt/dedup.go
+++ b/personalities/sctfe/storage/bbolt/dedup.go
@@ -18,6 +18,7 @@ package bbolt
 import (
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/transparency-dev/trillian-tessera/personalities/sctfe/modules/dedup"
@@ -102,7 +103,7 @@ func (s *Storage) Add(_ context.Context, kvs []dedup.KV) error {
 			size := btoi(sizeB)
 
 			if old := db.Get(kv.K); old != nil {
-				klog.V(3).Infof("Add(): bucket %q already contains an entry for %q, not updating", dedupBucket, string(kv.K))
+				klog.V(3).Infof("Add(): bucket %q already contains an entry for %q, not updating", dedupBucket, hex.EncodeToString(kv.K))
 			}
 			if err := db.Put(kv.K, itob(kv.V)); err != nil {
 				return err

--- a/personalities/sctfe/storage/bbolt/dedup.go
+++ b/personalities/sctfe/storage/bbolt/dedup.go
@@ -108,8 +108,8 @@ func (s *Storage) Add(_ context.Context, kvs []dedup.KV) error {
 			if err := db.Put(kv.K, itob(kv.V)); err != nil {
 				return err
 			}
-			// sizeB is indexes from 1 since it's a size, kv.K from 0.
-			// Therefore, if they're equal, kv is a new entry.
+			// size is a length, kv.V an index, so if they're equal,
+			// kv is a new entry.
 			if size == kv.V {
 				klog.V(3).Infof("Add(): updating deduped size to %d", size+1)
 				if err := sb.Put([]byte("size"), itob(size+1)); err != nil {
@@ -119,7 +119,7 @@ func (s *Storage) Add(_ context.Context, kvs []dedup.KV) error {
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("b.Put(): error writting leaf index %d: err", kv.V)
+			return fmt.Errorf("b.Put(): error writing leaf index %d: err", kv.V)
 		}
 	}
 	return nil

--- a/personalities/sctfe/storage/bbolt/dedup.go
+++ b/personalities/sctfe/storage/bbolt/dedup.go
@@ -135,6 +135,7 @@ func (s *Storage) Add(_ context.Context, lidxs []dedup.LeafIdx) error {
 
 // Get reads entries from the dedup bucket.
 //
+// If the requested entry is missing from the bucket, returns false ("comma ok" idiom).
 // The context is here for consistency with interfaces, but isn't used by BBolt.
 func (s *Storage) Get(_ context.Context, leafID []byte) (uint64, bool, error) {
 	var idx []byte

--- a/personalities/sctfe/storage/bbolt/dedup.go
+++ b/personalities/sctfe/storage/bbolt/dedup.go
@@ -13,6 +13,16 @@
 // limitations under the License.
 
 // Package bbolt implements modules/dedup using BBolt.
+//
+// It contains two buckets:
+//   - The dedup bucket stores <leafID, idx> pairs. Entries can either be added after sequencing,
+//     by the server that received the request, or later when synchronising the dedup storage with
+//     the log state.
+//   - The size bucket has a single entry: <"size", X>, where X is the largest contiguous index
+//     from 0 that has been inserted in the dedup bucket. This allows to know what is the next
+//     <leafID, idx> to add to the bucket in order to have a full represation of the log.
+//
+// Calls to Add<leafID, idx> will update idx to a smaller value, if possible.
 package bbolt
 
 import (
@@ -40,7 +50,7 @@ type Storage struct {
 //
 // The dedup bucket stores <leafID, idx> pairs.
 // The size bucket has a single entry: <"size", X>, where X is the largest contiguous index from 0
-// that has been inserted in the deudp bucket.
+// that has been inserted in the dedup bucket.
 //
 // If a database already exists at the provided path, NewStorage will load it.
 func NewStorage(path string) (*Storage, error) {

--- a/personalities/sctfe/storage/bbolt/dedup.go
+++ b/personalities/sctfe/storage/bbolt/dedup.go
@@ -80,7 +80,6 @@ func NewStorage(path string) (*Storage, error) {
 	return s, nil
 }
 
-// TODO(phboneff): Make sure that we don't override existing values
 func (s *Storage) Add(_ context.Context, kvs []dedup.KV) error {
 	for _, kv := range kvs {
 		err := s.db.Update(func(tx *bolt.Tx) error {
@@ -92,6 +91,9 @@ func (s *Storage) Add(_ context.Context, kvs []dedup.KV) error {
 			}
 			size := btoi(sizeB)
 
+			if old := db.Get(kv.K); old != nil {
+				klog.V(3).Infof("Add(): bucket %q already contains an entry for %q, not updating", dedupBucket, string(kv.K))
+			}
 			if err := db.Put(kv.K, itob(kv.V)); err != nil {
 				return err
 			}

--- a/personalities/sctfe/storage/gcp/client.go
+++ b/personalities/sctfe/storage/gcp/client.go
@@ -1,0 +1,44 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(phboneff): create a doc file with good docstring
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	gcs "cloud.google.com/go/storage"
+)
+
+// GetFetcher returns a GCS read function for objects in a given bucket
+func GetFetcher(ctx context.Context, bucket string) (func(ctx context.Context, path string) ([]byte, error), error) {
+	c, err := gcs.NewClient(ctx, gcs.WithJSONReads())
+	if err != nil {
+		return func(context.Context, string) ([]byte, error) { return nil, nil }, nil
+	}
+	return func(ctx context.Context, path string) ([]byte, error) {
+		r, err := c.Bucket(bucket).Object(path).NewReader(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("getObject: failed to create reader for object %q in bucket %q: %w", path, bucket, err)
+		}
+
+		d, err := io.ReadAll(r)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %q: %v", path, err)
+		}
+		return d, r.Close()
+	}, nil
+}

--- a/personalities/sctfe/storage/gcp/client.go
+++ b/personalities/sctfe/storage/gcp/client.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(phboneff): create a doc file with good docstring
 package gcp
 
 import (
@@ -23,7 +22,7 @@ import (
 	gcs "cloud.google.com/go/storage"
 )
 
-// GetFetcher returns a GCS read function for objects in a given bucket
+// GetFetcher returns a GCS read function for objects in a given bucket.
 func GetFetcher(ctx context.Context, bucket string) (func(ctx context.Context, path string) ([]byte, error), error) {
 	c, err := gcs.NewClient(ctx, gcs.WithJSONReads())
 	if err != nil {

--- a/personalities/sctfe/storage/gcp/doc.go
+++ b/personalities/sctfe/storage/gcp/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package gcp allows the SCTFE to interact with GCS to:
+  - store issuers
+  - read log entries
+*/
+package gcp

--- a/personalities/sctfe/storage/gcp/issuers.go
+++ b/personalities/sctfe/storage/gcp/issuers.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package gcp implements SCTFE storage systems for issuers.
-//
-// The interfaces are defined in sctfe/storage.go
 package gcp
 
 import (


### PR DESCRIPTION
Towards #88 

This PR introduces: 
 - a standard personality deduplication module with interfaces that allow for global and local implementation. Eventually, the module will be moved out of the SCTFE codebase such that it can be used by other personalities, but let's start by having it here.
 - a local deduplication implementation using Bbolt