### PR TITLE
POSIX README nits

### DIFF
--- a/cmd/examples/posix-oneshot/README.md
+++ b/cmd/examples/posix-oneshot/README.md
@@ -16,10 +16,10 @@ export LOG_DIR=/tmp/mylog
 go run ./cmd/examples/posix-oneshot --storage_dir=${LOG_DIR} --initialise
 
 # Create files containing new leaves to add
-mkdir /tmp/logleaves
-echo "one" > /tmp/logleaves/1
-echo "two" > /tmp/logleaves/2
-echo "three" > /tmp/logleaves/3
+mkdir /tmp/stuff
+echo "foo" > /tmp/stuff/foo
+echo "bar" > /tmp/stuff/bar
+echo "baz" > /tmp/stuff/baz
 
 # Integrate all of these leaves into the tree
 go run ./cmd/examples/posix-oneshot --storage_dir=${LOG_DIR} --entries="/tmp/logleaves/*"


### PR DESCRIPTION
A couple of suggestions from independent review; mostly make it clear that ordering of files evaluated by the glob aren't necessarily deterministic, and rename the directory for the leaves to add to make it clearer that it isn't part of the log.
