### PR TITLE
POSIX: storage doesn't take readCP func

### DIFF
--- a/cmd/example-posix/main.go
+++ b/cmd/example-posix/main.go
@@ -118,18 +118,7 @@ func main() {
 		klog.Exitf("Failed to instantiate Verifier: %q", err)
 	}
 
-	readCP := func() (uint64, []byte, error) {
-		cpRaw, err := posix.ReadCheckpoint(*storageDir)
-		if err != nil {
-			klog.Exitf("Failed to read log checkpoint: %q", err)
-		}
-		cp, _, _, err := fmtlog.ParseCheckpoint(cpRaw, origin, v)
-		if err != nil {
-			return 0, []byte{}, fmt.Errorf("Failed to parse Checkpoint: %q", err)
-		}
-		return cp.Size, cp.Hash, nil
-	}
-	storage := posix.New(ctx, *storageDir, readCP, tessera.WithCheckpointSignerVerifier(s, v), tessera.WithBatching(256, time.Second))
+	storage := posix.New(ctx, *storageDir, tessera.WithCheckpointSignerVerifier(s, v), tessera.WithBatching(256, time.Second))
 
 	http.HandleFunc("POST /add", func(w http.ResponseWriter, r *http.Request) {
 		b, err := io.ReadAll(r.Body)

--- a/cmd/posix-oneshot/main.go
+++ b/cmd/posix-oneshot/main.go
@@ -83,19 +83,7 @@ func main() {
 
 	filesToAdd := readEntriesOrDie()
 
-	// TODO(mhutchinson): This function should be implemented inside Tessera (it has the verifier now)
-	readCP := func() (uint64, []byte, error) {
-		cpRaw, err := posix.ReadCheckpoint(*storageDir)
-		if err != nil {
-			klog.Exitf("Failed to read log checkpoint: %q", err)
-		}
-		cp, _, _, err := fmtlog.ParseCheckpoint(cpRaw, origin, v)
-		if err != nil {
-			return 0, []byte{}, fmt.Errorf("Failed to parse Checkpoint: %q", err)
-		}
-		return cp.Size, cp.Hash, nil
-	}
-	st := posix.New(ctx, *storageDir, readCP, tessera.WithCheckpointSignerVerifier(s, v), tessera.WithBatching(uint(len(filesToAdd)), time.Second))
+	st := posix.New(ctx, *storageDir, tessera.WithCheckpointSignerVerifier(s, v), tessera.WithBatching(uint(len(filesToAdd)), time.Second))
 
 	// sequence entries
 


### PR DESCRIPTION
The storage layer knows everything required to do this, so this change implements the function internally.