### PR TITLE
[GCP] Update `terra{grunt,form}` to reflect externally managed service accounts

### DIFF
--- a/deployment/live/gcp/cloudbuild/prod/terragrunt.hcl
+++ b/deployment/live/gcp/cloudbuild/prod/terragrunt.hcl
@@ -6,6 +6,7 @@ include "root" {
 inputs = merge(
   include.root.locals,
   {
+    service_account    = "cloudbuild-${var.env}-sa@trillian-tessera.iam.gserviceaccount.com"
     kms_key_version_id = get_env("TESSERA_KMS_KEY_VERSION", "projects/${include.root.locals.project_id}/locations/${include.root.locals.region}/keyRings/ci-conformance/cryptoKeys/log-signer/cryptoKeyVersions/1")
     log_origin         = "ci-conformance"
   }

--- a/deployment/live/gcp/cloudbuild/prod/terragrunt.hcl
+++ b/deployment/live/gcp/cloudbuild/prod/terragrunt.hcl
@@ -6,7 +6,8 @@ include "root" {
 inputs = merge(
   include.root.locals,
   {
-    service_account    = "cloudbuild-${var.env}-sa@trillian-tessera.iam.gserviceaccount.com"
+    # Service accounts are managed externally.
+    service_account    = "cloudbuild-${include.root.locals.env}-sa@trillian-tessera.iam.gserviceaccount.com"
     kms_key_version_id = get_env("TESSERA_KMS_KEY_VERSION", "projects/${include.root.locals.project_id}/locations/${include.root.locals.region}/keyRings/ci-conformance/cryptoKeys/log-signer/cryptoKeyVersions/1")
     log_origin         = "ci-conformance"
   }

--- a/deployment/live/gcp/conformance/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/terragrunt.hcl
@@ -11,9 +11,9 @@ locals {
   kms_key_version_id           = get_env("TESSERA_KMS_KEY_VERSION", "projects/${local.project_id}/locations/${local.location}/keyRings/${local.base_name}/cryptoKeys/log-signer/cryptoKeyVersions/1")
   log_origin                   = local.base_name
   # Service accounts are managed externally:
-  conformance_users          = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
-  bucket_readers             = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
-  cloudrun_service_account   = "cloudrun-${local.env}-sa@trillian-tessera.iam.gserviceaccount.com"
+  conformance_users        = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
+  bucket_readers           = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
+  cloudrun_service_account = "cloudrun-${local.env}-sa@trillian-tessera.iam.gserviceaccount.com"
 }
 
 remote_state {

--- a/deployment/live/gcp/conformance/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/terragrunt.hcl
@@ -11,9 +11,9 @@ locals {
   kms_key_version_id           = get_env("TESSERA_KMS_KEY_VERSION", "projects/${local.project_id}/locations/${local.location}/keyRings/${local.base_name}/cryptoKeys/log-signer/cryptoKeyVersions/1")
   log_origin                   = local.base_name
   # Service accounts are managed externally:
-  conformance_users            = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
-  bucket_readers               = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
-  log_writers                  = ["serviceAccount:cloudrun-${local.env}-sa@trillian-tessera.iam.gserviceaccount.com"]
+  conformance_users          = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
+  bucket_readers             = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
+  cloudrun_service_account   = "cloudrun-${local.env}-sa@trillian-tessera.iam.gserviceaccount.com"
 }
 
 remote_state {

--- a/deployment/live/gcp/conformance/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/terragrunt.hcl
@@ -10,8 +10,10 @@ locals {
   conformance_gcp_docker_image = "${local.location}-docker.pkg.dev/trillian-tessera/docker-${local.env}/conformance-gcp:latest"
   kms_key_version_id           = get_env("TESSERA_KMS_KEY_VERSION", "projects/${local.project_id}/locations/${local.location}/keyRings/${local.base_name}/cryptoKeys/log-signer/cryptoKeyVersions/1")
   log_origin                   = local.base_name
+  # Service accounts are managed externally:
   conformance_users            = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
   bucket_readers               = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
+  log_writers                  = ["serviceAccount:cloudrun-${local.env}-sa@trillian-tessera.iam.gserviceaccount.com"]
 }
 
 remote_state {

--- a/deployment/modules/gcp/cloudbuild/variables.tf
+++ b/deployment/modules/gcp/cloudbuild/variables.tf
@@ -23,4 +23,8 @@ variable "kms_key_version_id" {
   type        = string
 }
 
+variable "service_account" {
+  description = "Service account email to use for cloudbuild"
+}
+
 

--- a/deployment/modules/gcp/conformance/outputs.tf
+++ b/deployment/modules/gcp/conformance/outputs.tf
@@ -1,8 +1,3 @@
-output "run_service_account" {
-  description = "The CloudRun service account"
-  value       = google_service_account.cloudrun_service_account
-}
-
 output "conformance_url" {
   description = "The URL of the running conformance server"
   value       = google_cloud_run_v2_service.default.uri

--- a/deployment/modules/gcp/conformance/variables.tf
+++ b/deployment/modules/gcp/conformance/variables.tf
@@ -33,12 +33,17 @@ variable "kms_key_version_id" {
   type        = string
 }
 
+variable "cloudrun_service_account" {
+  description = "The service account email to use for the CloudRun instance"
+  type        = string
+}
+
 variable "conformance_users" {
   description = "The list of users allowed to invoke calls to the conformance instance."
-  type = list
+  type        = list(any)
 }
 
 variable "bucket_readers" {
   description = "The list of users allowed to read the conformance bucket contents"
-  type = list
+  type        = list(any)
 }

--- a/deployment/modules/gcp/gcs/main.tf
+++ b/deployment/modules/gcp/gcs/main.tf
@@ -18,14 +18,6 @@ resource "google_project_service" "storage_googleapis_com" {
 
 ## Resources
 
-# Service accounts
-
-resource "google_service_account" "log_writer" {
-  account_id   = "${var.base_name}-writer"
-  display_name = "Transparency log writer service account"
-}
-
-
 # Buckets
 
 resource "google_storage_bucket" "log_bucket" {
@@ -39,17 +31,15 @@ resource "google_storage_bucket_iam_binding" "log_bucket_reader" {
   bucket = google_storage_bucket.log_bucket.name
   role   = "roles/storage.objectViewer"
   members = concat(
-    [ google_service_account.log_writer.member ],
+    var.log_writer_members,
     var.bucket_readers
   )
 }
 
 resource "google_storage_bucket_iam_binding" "log_bucket_writer" {
-  bucket = google_storage_bucket.log_bucket.name
-  role   = "roles/storage.legacyBucketWriter"
-  members = [
-    google_service_account.log_writer.member
-  ]
+  bucket  = google_storage_bucket.log_bucket.name
+  role    = "roles/storage.legacyBucketWriter"
+  members = var.log_writer_members
 }
 
 # Spanner
@@ -76,7 +66,5 @@ resource "google_spanner_database_iam_binding" "database" {
   database = google_spanner_database.log_db.name
   role     = "roles/spanner.databaseUser"
 
-  members = [
-    google_service_account.log_writer.member
-  ]
+  members = var.log_writer_members
 }

--- a/deployment/modules/gcp/gcs/outputs.tf
+++ b/deployment/modules/gcp/gcs/outputs.tf
@@ -13,7 +13,3 @@ output "log_spanner_instance" {
   value       = google_spanner_instance.log_spanner
 }
 
-output "service_account_name" {
-  description = "Name of the service account with write permission for storage"
-  value       = google_service_account.log_writer.member
-}

--- a/deployment/modules/gcp/gcs/variables.tf
+++ b/deployment/modules/gcp/gcs/variables.tf
@@ -20,6 +20,11 @@ variable "env" {
 
 variable "bucket_readers" {
   description = "List of identities allowed to read the log bucket"
-  type = list
-  default = [ "allUsers" ]
+  type        = list(any)
+  default     = ["allUsers"]
+}
+
+variable "log_writer_members" {
+  description = "List of identities in member format allowed to write to the log"
+  type        = list(any)
 }


### PR DESCRIPTION
This PR updates the GCP `terra{grunt,form}` configs so that they don't attempt to manage service accounts, as these are being managed externally.