### PR TITLE
Generate duplicates over whole log range

### DIFF
--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"context"
-	crand "crypto/rand"
 	"crypto/tls"
 	"errors"
 	"flag"
@@ -369,11 +368,15 @@ func (a *HammerAnalyser) errorLoop(ctx context.Context) {
 // startSize should be set to the initial size of the log so that repeated runs of the
 // hammer can start seeding leaves to avoid duplicates with previous runs.
 func newLeafGenerator(startSize uint64, minLeafSize int, dupChance float64) func() []byte {
+	// genLeaf MUST be determinstic given n
 	genLeaf := func(n uint64) []byte {
 		// Make a slice with half the number of requested bytes since we'll
 		// hex-encode them below which gets us back up to the full amount.
 		filler := make([]byte, minLeafSize/2)
-		_, _ = crand.Read(filler)
+		source := rand.New(rand.NewPCG(0, n))
+		for i := range filler {
+			filler[i] = byte(source.Int())
+		}
 		return []byte(fmt.Sprintf("%x %d", filler, n))
 	}
 

--- a/internal/hammer/hammer_test.go
+++ b/internal/hammer/hammer_test.go
@@ -21,6 +21,25 @@ import (
 	"time"
 )
 
+func TestLeafGenerator(t *testing.T) {
+	// Always generate new values
+	gN := newLeafGenerator(0, 100, 0)
+	vs := make(map[string]bool)
+	for range 256 {
+		v := string(gN())
+		vs[v] = true
+	}
+
+	// Always generate duplicate
+	gD := newLeafGenerator(256, 100, 100)
+	for range 256 {
+		v := string(gD())
+		if !vs[v] {
+			t.Error("Expected duplicate")
+		}
+	}
+}
+
 func TestHammerAnalyser_Stats(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/hammer/hammer_test.go
+++ b/internal/hammer/hammer_test.go
@@ -31,7 +31,7 @@ func TestLeafGenerator(t *testing.T) {
 	}
 
 	// Always generate duplicate
-	gD := newLeafGenerator(256, 100, 100)
+	gD := newLeafGenerator(256, 100, 1.0)
 	for range 256 {
 		if !vs[string(gD())] {
 			t.Error("Expected duplicate")

--- a/internal/hammer/hammer_test.go
+++ b/internal/hammer/hammer_test.go
@@ -33,8 +33,7 @@ func TestLeafGenerator(t *testing.T) {
 	// Always generate duplicate
 	gD := newLeafGenerator(256, 100, 100)
 	for range 256 {
-		v := string(gD())
-		if !vs[v] {
+		if !vs[string(gD())] {
 			t.Error("Expected duplicate")
 		}
 	}


### PR DESCRIPTION
Previously this would only create consecutive duplicates. Now it can create duplicates covering the whole rangeof the log.
This fixes #293.

Also made the threading semantics clearer, as this was performing reads and writes from multiple threads on an unprotected uint64.
