### PR TITLE
Support `file://` scheme in integration test

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Start Docker services (tessera-conformance-posix)
         run: docker compose -f ./cmd/conformance/posix/docker/compose.yaml up --build --detach
       - name: Run integration test 
-        run: go test -v -race ./integration/... --run_integration_test=true --log_url="http://localhost:2025" --write_log_url="http://localhost:2025" --log_public_key="example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
+        run: go test -v -race ./integration/... --run_integration_test=true --log_url="file:///tmp/tessera-posix-log" --write_log_url="http://localhost:2025" --log_public_key="example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
       - name: Stop Docker services (tessera-conformance-posix)
         if: ${{ always() }}
         run: docker compose -f ./cmd/conformance/posix/docker/compose.yaml down

--- a/cmd/conformance/posix/docker/compose.yaml
+++ b/cmd/conformance/posix/docker/compose.yaml
@@ -18,9 +18,5 @@ services:
       "--v=2",
     ]
     volumes:
-      - tiles:/tmp/tessera-posix-log
+      - /tmp/tessera-posix-log:/tmp/tessera-posix-log
     restart: always
-
-volumes:
-  tiles:
-    name: "tiles"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -50,8 +50,8 @@ var (
 
 	noteVerifier note.Verifier
 
-	logBaseURL url.URL
-	logRead    client.Fetcher
+	logReadBaseURL *url.URL
+	logRead        client.Fetcher
 
 	hc = &http.Client{
 		Transport: &http.Transport{
@@ -77,18 +77,18 @@ func TestMain(m *testing.M) {
 		klog.Fatalf("Failed to create new verifier: %v", err)
 	}
 
-	logBaseURL, err := url.Parse(*logURL)
+	logReadBaseURL, err = url.Parse(*logURL)
 	if err != nil {
 		klog.Fatalf("failed to parse logURL: %v", err)
 	}
 
-	switch logBaseURL.Scheme {
+	switch logReadBaseURL.Scheme {
 	case "http", "https":
 		logRead = httpRead
 	case "file":
 		logRead = fileRead
 	default:
-		klog.Fatalf("unsupported url scheme: %s", logBaseURL.Scheme)
+		klog.Fatalf("unsupported url scheme: %s", logReadBaseURL.Scheme)
 	}
 
 	os.Exit(m.Run())
@@ -234,7 +234,7 @@ func httpRead(ctx context.Context, path string) ([]byte, error) {
 }
 
 func fileRead(_ context.Context, path string) ([]byte, error) {
-	return os.ReadFile(logBaseURL.JoinPath(path).Path)
+	return os.ReadFile(logReadBaseURL.JoinPath(path).Path)
 }
 
 type entryWriter struct {


### PR DESCRIPTION
#8 #22 

<s>The files created by Docker are always owned by `root`. The integration test cannot read the checkpoints, tiles and entry bundles.</s>