### PR TITLE
Add tighter-scoped function types in /client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -43,7 +43,7 @@ var (
 // checkpoint from a log's data storage.
 //
 // Note that the implementation of this MUST return (either directly or wrapped)
-// an os.ErrIsNotExit when the file referenced by path does not exist, e.g. a HTTP
+// an os.ErrIsNotExist when the file referenced by path does not exist, e.g. a HTTP
 // based implementation MUST return this error when it receives a 404 StatusCode.
 type CheckpointFetcherFunc func(ctx context.Context) ([]byte, error)
 
@@ -51,7 +51,7 @@ type CheckpointFetcherFunc func(ctx context.Context) ([]byte, error)
 // for a given tile.
 //
 // Note that the implementation of this MUST return (either directly or wrapped)
-// an os.ErrIsNotExit when the file referenced by path does not exist, e.g. a HTTP
+// an os.ErrIsNotExist when the file referenced by path does not exist, e.g. a HTTP
 // based implementation MUST return this error when it receives a 404 StatusCode.
 type TileFetcherFunc func(ctx context.Context, level, index, logSize uint64) ([]byte, error)
 
@@ -176,10 +176,6 @@ func (pb *ProofBuilder) fetchNodes(ctx context.Context, nodes proof.Nodes) ([][]
 	}
 	return hashes, nil
 }
-
-// GetTileFunc is the signature of a function which knows how to fetch a
-// specific tile.
-type GetTileFunc func(ctx context.Context, level, index uint64) (*api.HashTile, error)
 
 // FetchRangeNodes returns the set of nodes representing the compact range covering
 // a log of size s.

--- a/client/client.go
+++ b/client/client.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"sort"
 	"strings"
 
@@ -144,6 +145,23 @@ func (h HTTPFetcher) ReadTile(ctx context.Context, l, i, sz uint64) ([]byte, err
 
 func (h HTTPFetcher) ReadEntryBundle(ctx context.Context, i, sz uint64) ([]byte, error) {
 	return h.fetch(ctx, layout.EntriesPath(i, sz))
+}
+
+// FileFetcher knows how to fetch log artifacts from a filesystem rooted at Root.
+type FileFetcher struct {
+	Root string
+}
+
+func (f FileFetcher) ReadCheckpoint(_ context.Context) ([]byte, error) {
+	return os.ReadFile(path.Join(f.Root, layout.CheckpointPath))
+}
+
+func (f FileFetcher) ReadTile(_ context.Context, l, i, sz uint64) ([]byte, error) {
+	return os.ReadFile(path.Join(f.Root, layout.TilePath(l, i, sz)))
+}
+
+func (f FileFetcher) ReadEntryBundle(_ context.Context, i, sz uint64) ([]byte, error) {
+	return os.ReadFile(path.Join(f.Root, layout.EntriesPath(i, sz)))
 }
 
 // ConsensusCheckpointFunc is a function which returns the largest checkpoint known which is

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -1,0 +1,124 @@
+// Copyright 2024 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"k8s.io/klog/v2"
+)
+
+// NewHTTPFetcher creates a new HTTPFetcher for the log rooted at the given URL, using
+// the provided HTTP client.
+//
+// rootURL should end in a trailing slash.
+// c may be nil, in which case http.DefaultClient will be used.
+func NewHTTPFetcher(rootURL *url.URL, c *http.Client) (*HTTPFetcher, error) {
+	if !strings.HasSuffix(rootURL.String(), "/") {
+		rootURL.Path += "/"
+	}
+	if c == nil {
+		c = http.DefaultClient
+	}
+	return &HTTPFetcher{
+		c:       c,
+		rootURL: rootURL,
+	}, nil
+}
+
+// HTTPFetcher knows how to fetch log artifacts from a log being served via HTTP.
+type HTTPFetcher struct {
+	c          *http.Client
+	rootURL    *url.URL
+	authHeader string
+}
+
+// SetAuthorizationHeader sets the value to be used with an Authorization: header
+// for every request made by this fetcher.
+func (h *HTTPFetcher) SetAuthorizationHeader(v string) {
+	h.authHeader = v
+}
+
+func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
+	u, err := h.rootURL.Parse(p)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %v", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("NewRequestWithContext(%q): %v", u.String(), err)
+	}
+	if h.authHeader != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", h.authHeader))
+	}
+	r, err := h.c.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get(%q): %v", u.String(), err)
+	}
+	switch r.StatusCode {
+	case http.StatusOK:
+		// All good, continue below
+		break
+	case http.StatusNotFound:
+		// Need to return ErrNotExist here, by contract.
+		return nil, fmt.Errorf("get(%q): %v", u.String(), os.ErrNotExist)
+	default:
+		return nil, fmt.Errorf("get(%q): %v", u.String(), r.StatusCode)
+	}
+
+	defer func() {
+		if err := r.Body.Close(); err != nil {
+			klog.Errorf("resp.Body.Close(): %v", err)
+		}
+	}()
+	return io.ReadAll(r.Body)
+}
+
+func (h HTTPFetcher) ReadCheckpoint(ctx context.Context) ([]byte, error) {
+	return h.fetch(ctx, layout.CheckpointPath)
+}
+
+func (h HTTPFetcher) ReadTile(ctx context.Context, l, i, sz uint64) ([]byte, error) {
+	return h.fetch(ctx, layout.TilePath(l, i, sz))
+}
+
+func (h HTTPFetcher) ReadEntryBundle(ctx context.Context, i, sz uint64) ([]byte, error) {
+	return h.fetch(ctx, layout.EntriesPath(i, sz))
+}
+
+// FileFetcher knows how to fetch log artifacts from a filesystem rooted at Root.
+type FileFetcher struct {
+	Root string
+}
+
+func (f FileFetcher) ReadCheckpoint(_ context.Context) ([]byte, error) {
+	return os.ReadFile(path.Join(f.Root, layout.CheckpointPath))
+}
+
+func (f FileFetcher) ReadTile(_ context.Context, l, i, sz uint64) ([]byte, error) {
+	return os.ReadFile(path.Join(f.Root, layout.TilePath(l, i, sz)))
+}
+
+func (f FileFetcher) ReadEntryBundle(_ context.Context, i, sz uint64) ([]byte, error) {
+	return os.ReadFile(path.Join(f.Root, layout.EntriesPath(i, sz)))
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -36,7 +35,6 @@ import (
 	"github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/merkle/proof"
 	"github.com/transparency-dev/merkle/rfc6962"
-	"github.com/transparency-dev/trillian-tessera/api/layout"
 	"github.com/transparency-dev/trillian-tessera/client"
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/sync/errgroup"
@@ -96,7 +94,7 @@ func TestMain(m *testing.M) {
 		logReadTile = hf.ReadTile
 		logReadEntryBundle = hf.ReadEntryBundle
 	case "file":
-		ff := fileReader{dir: logReadBaseURL.Path}
+		ff := client.FileFetcher{Root: logReadBaseURL.Path}
 		logReadCP = ff.ReadCheckpoint
 		logReadTile = ff.ReadTile
 		logReadEntryBundle = ff.ReadEntryBundle
@@ -209,22 +207,6 @@ func TestLiveLogIntegration(t *testing.T) {
 	if err := client.CheckConsistency(ctx, logReadTile, checkpoints); err != nil {
 		t.Errorf("log consistency checks failed: %v", err)
 	}
-}
-
-type fileReader struct {
-	dir string
-}
-
-func (f *fileReader) ReadCheckpoint(_ context.Context) ([]byte, error) {
-	return os.ReadFile(path.Join(f.dir, layout.CheckpointPath))
-}
-
-func (f *fileReader) ReadTile(_ context.Context, l, i, sz uint64) ([]byte, error) {
-	return os.ReadFile(path.Join(f.dir, layout.TilePath(l, i, sz)))
-}
-
-func (f *fileReader) ReadEntryBundle(_ context.Context, i, sz uint64) ([]byte, error) {
-	return os.ReadFile(path.Join(f.dir, layout.EntriesPath(i, sz)))
 }
 
 type entryWriter struct {

--- a/integration/storage_uniformity_test.go
+++ b/integration/storage_uniformity_test.go
@@ -21,6 +21,7 @@ import (
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/storage/gcp"
 	"github.com/transparency-dev/trillian-tessera/storage/mysql"
+	"github.com/transparency-dev/trillian-tessera/storage/posix"
 )
 
 type StorageContract interface {
@@ -33,4 +34,5 @@ type StorageContract interface {
 var (
 	_ StorageContract = &mysql.Storage{}
 	_ StorageContract = &gcp.Storage{}
+	_ StorageContract = &posix.Storage{}
 )

--- a/internal/hammer/client.go
+++ b/internal/hammer/client.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,6 +32,12 @@ import (
 )
 
 var ErrRetry = errors.New("retry")
+
+type fetcher interface {
+	ReadCheckpoint(ctx context.Context) ([]byte, error)
+	ReadTile(ctx context.Context, l, i, sz uint64) ([]byte, error)
+	ReadEntryBundle(ctx context.Context, i, sz uint64) ([]byte, error)
+}
 
 // newLogClientsFromFlags returns a fetcher and a writer that will read
 // and write leaves to all logs in the `log_url` flag set.
@@ -58,7 +63,7 @@ func newLogClientsFromFlags() (*roundRobinFetcher, *roundRobinLeafWriter) {
 		return rootURL
 	}
 
-	fetchers := []client.Fetcher{}
+	fetchers := []fetcher{}
 	for _, s := range logURL {
 		fetchers = append(fetchers, newFetcher(rootUrlOrDie(s)))
 	}
@@ -74,62 +79,20 @@ func newLogClientsFromFlags() (*roundRobinFetcher, *roundRobinLeafWriter) {
 }
 
 // newFetcher creates a Fetcher for the log at the given root location.
-func newFetcher(root *url.URL) client.Fetcher {
-	get := getByScheme[root.Scheme]
-	if get == nil {
-		panic(fmt.Errorf("unsupported URL scheme %s", root.Scheme))
-	}
-
-	return func(ctx context.Context, p string) ([]byte, error) {
-		u, err := root.Parse(p)
+func newFetcher(root *url.URL) fetcher {
+	switch root.Scheme {
+	case "http", "https":
+		c, err := client.NewHTTPFetcher(root, nil)
 		if err != nil {
-			return nil, err
+			klog.Exitf("NewHTTPFetcher: %v", err)
 		}
-		return get(ctx, u)
+		c.SetAuthorizationHeader(*bearerToken)
+		return c
+	case "file":
+		return client.FileFetcher{Root: root.Path}
 	}
-}
-
-var getByScheme = map[string]func(context.Context, *url.URL) ([]byte, error){
-	"http":  readHTTP,
-	"https": readHTTP,
-	"file": func(_ context.Context, u *url.URL) ([]byte, error) {
-		return os.ReadFile(u.Path)
-	},
-}
-
-func readHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	if *bearerToken != "" {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", *bearerToken))
-	}
-
-	resp, err := hc.Do(req.WithContext(ctx))
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			klog.Errorf("resp.Body.Close(): %v", err)
-		}
-	}()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read body: %v", err)
-	}
-
-	switch resp.StatusCode {
-	case http.StatusNotFound:
-		klog.Infof("Not found: %q", u.String())
-		return nil, os.ErrNotExist
-	case http.StatusOK:
-		break
-	default:
-		return nil, fmt.Errorf("unexpected http status %q", resp.Status)
-	}
-	return body, nil
+	klog.Exitf("Unknown scheme on log URL: %q", root.Scheme)
+	return nil
 }
 
 // roundRobinFetcher ensures that read requests are sent to all configured fetchers
@@ -137,15 +100,25 @@ func readHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
 type roundRobinFetcher struct {
 	sync.Mutex
 	idx int
-	f   []client.Fetcher
+	f   []fetcher
 }
 
-func (rr *roundRobinFetcher) Fetch(ctx context.Context, path string) ([]byte, error) {
+func (rr *roundRobinFetcher) ReadCheckpoint(ctx context.Context) ([]byte, error) {
 	f := rr.next()
-	return f(ctx, path)
+	return f.ReadCheckpoint(ctx)
 }
 
-func (rr *roundRobinFetcher) next() client.Fetcher {
+func (rr *roundRobinFetcher) ReadTile(ctx context.Context, l, i, sz uint64) ([]byte, error) {
+	f := rr.next()
+	return f.ReadTile(ctx, l, i, sz)
+}
+
+func (rr *roundRobinFetcher) ReadEntryBundle(ctx context.Context, i, sz uint64) ([]byte, error) {
+	f := rr.next()
+	return f.ReadEntryBundle(ctx, i, sz)
+}
+
+func (rr *roundRobinFetcher) next() fetcher {
 	rr.Lock()
 	defer rr.Unlock()
 

--- a/internal/hammer/client.go
+++ b/internal/hammer/client.go
@@ -86,7 +86,9 @@ func newFetcher(root *url.URL) fetcher {
 		if err != nil {
 			klog.Exitf("NewHTTPFetcher: %v", err)
 		}
-		c.SetAuthorizationHeader(*bearerToken)
+		if *bearerToken != "" {
+			c.SetAuthorizationHeader(fmt.Sprintf("Bearer: %s", *bearerToken))
+		}
 		return c
 	case "file":
 		return client.FileFetcher{Root: root.Path}

--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -364,7 +364,7 @@ func (a *HammerAnalyser) errorLoop(ctx context.Context) {
 // dupChance provides the probability that a new leaf will be a duplicate of a previous entry.
 // Leaves will be unique if dupChance is 0, and if set to 1 then all values will be duplicates.
 // startSize should be set to the initial size of the log so that repeated runs of the
-// hammer can start seeding leaves to avoid duplicates with p:e revious runs.
+// hammer can start seeding leaves to avoid duplicates with previous runs.
 func newLeafGenerator(startSize uint64, minLeafSize int, dupChance float64) func() []byte {
 	genLeaf := func(n uint64) []byte {
 		// Make a slice with half the number of requested bytes since we'll

--- a/internal/hammer/workers.go
+++ b/internal/hammer/workers.go
@@ -34,7 +34,7 @@ type LeafWriter func(ctx context.Context, data []byte) (uint64, error)
 // NewLeafReader creates a LeafReader.
 // The next function provides a strategy for which leaves will be read.
 // Custom implementations can be passed, or use RandomNextLeaf or MonotonicallyIncreasingNextLeaf.
-func NewLeafReader(tracker *client.LogStateTracker, f client.Fetcher, next func(uint64) uint64, throttle <-chan bool, errChan chan<- error) *LeafReader {
+func NewLeafReader(tracker *client.LogStateTracker, f client.EntryBundleFetcherFunc, next func(uint64) uint64, throttle <-chan bool, errChan chan<- error) *LeafReader {
 	return &LeafReader{
 		tracker:  tracker,
 		f:        f,
@@ -48,7 +48,7 @@ func NewLeafReader(tracker *client.LogStateTracker, f client.Fetcher, next func(
 // This class is not thread safe.
 type LeafReader struct {
 	tracker  *client.LogStateTracker
-	f        client.Fetcher
+	f        client.EntryBundleFetcherFunc
 	next     func(uint64) uint64
 	throttle <-chan bool
 	errChan  chan<- error


### PR DESCRIPTION
This PR adapts the `client` package to use tighter scoped functions for fetching different types of log artifact, as opposed to the more generic "fetchURL" approach it previously took.

These tighter function signatures match the ones in #281, allowing personality authors to directly use storage instances when e.g. building off-line proof bundles etc. 
