### PR TITLE
Basic codelab for simple HTTP personalities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ migration to Tessera and adopting the patterns it encourages.
 
 ### Getting started
 
+The best place to start is the codelab provided in the [conformance](./cmd/conformance/) directory.
+This will walk you through setting up your first log, writing some entries to it via HTTP, and inspecting the contents.
+
 Take a look at the example personalities in the `/cmd/` directory:
   - [posix](./cmd/conformance/posix/): example of operating a log backed by a local filesystem
     - This example runs an HTTP web server that takes arbitrary data and adds it to a file-based log.

--- a/cmd/conformance/README.md
+++ b/cmd/conformance/README.md
@@ -8,15 +8,15 @@ Each subdirectory contains an implementation of the same personality built on to
 Implementations are provided that use:
  - [A local filesystem](./posix/)
  - [MySQL](./mysql/)
- - [GCP](./gcp//)
+ - [GCP](./gcp/)
 
 Each of these personalities exposes an endpoint that accepts `POST` requests at a `/add` URL.
-The contents of any request body will be appended to the log, and the decimal index of the sequenced entry will be returned.
+The contents of any request body will be appended to the log, and the decimal index assigned to this newly _sequenced_ entry will be returned.
 
 ## Codelab
 
 Choose one of the implementations above and deploy it.
-In the shell you are going to run this codelab in, define the following environment variables (check the logging output from starting the log, as these may have been output):
+In the shell you are going to run this codelab in, define the following environment variables (check the logging output from the implementation you deployed, as these may have been output):
  - The write URL: `${WRITE_URL}`
  - The read URL: `${READ_URL}`
  - The log public key: `${LOG_PUBLIC_KEY}`

--- a/cmd/conformance/README.md
+++ b/cmd/conformance/README.md
@@ -1,0 +1,49 @@
+# Conformance Personalities
+
+This directory contains personalities that serve a dual purpose:
+ - To provide a simple example of a personality that can be deployed with each backend
+ - To function as conformance and performance harnesses for Tessera (using the [hammer](../../hammer/))
+
+Each subdirectory contains an implementation of the same personality built on top of Tessera.
+Implementations are provided that use:
+ - [A local filesystem](./posix/)
+ - [MySQL](./mysql/)
+ - [GCP](./gcp//)
+
+Each of these personalities exposes an endpoint that accepts `POST` requests at a `/add` URL.
+The contents of any request body will be appended to the log, and the decimal index of the sequenced entry will be returned.
+
+## Codelab
+
+Choose one of the implementations above and deploy it.
+In the shell you are going to run this codelab in, define the following environment variables (check the logging output from starting the log, as these may have been output):
+ - The write URL: `${WRITE_URL}`
+ - The read URL: `${READ_URL}`
+ - The log public key: `${LOG_PUBLIC_KEY}`
+
+The commands below add entries to the log, and then show a few approaches to inspect the contents of the log.
+
+```shell
+# Add 3 entries in parallel, and wait for all requests to complete
+curl -d 'foo' -H "Content-Type: application/data" -X POST ${WRITE_URL}/add &
+curl -d 'bar' -H "Content-Type: application/data" -X POST ${WRITE_URL}/add &
+curl -d 'baz' -H "Content-Type: application/data" -X POST ${WRITE_URL}/add &
+wait
+
+# Check that the checkpoint is of the correct size and the leaves are present
+curl ${READ_URL}/checkpoint
+curl -output - ${READ_URL}/tile/entries/000.p/3
+```
+
+The tiles format is plain-text, but it's better to inspect the log via tooling made for this purpose:
+
+```shell
+go run github.com/mhutchinson/woodpecker@main \
+  --custom_log_type=tiles \
+  --custom_log_url=${READ_URL} \
+  --custom_log_vkey=${LOG_PUBLIC_KEY}
+```
+
+Use arrow keys left and right to go backwards and forwards through the entries in the log.
+Use `q` to quit.
+

--- a/cmd/conformance/posix/main.go
+++ b/cmd/conformance/posix/main.go
@@ -48,7 +48,7 @@ func main() {
 	ctx := context.Background()
 
 	// Gather the info needed for reading/writing checkpoints
-	v := getVerifierOrDie()
+	vkey, v := getVerifierOrDie()
 	s := getSignerOrDie()
 
 	// Create the Tessera POSIX storage, using the directory from the --storage_dir flag
@@ -79,6 +79,11 @@ func main() {
 	// This makes it easier to test this implementation from another machine.
 	http.Handle("GET /", http.FileServer(http.Dir(*storageDir)))
 
+	// TODO(mhutchinson): Change the listen flag to just a port, or fix up this address formatting
+	klog.Infof("Environment variables useful for accessing this log:\n"+
+		"export WRITE_URL=http://localhost%s/ \n"+
+		"export READ_URL=http://localhost%s/ \n"+
+		"export LOG_PUBLIC_KEY=%s", *listen, *listen, vkey)
 	// Run the HTTP server with the single handler and block until this is terminated
 	if err := http.ListenAndServe(*listen, http.DefaultServeMux); err != nil {
 		klog.Exitf("ListenAndServe: %v", err)
@@ -86,7 +91,7 @@ func main() {
 }
 
 // Read log public key from file or environment variable
-func getVerifierOrDie() note.Verifier {
+func getVerifierOrDie() (string, note.Verifier) {
 	var pubKey string
 	var err error
 	if len(*pubKeyFile) > 0 {
@@ -106,7 +111,7 @@ func getVerifierOrDie() note.Verifier {
 		klog.Exitf("Failed to instantiate Verifier: %q", err)
 	}
 
-	return v
+	return pubKey, v
 }
 
 // Read log private key from file or environment variable


### PR DESCRIPTION
The POSIX and MySQL commands have been updated to output the required
env variables. I'll need some help with the GCP one as we can't assume
localhost and I don't think all the info we need is available. Maybe
this can be output by the terraform script?
