### PR TITLE
Documentation for POSIX and one-shot command

### DIFF
--- a/cmd/posix-oneshot/main.go
+++ b/cmd/posix-oneshot/main.go
@@ -72,7 +72,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Evaluate the glob provided by the flag in to determine the files containing leaves
+	// Evaluate the glob provided by the --entries flag to determine the files containing leaves
 	filesToAdd := readEntriesOrDie()
 
 	// Construct a new Tessera POSIX log storage, anchored at the correct directory, and initialising it if requested.

--- a/cmd/posix-oneshot/main.go
+++ b/cmd/posix-oneshot/main.go
@@ -42,6 +42,15 @@ var (
 	privKeyFile = flag.String("private_key", "", "Location of private key file. If unset, uses the contents of the LOG_PRIVATE_KEY environment variable.")
 )
 
+// entryInfo binds the actual bytes to be added as a leaf with a
+// user-recognisable name for the source of those bytes.
+// The name is only used below in order to inform the user of the
+// sequence numbers assigned to the data from the provided input files.
+type entryInfo struct {
+	name string
+	f    tessera.IndexFuture
+}
+
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -51,6 +60,7 @@ func main() {
 	v := getVerifierOrDie()
 	s := getSignerOrDie()
 
+	// Handle the case where no entries are to be added.
 	if len(*entries) == 0 {
 		if *initialise {
 			_, err := posix.New(ctx, *storageDir, *initialise, tessera.WithCheckpointSignerVerifier(s, v))
@@ -62,22 +72,20 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Evaluate the glob provided by the flag in to determine the files containing leaves
 	filesToAdd := readEntriesOrDie()
+
+	// Construct a new Tessera POSIX log storage, anchored at the correct directory, and initialising it if requested.
+	// The options provide the checkpoint signer & verifier, and batch options.
+	// In this case, we want to create a single batch containing all of the leaves being added in order to
+	// add all of these leaves without creating any intermediate checkpoints.
 	st, err := posix.New(ctx, *storageDir, *initialise, tessera.WithCheckpointSignerVerifier(s, v), tessera.WithBatching(uint(len(filesToAdd)), time.Second))
 	if err != nil {
 		klog.Exitf("Failed to construct storage: %v", err)
 	}
 
-	// sequence entries
-
-	// entryInfo binds the actual bytes to be added as a leaf with a
-	// user-recognisable name for the source of those bytes.
-	// The name is only used below in order to inform the user of the
-	// sequence numbers assigned to the data from the provided input files.
-	type entryInfo struct {
-		name string
-		f    tessera.IndexFuture
-	}
+	// Add each of the leaves in order, and store the futures in a slice
+	// that we will check once all leaves are sent to storage.
 	indexFutures := make([]entryInfo, 0, len(filesToAdd))
 	for _, fp := range filesToAdd {
 		b, err := os.ReadFile(fp)
@@ -85,11 +93,11 @@ func main() {
 			klog.Exitf("Failed to read entry file %q: %q", fp, err)
 		}
 
-		// ask storage to sequence and we'll store the future for later
 		f := st.Add(ctx, tessera.NewEntry(b))
 		indexFutures = append(indexFutures, entryInfo{name: fp, f: f})
 	}
 
+	// Check each of the futures to ensure that the leaves are sequenced.
 	for _, entry := range indexFutures {
 		seq, err := entry.f()
 		if err != nil {
@@ -97,6 +105,8 @@ func main() {
 		}
 		klog.Infof("%d: %v", seq, entry.name)
 	}
+
+	// All futures have been resolved, which means the log is built and we can allow the process to terminate. Goodbye!
 }
 
 // Read log public key from file or environment variable

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -129,9 +129,12 @@ func (s *Storage) unlockCP() error {
 }
 
 // Add takes an entry and queues it for inclusion in the log.
-// Upon storing the entry in a queue to be sequenced, it returns a future that will
+// Upon placing the entry in an in-memory queue to be sequenced, it returns a future that will
 // evaluate to either the sequence number assigned to this entry, or an error.
-// This future is made available when the entry is queued, but not sequenced.
+// This future is made available when the entry is queued. Any further calls to Add after
+// this returns will guarantee that the later entry appears later in the log than any
+// earlier entries. Concurrent calls to Add are supported, but the order they are queued and
+// thus included in the log is non-deterministic.
 //
 // If the future resolves to a non-error state then it means that the entry is both
 // sequenced and integrated into the log. This means that a checkpoint will be available

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -128,8 +128,19 @@ func (s *Storage) unlockCP() error {
 	return nil
 }
 
-// Add commits to sequence numbers for an entry
-// Returns the sequence number assigned to the first entry in the batch, or an error.
+// Add takes an entry and queues it for inclusion in the log.
+// Upon storing the entry in a queue to be sequenced, it returns a future that will
+// evaluate to either the sequence number assigned to this entry, or an error.
+// This future is made available when the entry is queued, but not sequenced.
+//
+// If the future resolves to a non-error state then it means that the entry is both
+// sequenced and integrated into the log. This means that a checkpoint will be available
+// that commits to this entry.
+//
+// It is recommended that the caller keeps the process running until all futures returned
+// by this method have successfully evaluated. Terminating earlier than this will likely
+// mean that some of the entries added are not committed to by a checkpoint, and thus are
+// not considered to be in the log.
 func (s *Storage) Add(ctx context.Context, e *tessera.Entry) tessera.IndexFuture {
 	return s.queue.Add(ctx, e)
 }
@@ -229,7 +240,7 @@ func (s *Storage) sequenceBatch(ctx context.Context, entries []*tessera.Entry) e
 		}
 	}
 
-	// For simplicitly, well in-line the integration of these new entries into the Merkle structure too.
+	// For simplicitly, in-line the integration of these new entries into the Merkle structure too.
 	if err := s.doIntegrate(ctx, seq, seqEntries); err != nil {
 		klog.Errorf("Integrate failed: %v", err)
 		return err


### PR DESCRIPTION
This documentation makes it clear when integration is performed in this implementation, and gives a clear motivation in the one-shot tooling for iterating over all of the futures to resolve them.
