### PR TITLE
Fix hammer command in posix example

### DIFF
--- a/cmd/conformance/posix/README.md
+++ b/cmd/conformance/posix/README.md
@@ -25,7 +25,7 @@ In this example, we're running 32 writers against the log to add 128 new leaves 
 ```shell
 go run ./hammer \
   --log_public_key=example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx \
-  --write_log_url=http://localhost:2025 \
+  --log_url=http://localhost:2025 \
   --max_read_ops=0 \
   --num_writers=32 \
   --max_write_ops=64 \


### PR DESCRIPTION
The hammer tool gives an error `--log_url must be provided` when executing the example command. Update the flags to match the working command for the mysql example.