### PR TITLE
Add required `tg_dir` to Terragrunt format check

### DIFF
--- a/.github/workflows/terragrunt_test.yml
+++ b/.github/workflows/terragrunt_test.yml
@@ -18,4 +18,5 @@ jobs:
         with:
           tf_version: ${{ env.tf_version }}
           tg_version: ${{ env.tg_version }}
+          tg_dir: 'deployment'
           tg_command: 'hclfmt --terragrunt-check --terragrunt-diff'


### PR DESCRIPTION
`tg_dir` is a required GitHub Action input but it is missing at the moment.

<img width="841" alt="image" src="https://github.com/user-attachments/assets/bbef7de3-a854-4cc6-808d-54c20ac0e9af">

https://github.com/gruntwork-io/terragrunt-action?tab=readme-ov-file#inputs