### PR TITLE
HTTP handlers: skip closing the body

### DIFF
--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -79,7 +79,6 @@ func main() {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		defer r.Body.Close()
 
 		id := sha256.Sum256(b)
 		idx, err := storage.Add(r.Context(), tessera.NewEntry(b, tessera.WithIdentity(id[:])))()

--- a/cmd/conformance/mysql/main.go
+++ b/cmd/conformance/mysql/main.go
@@ -87,11 +87,6 @@ func main() {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		defer func() {
-			if err := r.Body.Close(); err != nil {
-				klog.Warningf("/add: %v", err)
-			}
-		}()
 		idx, err := storage.Add(r.Context(), tessera.NewEntry(b))()
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/cmd/conformance/posix/main.go
+++ b/cmd/conformance/posix/main.go
@@ -98,11 +98,6 @@ func main() {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		defer func() {
-			if err := r.Body.Close(); err != nil {
-				klog.Warningf("/add: %v", err)
-			}
-		}()
 		idx, err := storage.Add(r.Context(), tessera.NewEntry(b))()
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
From Request.Body docs: The Server will close the request body. The ServeHTTP Handler does not need to.
