### PR TITLE
Commit terragrunt lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ go.work.sum
 
 # Project IDX
 .idx/
+
+# Terraform and terragrunt files
+/deployment/.terraform
+/deployment/*.tfstate.backup
+/deployment/**/.terragrunt-cache

--- a/deployment/live/gcp/cloudbuild/prod/.terraform.lock.hcl
+++ b/deployment/live/gcp/cloudbuild/prod/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.9.0"
+  hashes = [
+    "h1:MsKAs34RhnHsJ2xFtbRiwvDYWZgEPaZwqK0Hm/G8UH0=",
+    "zh:53e9d7ffed63e2accff949ac7ca348d03be3e404e0b18c93ec596bcb52bac97a",
+    "zh:6cbaf7e40fba2cff3d3fe4b3213de81c6157e327e996febad6949949b104b6ae",
+    "zh:74562331eae7c88a8f934eb05971c361081c6e23d7a4564d1b11206558c037ed",
+    "zh:ac65f1507886d92858ddeeff710c7dab942437c7421c63c1c7aeb139f2bb44af",
+    "zh:b4a562b7c497661cd6c972097fea12449f183bb7e11bf6c62a750cc97bd3407e",
+    "zh:b9cdc22e59c47604492bdf3e4d123037e2f5dd0f8a0ec0cf0b81fda165dd8581",
+    "zh:c3f146d739b88de32339fb0091898bc9ad0aa3b257c8db4526076476c78e467a",
+    "zh:c7567999d7563913360598bca4c9fce59f43e3a45726da4fa3f6d2752469c486",
+    "zh:f3451c149844709713301641a5a2cfbf8add4abda927a457c5a2d67fa565887b",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f7df50451a534f59c472a190fc2e49caaed9ebdb22bd0b6e4fe2be423ce3a7a5",
+    "zh:fd41e513b9546f2ab6b2cc36de36f4cd8ae3eb04ba3fca9b308ec6e387837366",
+  ]
+}

--- a/deployment/live/gcp/conformance/ci/.terraform.lock.hcl
+++ b/deployment/live/gcp/conformance/ci/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.1.0"
+  constraints = "6.1.0"
+  hashes = [
+    "h1:okppWOAoIPz45VkydzAA74HRLgEKvP4CFXypPU228j8=",
+    "zh:2463510438c97c59e06ab1fb1ef76221c844abd1bc404c439401fc256e9928ab",
+    "zh:2afd9b76a81c51632bd54d3cc3bdc2685e8d89b8ace8ca7578b1ae42880228b5",
+    "zh:51e2fb64c7c8258ac0ec7315d488e5c655b392bf565f9bee2922ee72f6abfb90",
+    "zh:85aa39bad51132810ee6cd369f426614abff59cb0274fc737d087c17afa9b5ee",
+    "zh:989669bfed5ca7bf4d960eb9f27a62cbe2578ca2907da7c74fc93edae9a497fa",
+    "zh:a26665782e90ef3fd322d6a23a1de383c81ae93395e7c2bd9648a1aa85c69876",
+    "zh:d5e1b785b4c8569b91153eeba89280ffbbe7a0aaabb708833ada67544aeed057",
+    "zh:d748c69eab6acc4ab7ec369b3bd3ddd5d2e4120d99570743dafde74934959a20",
+    "zh:eb853ab5c4c0d3e536b8c77abf844b7893ac355967c95b6e0d39b12526e67989",
+    "zh:f4b50f0ae082412ba189041b6ac540523b7d6463905fed63be67eec03e1539b9",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f6e7adcfafe267d9c657a6c087388f7e0c1e3be4dc179a9a823f75c830a499b7",
+  ]
+}


### PR DESCRIPTION
This ensures that everyone is using the same versions of the terrraform modules when deploying. Added the gitignore files for stuff that shouldn't be committed.
