### PR TITLE
Move stuff to internal and improve comments

### DIFF
--- a/ct_only.go
+++ b/ct_only.go
@@ -37,7 +37,9 @@ type Storage interface {
 // a) embodies some techniques which are not considered to be best practice (it does this to retain backawards-compatibility with RFC6962)
 // b) is not compatible with the https://c2sp.org/tlog-tiles API which we _very strongly_ encourage you to use instead.
 //
-// Returns the assigned index in the log, or an error.
+// Users of this MUST NOT call `Add` on the underlying storage directly.
+//
+// Returns a future, which resolves to the assigned index in the log, or an error.
 func NewCertificateTransparencySequencedWriter(s Storage) func(context.Context, *ctonly.Entry) IndexFuture {
 	return func(ctx context.Context, e *ctonly.Entry) IndexFuture {
 		return s.Add(ctx, convertCTEntry(e))

--- a/ct_only.go
+++ b/ct_only.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/transparency-dev/trillian-tessera/api/layout"
 	"github.com/transparency-dev/trillian-tessera/ctonly"
+	"github.com/transparency-dev/trillian-tessera/internal/options"
 )
 
 // Storage described the expected functions from Tessera storage implementations.
@@ -62,8 +63,8 @@ func convertCTEntry(e *ctonly.Entry) *Entry {
 }
 
 // WithCTLayout instructs the underlying storage to use a Static CT API compatible scheme for layout.
-func WithCTLayout() func(*StorageOptions) {
-	return func(opts *StorageOptions) {
+func WithCTLayout() func(*options.StorageOptions) {
+	return func(opts *options.StorageOptions) {
 		opts.EntriesPath = ctEntriesPath
 	}
 }

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -1,0 +1,43 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"time"
+
+	f_log "github.com/transparency-dev/formats/log"
+)
+
+// NewCPFunc is the signature of a function which knows how to format and sign checkpoints.
+type NewCPFunc func(size uint64, hash []byte) ([]byte, error)
+
+// ParseCPFunc is the signature of a function which knows how to verify and parse checkpoints.
+type ParseCPFunc func(raw []byte) (*f_log.Checkpoint, error)
+
+// EntriesPathFunc is the signature of a function which knows how to format entry bundle paths.
+type EntriesPathFunc func(n, logSize uint64) string
+
+// StorageOptions holds optional settings for all storage implementations.
+type StorageOptions struct {
+	NewCP   NewCPFunc
+	ParseCP ParseCPFunc
+
+	BatchMaxAge  time.Duration
+	BatchMaxSize uint
+
+	PushbackMaxOutstanding uint
+
+	EntriesPath EntriesPathFunc
+}

--- a/log.go
+++ b/log.go
@@ -21,14 +21,8 @@ import (
 	"time"
 
 	f_log "github.com/transparency-dev/formats/log"
-	"github.com/transparency-dev/trillian-tessera/api/layout"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
-)
-
-const (
-	DefaultBatchMaxSize = 256
-	DefaultBatchMaxAge  = 250 * time.Millisecond
 )
 
 // ErrPushback is returned by underlying storage implementations when there are too many
@@ -64,19 +58,6 @@ type StorageOptions struct {
 	PushbackMaxOutstanding uint
 
 	EntriesPath EntriesPathFunc
-}
-
-// ResolveStorageOptions turns a variadic array of storage options into a StorageOptions instance.
-func ResolveStorageOptions(opts ...func(*StorageOptions)) *StorageOptions {
-	defaults := &StorageOptions{
-		BatchMaxSize: DefaultBatchMaxSize,
-		BatchMaxAge:  DefaultBatchMaxAge,
-		EntriesPath:  layout.EntriesPath,
-	}
-	for _, opt := range opts {
-		opt(defaults)
-	}
-	return defaults
 }
 
 // WithCheckpointSignerVerifier is an option for setting the note signer and verifier to use when creating and parsing checkpoints.

--- a/log.go
+++ b/log.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	f_log "github.com/transparency-dev/formats/log"
+	"github.com/transparency-dev/trillian-tessera/internal/options"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
 )
@@ -32,33 +33,11 @@ import (
 // in an appropriate manner (e.g. for HTTP services, return a 503 with a Retry-After header).
 var ErrPushback = errors.New("too many unintegrated entries")
 
-// NewCPFunc is the signature of a function which knows how to format and sign checkpoints.
-type NewCPFunc func(size uint64, hash []byte) ([]byte, error)
-
-// ParseCPFunc is the signature of a function which knows how to verify and parse checkpoints.
-type ParseCPFunc func(raw []byte) (*f_log.Checkpoint, error)
-
-// EntriesPathFunc is the signature of a function which knows how to format entry bundle paths.
-type EntriesPathFunc func(n, logSize uint64) string
-
 // IndexFuture is the signature of a function which can return an assigned index or error.
 //
 // Implementations of this func are likely to be "futures", or a promise to return this data at
 // some point in the future, and as such will block when called if the data isn't yet available.
 type IndexFuture func() (uint64, error)
-
-// StorageOptions holds optional settings for all storage implementations.
-type StorageOptions struct {
-	NewCP   NewCPFunc
-	ParseCP ParseCPFunc
-
-	BatchMaxAge  time.Duration
-	BatchMaxSize uint
-
-	PushbackMaxOutstanding uint
-
-	EntriesPath EntriesPathFunc
-}
 
 // WithCheckpointSignerVerifier is an option for setting the note signer and verifier to use when creating and parsing checkpoints.
 //
@@ -76,7 +55,7 @@ type StorageOptions struct {
 // as the checkpoint Origin line.
 //
 // Checkpoints signed by these signer(s) and verified by the provided verifier will be standard checkpoints as defined by https://c2sp.org/tlog-checkpoint.
-func WithCheckpointSignerVerifier(s note.Signer, v note.Verifier, additionalSigners ...note.Signer) func(*StorageOptions) {
+func WithCheckpointSignerVerifier(s note.Signer, v note.Verifier, additionalSigners ...note.Signer) func(*options.StorageOptions) {
 	origin := s.Name()
 	for _, signer := range additionalSigners {
 		if origin != signer.Name() {
@@ -84,7 +63,7 @@ func WithCheckpointSignerVerifier(s note.Signer, v note.Verifier, additionalSign
 		}
 
 	}
-	return func(o *StorageOptions) {
+	return func(o *options.StorageOptions) {
 		o.NewCP = func(size uint64, hash []byte) ([]byte, error) {
 			// If we're signing a zero-sized tree, the tlog-checkpoint spec says (via RFC6962) that
 			// the root must be SHA256 of the empty string, so we'll enforce that here:
@@ -116,8 +95,8 @@ func WithCheckpointSignerVerifier(s note.Signer, v note.Verifier, additionalSign
 }
 
 // WithBatching enables batching of write requests.
-func WithBatching(maxSize uint, maxAge time.Duration) func(*StorageOptions) {
-	return func(o *StorageOptions) {
+func WithBatching(maxSize uint, maxAge time.Duration) func(*options.StorageOptions) {
+	return func(o *options.StorageOptions) {
 		o.BatchMaxAge = maxAge
 		o.BatchMaxSize = maxSize
 	}
@@ -127,8 +106,8 @@ func WithBatching(maxSize uint, maxAge time.Duration) func(*StorageOptions) {
 //
 // maxOutstanding is the number of "in-flight" add requests - i.e. the number of entries with sequence numbers
 // assigned, but which are not yet integrated into the log.
-func WithPushback(maxOutstanding uint) func(*StorageOptions) {
-	return func(o *StorageOptions) {
+func WithPushback(maxOutstanding uint) func(*options.StorageOptions) {
+	return func(o *options.StorageOptions) {
 		o.PushbackMaxOutstanding = maxOutstanding
 	}
 }

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -46,7 +46,8 @@ import (
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
-	"github.com/transparency-dev/trillian-tessera/storage/internal"
+	"github.com/transparency-dev/trillian-tessera/internal/options"
+	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
@@ -70,9 +71,9 @@ type Storage struct {
 	projectID string
 	bucket    string
 
-	newCP       tessera.NewCPFunc
-	parseCP     tessera.ParseCPFunc
-	entriesPath tessera.EntriesPathFunc
+	newCP       options.NewCPFunc
+	parseCP     options.ParseCPFunc
+	entriesPath options.EntriesPathFunc
 
 	sequencer sequencer
 	objStore  objStore
@@ -113,7 +114,7 @@ type Config struct {
 }
 
 // New creates a new instance of the GCP based Storage.
-func New(ctx context.Context, cfg Config, opts ...func(*tessera.StorageOptions)) (*Storage, error) {
+func New(ctx context.Context, cfg Config, opts ...func(*options.StorageOptions)) (*Storage, error) {
 	opt := storage.ResolveStorageOptions(opts...)
 	if opt.PushbackMaxOutstanding == 0 {
 		opt.PushbackMaxOutstanding = DefaultPushbackMaxOutstanding

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -114,7 +114,7 @@ type Config struct {
 
 // New creates a new instance of the GCP based Storage.
 func New(ctx context.Context, cfg Config, opts ...func(*tessera.StorageOptions)) (*Storage, error) {
-	opt := tessera.ResolveStorageOptions(opts...)
+	opt := storage.ResolveStorageOptions(opts...)
 	if opt.PushbackMaxOutstanding == 0 {
 		opt.PushbackMaxOutstanding = DefaultPushbackMaxOutstanding
 	}

--- a/storage/internal/options.go
+++ b/storage/internal/options.go
@@ -17,8 +17,8 @@ package storage
 import (
 	"time"
 
-	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/internal/options"
 )
 
 const (
@@ -27,8 +27,8 @@ const (
 )
 
 // ResolveStorageOptions turns a variadic array of storage options into a StorageOptions instance.
-func ResolveStorageOptions(opts ...func(*tessera.StorageOptions)) *tessera.StorageOptions {
-	defaults := &tessera.StorageOptions{
+func ResolveStorageOptions(opts ...func(*options.StorageOptions)) *options.StorageOptions {
+	defaults := &options.StorageOptions{
 		BatchMaxSize: DefaultBatchMaxSize,
 		BatchMaxAge:  DefaultBatchMaxAge,
 		EntriesPath:  layout.EntriesPath,

--- a/storage/internal/options.go
+++ b/storage/internal/options.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"time"
+
+	tessera "github.com/transparency-dev/trillian-tessera"
+	"github.com/transparency-dev/trillian-tessera/api/layout"
+)
+
+const (
+	DefaultBatchMaxSize = 256
+	DefaultBatchMaxAge  = 250 * time.Millisecond
+)
+
+// ResolveStorageOptions turns a variadic array of storage options into a StorageOptions instance.
+func ResolveStorageOptions(opts ...func(*tessera.StorageOptions)) *tessera.StorageOptions {
+	defaults := &tessera.StorageOptions{
+		BatchMaxSize: DefaultBatchMaxSize,
+		BatchMaxAge:  DefaultBatchMaxAge,
+		EntriesPath:  layout.EntriesPath,
+	}
+	for _, opt := range opts {
+		opt(defaults)
+	}
+	return defaults
+}

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -27,6 +27,7 @@ import (
 	"github.com/transparency-dev/merkle/rfc6962"
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api"
+	options "github.com/transparency-dev/trillian-tessera/internal/options"
 	"github.com/transparency-dev/trillian-tessera/storage/internal"
 	"k8s.io/klog/v2"
 )
@@ -49,13 +50,13 @@ type Storage struct {
 	db    *sql.DB
 	queue *storage.Queue
 
-	newCheckpoint   tessera.NewCPFunc
-	parseCheckpoint tessera.ParseCPFunc
+	newCheckpoint   options.NewCPFunc
+	parseCheckpoint options.ParseCPFunc
 }
 
 // New creates a new instance of the MySQL-based Storage.
 // Note that `tessera.WithCheckpointSignerVerifier()` is mandatory in the `opts` argument.
-func New(ctx context.Context, db *sql.DB, opts ...func(*tessera.StorageOptions)) (*Storage, error) {
+func New(ctx context.Context, db *sql.DB, opts ...func(*options.StorageOptions)) (*Storage, error) {
 	opt := storage.ResolveStorageOptions(opts...)
 	s := &Storage{
 		db:              db,

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -56,7 +56,7 @@ type Storage struct {
 // New creates a new instance of the MySQL-based Storage.
 // Note that `tessera.WithCheckpointSignerVerifier()` is mandatory in the `opts` argument.
 func New(ctx context.Context, db *sql.DB, opts ...func(*tessera.StorageOptions)) (*Storage, error) {
-	opt := tessera.ResolveStorageOptions(opts...)
+	opt := storage.ResolveStorageOptions(opts...)
 	s := &Storage{
 		db:              db,
 		newCheckpoint:   opt.NewCP,

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -32,6 +32,7 @@ import (
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
+	options "github.com/transparency-dev/trillian-tessera/internal/options"
 	"github.com/transparency-dev/trillian-tessera/storage/mysql"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
@@ -133,7 +134,7 @@ func TestNew(t *testing.T) {
 
 	for _, test := range []struct {
 		name    string
-		opts    []func(*tessera.StorageOptions)
+		opts    []func(*options.StorageOptions)
 		wantErr bool
 	}{
 		{
@@ -143,13 +144,13 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name: "standard tessera.WithCheckpointSignerVerifier",
-			opts: []func(*tessera.StorageOptions){
+			opts: []func(*options.StorageOptions){
 				tessera.WithCheckpointSignerVerifier(noteSigner, noteVerifier),
 			},
 		},
 		{
 			name: "all tessera.StorageOption",
-			opts: []func(*tessera.StorageOptions){
+			opts: []func(*options.StorageOptions){
 				tessera.WithCheckpointSignerVerifier(noteSigner, noteVerifier),
 				tessera.WithBatching(1, 1*time.Second),
 				tessera.WithPushback(10),

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -28,6 +28,7 @@ import (
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/internal/options"
 	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
 	"k8s.io/klog/v2"
 )
@@ -47,10 +48,10 @@ type Storage struct {
 	cpFile *os.File
 
 	curSize uint64
-	newCP   tessera.NewCPFunc
-	parseCP tessera.ParseCPFunc
+	newCP   options.NewCPFunc
+	parseCP options.ParseCPFunc
 
-	entriesPath tessera.EntriesPathFunc
+	entriesPath options.EntriesPathFunc
 }
 
 // NewTreeFunc is the signature of a function which receives information about newly integrated trees.
@@ -59,7 +60,7 @@ type NewTreeFunc func(size uint64, root []byte) error
 // New creates a new POSIX storage.
 // - path is a directory in which the log should be stored
 // - create must only be set when first creating the log, and will create the directory structure and an empty checkpoint
-func New(ctx context.Context, path string, create bool, opts ...func(*tessera.StorageOptions)) (*Storage, error) {
+func New(ctx context.Context, path string, create bool, opts ...func(*options.StorageOptions)) (*Storage, error) {
 	opt := storage.ResolveStorageOptions(opts...)
 
 	r := &Storage{

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -60,7 +60,7 @@ type NewTreeFunc func(size uint64, root []byte) error
 // - path is a directory in which the log should be stored
 // - create must only be set when first creating the log, and will create the directory structure and an empty checkpoint
 func New(ctx context.Context, path string, create bool, opts ...func(*tessera.StorageOptions)) (*Storage, error) {
-	opt := tessera.ResolveStorageOptions(opts...)
+	opt := storage.ResolveStorageOptions(opts...)
 
 	r := &Storage{
 		path:        path,


### PR DESCRIPTION
I'm looking over https://pkg.go.dev/github.com/transparency-dev/trillian-tessera and making it clearer to newcomers.

This moves fields and types into internal, which is more refined approach to the file-based solution taken thus far to #280.
