### PR TITLE
Conformance binary for AWS

### DIFF
--- a/cmd/conformance/aws/Dockerfile
+++ b/cmd/conformance/aws/Dockerfile
@@ -15,10 +15,10 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN go build -o bin/conformance-gcp ./cmd/conformance/gcp
+RUN go build -o bin/conformance-aws ./cmd/conformance/aws
 
 # Build release image
 FROM alpine:3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
 
-COPY --from=builder /build/bin/conformance-gcp /bin/conformance-gcp
-ENTRYPOINT ["/bin/conformance-gcp"]
+COPY --from=builder /build/bin/conformance-aws /bin/conformance-aws
+ENTRYPOINT ["/bin/conformance-aws"]

--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -131,10 +131,10 @@ func storageConfigFromFlags() aws.Config {
 	}
 
 	dbEndpoint := fmt.Sprintf("%s:%d", *dbHost, *dbPort)
-
 	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?allowCleartextPasswords=true",
 		*dbUser, *dbPassword, dbEndpoint, *dbName,
 	)
+
 	return aws.Config{
 		Bucket:       *bucket,
 		DSN:          dsn,

--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -130,7 +130,7 @@ func storageConfigFromFlags() aws.Config {
 		klog.Exit("--db_password must be set")
 	}
 
-	var dbEndpoint string = fmt.Sprintf("%s:%d", *dbHost, *dbPort)
+	dbEndpoint := fmt.Sprintf("%s:%d", *dbHost, *dbPort)
 
 	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?allowCleartextPasswords=true",
 		*dbUser, *dbPassword, dbEndpoint, *dbName,


### PR DESCRIPTION
Towards #24 and #312 

Verified that `docker build -f ./cmd/conformance/aws/Dockerfile .` works.

This PR uses password based authentication for now, which is good enough to start with. I've tested IAM based authentication, which works. Let's get all the terraform in with passwords, and then we can eventually move to IAM.

While we're there, get rid for verifiers in `signerFromFlags` since we don't use them anymore.