### PR TITLE
Fix GCP ReadEntryBundle to use configured path

### DIFF
--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -188,7 +188,7 @@ func (s *Storage) ReadTile(ctx context.Context, l, i, sz uint64) ([]byte, error)
 }
 
 func (s *Storage) ReadEntryBundle(ctx context.Context, i, sz uint64) ([]byte, error) {
-	return s.get(ctx, layout.EntriesPath(i, sz))
+	return s.get(ctx, s.entriesPath(i, sz))
 }
 
 // get returns the requested object.


### PR DESCRIPTION
This PR fixes a bug in the GCP `ReadEntryBundle` implementation, which would have broken attempts to read from Static CT API logs.