### PR TITLE
Multiball signatures

### DIFF
--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -34,30 +34,33 @@ import (
 )
 
 var (
-	bucket   = flag.String("bucket", "", "Bucket to use for storing log")
-	listen   = flag.String("listen", ":2024", "Address:port to listen on")
-	project  = flag.String("project", os.Getenv("GOOGLE_CLOUD_PROJECT"), "GCP Project, take from env if unset")
-	spanner  = flag.String("spanner", "", "Spanner resource URI ('projects/.../...')")
-	signer   = flag.String("signer", "", "Note signer to use to sign checkpoints")
-	verifier = flag.String("verifier", "", "Note verifier corresponding to --signer")
-	origin   = flag.String("origin", "", "Log origin string")
+	bucket            = flag.String("bucket", "", "Bucket to use for storing log")
+	listen            = flag.String("listen", ":2024", "Address:port to listen on")
+	project           = flag.String("project", os.Getenv("GOOGLE_CLOUD_PROJECT"), "GCP Project, take from env if unset")
+	spanner           = flag.String("spanner", "", "Spanner resource URI ('projects/.../...')")
+	signer            = flag.String("signer", "", "Note signer to use to sign checkpoints")
+	verifier          = flag.String("verifier", "", "Note verifier corresponding to --signer")
+	additionalSigners = []string{}
 )
+
+func init() {
+	flag.Func("additional_signer", "Additional note signer for checkpoints, may be specified multiple times", func(s string) error {
+		additionalSigners = append(additionalSigners, s)
+		return nil
+	})
+}
 
 func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
 	ctx := context.Background()
 
-	if *origin == "" {
-		klog.Exit("Must supply --origin")
-	}
-
-	s, v := signerFromFlags()
+	s, v, a := signerFromFlags()
 
 	// Create our Tessera storage backend:
 	gcpCfg := storageConfigFromFlags()
 	storage, err := gcp.New(ctx, gcpCfg,
-		tessera.WithCheckpointSignerVerifier(s, v),
+		tessera.WithCheckpointSignerVerifier(s, v, a...),
 		tessera.WithBatching(1024, time.Second),
 		tessera.WithPushback(10*4096),
 	)
@@ -120,7 +123,7 @@ func storageConfigFromFlags() gcp.Config {
 	}
 }
 
-func signerFromFlags() (note.Signer, note.Verifier) {
+func signerFromFlags() (note.Signer, note.Verifier, []note.Signer) {
 	s, err := note.NewSigner(*signer)
 	if err != nil {
 		klog.Exitf("Failed to create new signer: %v", err)
@@ -131,5 +134,14 @@ func signerFromFlags() (note.Signer, note.Verifier) {
 		klog.Exitf("Failed to create new verifier: %v", err)
 	}
 
-	return s, v
+	var a []note.Signer
+	for _, as := range additionalSigners {
+		s, err := note.NewSigner(as)
+		if err != nil {
+			klog.Exitf("Failed to create additional signer: %v", err)
+		}
+		a = append(a, s)
+	}
+
+	return s, v, a
 }

--- a/deployment/live/gcp/cloudbuild/prod/terragrunt.hcl
+++ b/deployment/live/gcp/cloudbuild/prod/terragrunt.hcl
@@ -9,6 +9,5 @@ inputs = merge(
     # Service accounts are managed externally.
     service_account    = "cloudbuild-${include.root.locals.env}-sa@trillian-tessera.iam.gserviceaccount.com"
     kms_key_version_id = get_env("TESSERA_KMS_KEY_VERSION", "projects/${include.root.locals.project_id}/locations/${include.root.locals.region}/keyRings/ci-conformance/cryptoKeys/log-signer/cryptoKeyVersions/1")
-    log_origin         = "ci-conformance"
   }
 )

--- a/deployment/live/gcp/conformance/ci/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/ci/terragrunt.hcl
@@ -11,6 +11,5 @@ inputs = merge(
   include.root.locals,
   {
     server_docker_image = "us-central1-docker.pkg.dev/trillian-tessera/docker-prod/conformance-gcp:latest"
-    log_origin          = include.root.locals.base_name
   }
 )

--- a/deployment/live/gcp/conformance/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/terragrunt.hcl
@@ -10,7 +10,6 @@ locals {
   conformance_gcp_docker_image = "${local.location}-docker.pkg.dev/trillian-tessera/docker-${local.env}/conformance-gcp:latest"
   signer                       = get_env("TESSERA_SIGNER")
   verifier                     = get_env("TESSERA_VERIFIER")
-  log_origin                   = local.base_name
   # Service accounts are managed externally:
   conformance_users        = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
   bucket_readers           = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]

--- a/deployment/modules/gcp/cloudbuild/variables.tf
+++ b/deployment/modules/gcp/cloudbuild/variables.tf
@@ -13,11 +13,6 @@ variable "env" {
   type        = string
 }
 
-variable "log_origin" {
-  description = "The origin string for the conformance log"
-  type        = string
-}
-
 variable "service_account" {
   description = "Service account email to use for cloudbuild"
 }

--- a/deployment/modules/gcp/conformance/main.tf
+++ b/deployment/modules/gcp/conformance/main.tf
@@ -64,7 +64,6 @@ resource "google_cloud_run_v2_service" "default" {
         "--listen=:8080",
         "--signer=${var.signer}",
         "--verifier=${var.verifier}",
-        "--origin=${var.log_origin}",
       ]
       ports {
         name           = "h2c"

--- a/deployment/modules/gcp/conformance/variables.tf
+++ b/deployment/modules/gcp/conformance/variables.tf
@@ -23,11 +23,6 @@ variable "server_docker_image" {
   type        = string
 }
 
-variable "log_origin" {
-  description = "The origin string for the conformance log"
-  type        = string
-}
-
 variable "signer" {
   description = "The note signer which should be used to sign checkpoints"
   type        = string

--- a/log.go
+++ b/log.go
@@ -23,6 +23,7 @@ import (
 	f_log "github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
 	"golang.org/x/mod/sumdb/note"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -80,9 +81,28 @@ func ResolveStorageOptions(opts ...func(*StorageOptions)) *StorageOptions {
 
 // WithCheckpointSignerVerifier is an option for setting the note signer and verifier to use when creating and parsing checkpoints.
 //
-// Checkpoints signed by this signer and verified by this verifier will be standard checkpoints as defined by https://c2sp.org/tlog-checkpoint.
-// The provided signer's name will be used as the Origin line on the checkpoint.
-func WithCheckpointSignerVerifier(s note.Signer, v note.Verifier) func(*StorageOptions) {
+// A primary signer and verifier must be provided:
+// - the primary signer is the "canonical" signing identity which should be used when creating new checkpoints.
+// - the primary verifier is the verifier for the "canonical" identity which signed the _latest_ checkpoint.
+// Note that while for the most-part this signer and verifier will relate to the same key, this would not be the case when rolling keys.
+//
+// Zero or more dditional signers may also be provided.
+// This enables cases like:
+//   - a rolling key rotation, where checkpoints are signed by both the old and new keys for some period of time,
+//   - using different signature schemes for different audiences, etc.
+//
+// When providing additional signers, their names MUST be identical to the primary signer name, and this name will be used
+// as the checkpoint Origin line.
+//
+// Checkpoints signed by these signer(s) and verified by the provied verifier will be standard checkpoints as defined by https://c2sp.org/tlog-checkpoint.
+func WithCheckpointSignerVerifier(s note.Signer, v note.Verifier, additionalSigners ...note.Signer) func(*StorageOptions) {
+	origin := s.Name()
+	for _, signer := range additionalSigners {
+		if origin != signer.Name() {
+			klog.Exitf("WithCheckpointSignerVerifier: additional signer name (%q) does not match primary signer name (%q)", signer.Name(), origin)
+		}
+
+	}
 	return func(o *StorageOptions) {
 		o.NewCP = func(size uint64, hash []byte) ([]byte, error) {
 			// If we're signing a zero-sized tree, the tlog-checkpoint spec says (via RFC6962) that
@@ -92,12 +112,12 @@ func WithCheckpointSignerVerifier(s note.Signer, v note.Verifier) func(*StorageO
 				hash = emptyRoot[:]
 			}
 			cpRaw := f_log.Checkpoint{
-				Origin: s.Name(),
+				Origin: origin,
 				Size:   size,
 				Hash:   hash,
 			}.Marshal()
 
-			n, err := note.Sign(&note.Note{Text: string(cpRaw)}, s)
+			n, err := note.Sign(&note.Note{Text: string(cpRaw)}, append([]note.Signer{s}, additionalSigners...)...)
 			if err != nil {
 				return nil, fmt.Errorf("note.Sign: %w", err)
 			}

--- a/log.go
+++ b/log.go
@@ -94,7 +94,7 @@ func ResolveStorageOptions(opts ...func(*StorageOptions)) *StorageOptions {
 // When providing additional signers, their names MUST be identical to the primary signer name, and this name will be used
 // as the checkpoint Origin line.
 //
-// Checkpoints signed by these signer(s) and verified by the provied verifier will be standard checkpoints as defined by https://c2sp.org/tlog-checkpoint.
+// Checkpoints signed by these signer(s) and verified by the provided verifier will be standard checkpoints as defined by https://c2sp.org/tlog-checkpoint.
 func WithCheckpointSignerVerifier(s note.Signer, v note.Verifier, additionalSigners ...note.Signer) func(*StorageOptions) {
 	origin := s.Name()
 	for _, signer := range additionalSigners {


### PR DESCRIPTION
This PR allows Tessera to be configured with multiple checkpoint signers.

This is useful when rotating the key of a log whilst avoiding having to coordinate a global "flag day" for everyone to switch over, or for situations where different audiences of a log require different signature schemes.