### PR TITLE
Fix hammer auth header too

### DIFF
--- a/internal/hammer/client.go
+++ b/internal/hammer/client.go
@@ -87,7 +87,7 @@ func newFetcher(root *url.URL) fetcher {
 			klog.Exitf("NewHTTPFetcher: %v", err)
 		}
 		if *bearerToken != "" {
-			c.SetAuthorizationHeader(fmt.Sprintf("Bearer: %s", *bearerToken))
+			c.SetAuthorizationHeader(fmt.Sprintf("Bearer %s", *bearerToken))
 		}
 		return c
 	case "file":


### PR DESCRIPTION
This PR fixes an error in the `Authorization` header used by the hammer client.