### PR TITLE
Handle index overflow

### DIFF
--- a/api/layout/paths.go
+++ b/api/layout/paths.go
@@ -132,6 +132,9 @@ func ParseTileIndexWidth(index string) (uint64, uint64, error) {
 		if err != nil || n >= 1000 || len(indexPath) != 3 {
 			return 0, 0, fmt.Errorf("failed to parse tile index")
 		}
+		if c.N > (math.MaxUint64-n)/1000 {
+			return 0, 0, fmt.Errorf("failed to parse tile index")
+		}
 		i = i*1000 + n
 	}
 

--- a/api/layout/paths_test.go
+++ b/api/layout/paths_test.go
@@ -340,6 +340,11 @@ func TestParseTileLevelIndexWidth(t *testing.T) {
 			pathIndex: "x001/002.p/256",
 			wantErr:   true,
 		},
+		{
+			pathLevel: "63",
+			pathIndex: "x999/x999/x999/x999/x999/x999/999.p/255",
+			wantErr:   true,
+		},
 	} {
 		desc := fmt.Sprintf("pathLevel: %q, pathIndex: %q", test.pathLevel, test.pathIndex)
 		t.Run(desc, func(t *testing.T) {


### PR DESCRIPTION
Handle index overflow by comparing index against MaxUint64. Add test for overflow case.
