### PR TITLE
attempt to improve log messages

### DIFF
--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -405,20 +405,20 @@ func (s *Storage) updateEntryBundles(ctx context.Context, fromSeq uint64, entrie
 		numAdded++
 		if entriesInBundle == entryBundleSize {
 			//  This bundle is full, so we need to write it out...
-			klog.V(1).Infof("Bundle idx %d staged to be written to S3 is full, attempting write", bundleIndex)
+			klog.V(1).Infof("In-memory bundle idx %d is full, attempting write to S3", bundleIndex)
 			goSetEntryBundle(ctx, bundleIndex, fromSeq, bundleWriter.Bytes())
 			// ... and prepare the next entry bundle for any remaining entries in the batch
 			bundleIndex++
 			entriesInBundle = 0
 			// Don't use Reset/Truncate here - the backing []bytes is still being used by goSetEntryBundle above.
 			bundleWriter = &bytes.Buffer{}
-			klog.V(1).Infof("Starting to stage bundle idx %d to be written to S3", bundleIndex)
+			klog.V(1).Infof("Starting to fill in-memory bundle idx %d", bundleIndex)
 		}
 	}
 	// If we have a partial bundle remaining once we've added all the entries from the batch,
 	// this needs writing out too.
 	if entriesInBundle > 0 {
-		klog.V(1).Infof("Attempting to write staged partial bundle idx %d.%d to S3", bundleIndex, entriesInBundle)
+		klog.V(1).Infof("Attempting to write in-memory partial bundle idx %d.%d to S3", bundleIndex, entriesInBundle)
 		goSetEntryBundle(ctx, bundleIndex, fromSeq, bundleWriter.Bytes())
 	}
 	return seqErr.Wait()

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -405,20 +405,20 @@ func (s *Storage) updateEntryBundles(ctx context.Context, fromSeq uint64, entrie
 		numAdded++
 		if entriesInBundle == entryBundleSize {
 			//  This bundle is full, so we need to write it out...
-			klog.V(1).Infof("Bundle idx %d is full", bundleIndex)
+			klog.V(1).Infof("Bundle idx %d staged to be written to S3 is full, attempting write", bundleIndex)
 			goSetEntryBundle(ctx, bundleIndex, fromSeq, bundleWriter.Bytes())
 			// ... and prepare the next entry bundle for any remaining entries in the batch
 			bundleIndex++
 			entriesInBundle = 0
 			// Don't use Reset/Truncate here - the backing []bytes is still being used by goSetEntryBundle above.
 			bundleWriter = &bytes.Buffer{}
-			klog.V(1).Infof("Starting bundle idx %d", bundleIndex)
+			klog.V(1).Infof("Starting to stage bundle idx %d to be written to S3", bundleIndex)
 		}
 	}
 	// If we have a partial bundle remaining once we've added all the entries from the batch,
 	// this needs writing out too.
 	if entriesInBundle > 0 {
-		klog.V(1).Infof("Writing partial bundle idx %d.%d", bundleIndex, entriesInBundle)
+		klog.V(1).Infof("Attempting to write staged partial bundle idx %d.%d to S3", bundleIndex, entriesInBundle)
 		goSetEntryBundle(ctx, bundleIndex, fromSeq, bundleWriter.Bytes())
 	}
 	return seqErr.Wait()

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -391,20 +391,20 @@ func (s *Storage) updateEntryBundles(ctx context.Context, fromSeq uint64, entrie
 		numAdded++
 		if entriesInBundle == entryBundleSize {
 			//  This bundle is full, so we need to write it out...
-			klog.V(1).Infof("Bundle idx %d staged to be written to GCS is full, attempting write", bundleIndex)
+			klog.V(1).Infof("In-memory bundle idx %d is full, attempting write to GCS", bundleIndex)
 			goSetEntryBundle(ctx, bundleIndex, fromSeq, bundleWriter.Bytes())
 			// ... and prepare the next entry bundle for any remaining entries in the batch
 			bundleIndex++
 			entriesInBundle = 0
 			// Don't use Reset/Truncate here - the backing []bytes is still being used by goSetEntryBundle above.
 			bundleWriter = &bytes.Buffer{}
-			klog.V(1).Infof("Starting to stage bundle idx %d to be written to GCS", bundleIndex)
+			klog.V(1).Infof("Starting to fill in-memory bundle idx %d", bundleIndex)
 		}
 	}
 	// If we have a partial bundle remaining once we've added all the entries from the batch,
 	// this needs writing out too.
 	if entriesInBundle > 0 {
-		klog.V(1).Infof("Attempting to write staged partial bundle idx %d.%d to GCS", bundleIndex, entriesInBundle)
+		klog.V(1).Infof("Attempting to write in-memory partial bundle idx %d.%d to GCS", bundleIndex, entriesInBundle)
 		goSetEntryBundle(ctx, bundleIndex, fromSeq, bundleWriter.Bytes())
 	}
 	return seqErr.Wait()

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -391,20 +391,20 @@ func (s *Storage) updateEntryBundles(ctx context.Context, fromSeq uint64, entrie
 		numAdded++
 		if entriesInBundle == entryBundleSize {
 			//  This bundle is full, so we need to write it out...
-			klog.V(1).Infof("Bundle idx %d is full", bundleIndex)
+			klog.V(1).Infof("Bundle idx %d staged to be written to GCS is full, attempting write", bundleIndex)
 			goSetEntryBundle(ctx, bundleIndex, fromSeq, bundleWriter.Bytes())
 			// ... and prepare the next entry bundle for any remaining entries in the batch
 			bundleIndex++
 			entriesInBundle = 0
 			// Don't use Reset/Truncate here - the backing []bytes is still being used by goSetEntryBundle above.
 			bundleWriter = &bytes.Buffer{}
-			klog.V(1).Infof("Starting bundle idx %d", bundleIndex)
+			klog.V(1).Infof("Starting to stage bundle idx %d to be written to GCS", bundleIndex)
 		}
 	}
 	// If we have a partial bundle remaining once we've added all the entries from the batch,
 	// this needs writing out too.
 	if entriesInBundle > 0 {
-		klog.V(1).Infof("Writing partial bundle idx %d.%d", bundleIndex, entriesInBundle)
+		klog.V(1).Infof("Attempting to write staged partial bundle idx %d.%d to GCS", bundleIndex, entriesInBundle)
 		goSetEntryBundle(ctx, bundleIndex, fromSeq, bundleWriter.Bytes())
 	}
 	return seqErr.Wait()


### PR DESCRIPTION
These messages attempt to better reflect hat:
 - the bundle in S3/GCS are do not necessarily exist yet
 - write are attempted, but preconditions might prevent them from happening

Context: I wanted to double check what would happen in real life if bad data was already written to a tile / entry. I created a dummy entry bundle life idx X beyond the current checkpoint, and launched the hammer. I was a bit confused to see "Bundle idx X is full" in the log messages, since I knew that the precondition should have avoided Tessera from writing a bundle at entry X.

Please, a better wording suggestion is more than welcome!