### PR TITLE
Pre-clean conformance env

### DIFF
--- a/deployment/modules/gcp/cloudbuild/main.tf
+++ b/deployment/modules/gcp/cloudbuild/main.tf
@@ -137,7 +137,21 @@ resource "google_cloudbuild_trigger" "docker" {
       id   = "hammer"
       name = "golang"
       script = <<EOT
-      go run ./internal/hammer --log_public_key=$(cat /workspace/key.pub) --log_url=https://storage.googleapis.com/trillian-tessera-ci-conformance-bucket/ --write_log_url="$(cat /workspace/conformance_url)" -v=1 --show_ui=false --bearer_token="$(cat /workspace/cb_access)" --bearer_token_write="$(cat /workspace/cb_identity)" --logtostderr --num_writers=1100 --max_write_ops=1500 --leaf_min_size=1024 --leaf_write_goal=50000 --force_http2
+        apt update && apt install -y retry
+        retry -t 5 -d 15 --until=success go run ./internal/hammer \
+            --log_public_key=$(cat /workspace/key.pub) \
+            --log_url=https://storage.googleapis.com/trillian-tessera-ci-conformance-bucket/ \
+            --write_log_url="$(cat /workspace/conformance_url)" \
+            -v=1 \
+            --show_ui=false \
+            --bearer_token="$(cat /workspace/cb_access)" \
+            --bearer_token_write="$(cat /workspace/cb_identity)" \
+            --logtostderr \
+            --num_writers=1100 \
+            --max_write_ops=1500 \
+            --leaf_min_size=1024 \
+            --leaf_write_goal=50000 \
+            --force_http2
       EOT
       wait_for = ["terraform_outputs", "generate_keys", "access"]
     }

--- a/deployment/modules/gcp/cloudbuild/main.tf
+++ b/deployment/modules/gcp/cloudbuild/main.tf
@@ -33,6 +33,24 @@ resource "google_cloudbuild_trigger" "docker" {
   }
 
   build {
+    ## Destroy any pre-existing deployment/live/gcp/conformance/ci environment.
+    ## This might happen if a previous cloud build failed for some reason.
+    step {
+      id         = "preclean_env"
+      name       = "alpine/terragrunt"
+      script     = <<EOT
+        terragrunt --terragrunt-non-interactive destroy -auto-approve 2>&1
+      EOT
+      dir = "deployment/live/gcp/conformance/ci"
+      env = [
+        "TESSERA_SIGNER=unused",
+        "TESSERA_VERIFIER=unused",
+        "GOOGLE_PROJECT=${var.project_id}",
+        "TF_IN_AUTOMATION=1",
+        "TF_INPUT=false",
+        "TF_VAR_project_id=${var.project_id}"
+      ]
+    }
     ## Build the GCP conformance server docker image.
     ## This will be used by the conformance terragrunt config step further down.
     step {


### PR DESCRIPTION
This PR improves the resilience of the GCP CI pipeline.

When something goes wrong with a CI run, GCB bails and stops progressing through the configured steps. This means that we don't get to the "clean up and tear down" step right at the end.

Unfortunately there seems to be no way to instruct GCB that a particular step must run regardless of whatever else has happened, the nearest thing is the ability to tag individual steps as being "fail ok", but of course in reality they're not and so this complicates future steps as they need to figure out for themselves whether previous steps actually failed.

Instead, this PR simply attempts to tear down any resources in the CI env as the very first build step.

#7 

