### PR TITLE
Enable WithCTLayout

### DIFF
--- a/personalities/sctfe/ct_server_gcp/main.go
+++ b/personalities/sctfe/ct_server_gcp/main.go
@@ -274,7 +274,7 @@ func newGCPStorage(ctx context.Context, vCfg *sctfe.ValidatedLogConfig, signer n
 		Bucket:    cfg.Bucket,
 		Spanner:   cfg.SpannerDbPath,
 	}
-	tesseraStorage, err := gcpTessera.New(ctx, gcpCfg, tessera.WithCheckpointSignerVerifier(signer, nil))
+	tesseraStorage, err := gcpTessera.New(ctx, gcpCfg, tessera.WithCheckpointSignerVerifier(signer, nil), tessera.WithCTLayout())
 	if err != nil {
 		return nil, fmt.Errorf("Failed to initialize GCP Tessera storage: %v", err)
 	}


### PR DESCRIPTION
Will store entries under `tile/data` instead of `tile/entries`, see #171.

Toward #88 
