### PR TITLE
Add support for h2c to GCP conformance and HTTP/2 to hammer

### DIFF
--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -29,6 +29,8 @@ import (
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/storage/gcp"
 	"golang.org/x/mod/sumdb/note"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"k8s.io/klog/v2"
 )
 
@@ -93,7 +95,13 @@ func main() {
 		_, _ = w.Write([]byte(fmt.Sprintf("%d", idx)))
 	})
 
-	if err := http.ListenAndServe(*listen, http.DefaultServeMux); err != nil {
+	h2s := &http2.Server{}
+	h1s := &http.Server{
+		Addr:    *listen,
+		Handler: h2c.NewHandler(http.DefaultServeMux, h2s),
+	}
+
+	if err := h1s.ListenAndServe(); err != nil {
 		klog.Exitf("ListenAndServe: %v", err)
 	}
 }

--- a/deployment/modules/gcp/cloudbuild/main.tf
+++ b/deployment/modules/gcp/cloudbuild/main.tf
@@ -122,7 +122,7 @@ resource "google_cloudbuild_trigger" "docker" {
       id   = "hammer"
       name = "golang"
       script = <<EOT
-      go run ./hammer --log_public_key=$(cat /workspace/verifier.pub) --log_url=https://storage.googleapis.com/trillian-tessera-ci-conformance-bucket/ --write_log_url="$(cat /workspace/conformance_url)" -v=1 --show_ui=false --bearer_token="$(cat /workspace/cb_access)" --bearer_token_write="$(cat /workspace/cb_identity)" --logtostderr --num_writers=2000 --max_write_ops=2000 --leaf_min_size=1024 --leaf_write_goal=50000 --force_http2
+      go run ./hammer --log_public_key=$(cat /workspace/verifier.pub) --log_url=https://storage.googleapis.com/trillian-tessera-ci-conformance-bucket/ --write_log_url="$(cat /workspace/conformance_url)" -v=1 --show_ui=false --bearer_token="$(cat /workspace/cb_access)" --bearer_token_write="$(cat /workspace/cb_identity)" --logtostderr --num_writers=1100 --max_write_ops=1500 --leaf_min_size=1024 --leaf_write_goal=50000 --force_http2
       EOT
       wait_for = ["terraform_outputs", "generate_verifier", "access"]
     }

--- a/deployment/modules/gcp/cloudbuild/main.tf
+++ b/deployment/modules/gcp/cloudbuild/main.tf
@@ -122,7 +122,7 @@ resource "google_cloudbuild_trigger" "docker" {
       id   = "hammer"
       name = "golang"
       script = <<EOT
-      go run ./hammer --log_public_key=$(cat /workspace/verifier.pub) --log_url=https://storage.googleapis.com/trillian-tessera-ci-conformance-bucket/ --write_log_url="$(cat /workspace/conformance_url)" -v=1 --show_ui=false --bearer_token="$(cat /workspace/cb_access)" --bearer_token_write="$(cat /workspace/cb_identity)" --logtostderr --num_writers=1100 --max_write_ops=1024 --leaf_min_size=1024 --leaf_write_goal=50000
+      go run ./hammer --log_public_key=$(cat /workspace/verifier.pub) --log_url=https://storage.googleapis.com/trillian-tessera-ci-conformance-bucket/ --write_log_url="$(cat /workspace/conformance_url)" -v=1 --show_ui=false --bearer_token="$(cat /workspace/cb_access)" --bearer_token_write="$(cat /workspace/cb_identity)" --logtostderr --num_writers=2000 --max_write_ops=2000 --leaf_min_size=1024 --leaf_write_goal=50000 --force_http2
       EOT
       wait_for = ["terraform_outputs", "generate_verifier", "access"]
     }

--- a/deployment/modules/gcp/conformance/main.tf
+++ b/deployment/modules/gcp/conformance/main.tf
@@ -99,7 +99,7 @@ resource "google_cloud_run_v2_service" "default" {
     timeout = "10s"
 
     scaling {
-      max_instance_count = 4
+      max_instance_count = 3
     }
 
     containers {
@@ -123,7 +123,7 @@ resource "google_cloud_run_v2_service" "default" {
       resources {
         limits = {
           cpu = "2"
-          memory = "512Mi"
+          memory = "1024Mi"
         }
       }
 

--- a/deployment/modules/gcp/conformance/main.tf
+++ b/deployment/modules/gcp/conformance/main.tf
@@ -116,6 +116,7 @@ resource "google_cloud_run_v2_service" "default" {
         "--origin=${var.log_origin}",
       ]
       ports {
+        name = "h2c"
         container_port = 8080
       }
 

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.29.0 // indirect
 	golang.org/x/crypto v0.27.0
-	golang.org/x/net v0.28.0 // indirect
+	golang.org/x/net v0.28.0
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.25.0 // indirect


### PR DESCRIPTION
This PR enables the use of HTTP2/Cleartext (h2c) in the GCP conformance server, and adds an flag to optionally _force_ HTTP/2 usage in the hammer.

HTTP/2 supports much better multiplexing of requests over a socket connection compared to HTTP/1.1, which in turn results in better performance and fewer errors when sending a large number of concurrent requests (e.g. when running the hammer against a conformance server).

CloudRun detects and supports h2c if implemented by the server its hosting, otherwise it will [downgrade incoming HTTP/2 requests to HTTP/1](https://cloud.google.com/run/docs/configuring/http2).