### PR TITLE
[hammer] Allow distinct bearer tokens for read and write clients

### DIFF
--- a/hammer/client.go
+++ b/hammer/client.go
@@ -164,8 +164,8 @@ func (w httpLeafWriter) Write(ctx context.Context, newLeaf []byte) (uint64, erro
 	if err != nil {
 		return 0, fmt.Errorf("failed to create request: %v", err)
 	}
-	if *bearerToken != "" {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *bearerToken))
+	if *bearerTokenWrite != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *bearerTokenWrite))
 	}
 	resp, err := hc.Do(req.WithContext(ctx))
 	if err != nil {

--- a/hammer/hammer.go
+++ b/hammer/hammer.go
@@ -59,7 +59,8 @@ var (
 
 	showUI = flag.Bool("show_ui", true, "Set to false to disable the text-based UI")
 
-	bearerToken = flag.String("bearer_token", "", "The bearer token for auth. For GCP this is the result of `gcloud auth print-identity-token`")
+	bearerToken      = flag.String("bearer_token", "", "The bearer token for auth. For GCP this is the result of `gcloud auth print-access-token`")
+	bearerTokenWrite = flag.String("bearer_token_write", "", "The bearer token for auth to write. For GCP this is the result of `gcloud auth print-identity-token`. If unset will default to --bearer_token.")
 
 	hc = &http.Client{
 		Transport: &http.Transport{
@@ -74,6 +75,11 @@ var (
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
+
+	// If bearerTokenWrite is unset, default it to whatever bearerToken has (which may too be unset).
+	if *bearerTokenWrite == "" {
+		*bearerTokenWrite = *bearerToken
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
This PR extends the support within `hammer` by allowing distinct bearer tokens to be used for read and write requests.