### PR TITLE
Storage impls have a common read API

### DIFF
--- a/integration/storage_uniformity_test.go
+++ b/integration/storage_uniformity_test.go
@@ -25,6 +25,9 @@ import (
 
 type StorageContract interface {
 	Add(ctx context.Context, entry *tessera.Entry) tessera.IndexFuture
+	ReadCheckpoint(ctx context.Context) ([]byte, error)
+	ReadTile(ctx context.Context, level, index, treeSize uint64) ([]byte, error)
+	ReadEntryBundle(ctx context.Context, index, treeSize uint64) ([]byte, error)
 }
 
 var (

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -178,17 +178,29 @@ func (s *Storage) Add(ctx context.Context, e *tessera.Entry) tessera.IndexFuture
 	return s.queue.Add(ctx, e)
 }
 
-// Get returns the requested object.
+func (s *Storage) ReadCheckpoint(ctx context.Context) ([]byte, error) {
+	return s.get(ctx, layout.CheckpointPath)
+}
+
+func (s *Storage) ReadTile(ctx context.Context, l, i, sz uint64) ([]byte, error) {
+	return s.get(ctx, layout.TilePath(l, i, sz))
+}
+
+func (s *Storage) ReadEntryBundle(ctx context.Context, i, sz uint64) ([]byte, error) {
+	return s.get(ctx, layout.EntriesPath(i, sz))
+}
+
+// get returns the requested object.
 //
 // This is indended to be used to proxy read requests through the personality for debug/testing purposes.
-func (s *Storage) Get(ctx context.Context, path string) ([]byte, error) {
+func (s *Storage) get(ctx context.Context, path string) ([]byte, error) {
 	d, _, err := s.objStore.getObject(ctx, path)
 	return d, err
 }
 
 // init ensures that the storage represents a log in a valid state.
 func (s *Storage) init(ctx context.Context) error {
-	cpRaw, err := s.Get(ctx, layout.CheckpointPath)
+	cpRaw, err := s.get(ctx, layout.CheckpointPath)
 	if err != nil {
 		if errors.Is(err, gcs.ErrObjectNotExist) {
 			// No checkpoint exists, do a forced (possibly empty) integration to create one in a safe

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -188,7 +188,7 @@ func (s *Storage) writeTile(ctx context.Context, tx *sql.Tx, level, index uint64
 // 3. Partial tile request with full/larger partial tile output: Return trimmed partial tile with correct tile width.
 // 4. Partial tile request with partial tile (same width) output: Return partial tile.
 // 5. Partial tile request with smaller partial tile output: Return error.
-func (s *Storage) ReadEntryBundle(ctx context.Context, index uint64) ([]byte, error) {
+func (s *Storage) ReadEntryBundle(ctx context.Context, index, treeSize uint64) ([]byte, error) {
 	row := s.db.QueryRowContext(ctx, selectTiledLeavesSQL, index)
 	if err := row.Err(); err != nil {
 		return nil, err

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -213,7 +213,7 @@ func TestReadMissingEntryBundle(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			entryBundle, err := s.ReadEntryBundle(ctx, test.index)
+			entryBundle, err := s.ReadEntryBundle(ctx, test.index, test.index)
 			if err != nil {
 				t.Errorf("got err: %v", err)
 			}
@@ -335,7 +335,7 @@ func TestEntryBundleRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Errorf("Add got err: %v", err)
 			}
-			entryBundleRaw, err := s.ReadEntryBundle(ctx, entryIndex/256)
+			entryBundleRaw, err := s.ReadEntryBundle(ctx, entryIndex/256, entryIndex)
 			if err != nil {
 				t.Errorf("ReadEntryBundle got err: %v", err)
 			}


### PR DESCRIPTION
This PR adds the MySQL "read" API onto the other storage implementations.

While we wouldn't generally expect applications to serve the read API directly unless they're using they MySQL storage implementation, we do expect that some subset of applications will want to be able to inspect the state of the tree locally (e.g. in order to expose an API which appears to implement synchronous integration). Such applications are generally going to want to have access to the read-only resources via the same "fast" path as Tessera has rather than the public path which may plausibly involve going via a CDN, waiting for replication, etc. 

#278 