### PR TITLE
AWS backend terraform + Readme

### DIFF
--- a/deployment/live/aws/conformance/ci/README.md
+++ b/deployment/live/aws/conformance/ci/README.md
@@ -1,0 +1,40 @@
+# AWS Conformance Configs
+
+Work in progress.
+
+## Prequisites
+
+You'll need to have configured the right IAM permissions to create S3 buckets
+and RDS databases, and configured a local AWS profile that can make use of
+these permissions. For instance, 
+
+TODO(phboneff): establish what's the minimum set of permissions we need, and list
+them here.
+
+## Manual deployment
+
+Configure an AWS profile on your workstation using your prefered method, (e.g
+[sso](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html)
+or [credential
+files](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html))
+
+Set the required environment variables:
+```bash
+export AWS_PROFILE={VALUE}
+```
+
+Optionally, customize the AWS region (defaults to "us-east-1"), prefix, and base
+name for resources (defaults to "trillian-tessera" and "conformance"):
+```bash
+export AWS_REGION={VALUE}
+export TESSERA_BASE_NAME={VALUE}
+export TESSERA_PREFIX_NAME={VALUE}
+```
+
+Resources will be named using a `${TESSERA_PREFIX_NAME}-${TESSERA_BASE_NAME}`
+convention.
+
+Terraforming the project can be done by:
+ 1. `cd` to the relevant directory for the environment to deploy/change (e.g. `ci`)
+ 2. Run `terragrunt apply`
+

--- a/deployment/live/aws/conformance/ci/terragrunt.hcl
+++ b/deployment/live/aws/conformance/ci/terragrunt.hcl
@@ -1,0 +1,10 @@
+terraform {
+  source = "${get_repo_root()}/deployment/modules/aws//storage"
+}
+
+include "root" {
+  path   = find_in_parent_folders()
+  expose = true
+}
+
+inputs = include.root.locals

--- a/deployment/live/aws/conformance/terragrunt.hcl
+++ b/deployment/live/aws/conformance/terragrunt.hcl
@@ -1,0 +1,28 @@
+terraform {
+  source = "${get_repo_root()}/deployment/modules/aws//storage"
+}
+
+locals {
+  env         = path_relative_to_include()
+  account_id  = "${get_aws_account_id()}"
+  region      = get_env("AWS_REGION", "us-east-1")
+  profile     = get_env("AWS_PROFILE", "default")
+  base_name   = get_env("TESSERA_BASE_NAME", "${local.env}-conformance")
+  prefix_name = get_env("TESSERA_PREFIX_NAME", "trillian-tessera")
+  ephemeral   = true
+}
+
+remote_state {
+  backend = "s3"
+
+  config = {
+    region         = local.region
+    profile        = local.profile
+    bucket         = "${local.prefix_name}-${local.base_name}-terraform-state"
+    key            = "${local.env}/terraform.tfstate"
+    dynamodb_table = "${local.prefix_name}-${local.base_name}-terraform-lock"
+    s3_bucket_tags = {
+      name = "terraform_state_storage"
+    }
+  }
+}

--- a/deployment/modules/aws/storage/main.tf
+++ b/deployment/modules/aws/storage/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "5.76.0"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  name = "${var.prefix_name}-${var.base_name}"
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  region = var.region
+}
+
+# Resources
+
+## S3 Bucket
+resource "aws_s3_bucket" "log_bucket" {
+  bucket = "${local.name}-bucket"
+  force_destroy = var.ephemeral
+}
+
+## Aurora MySQL RDS database
+resource "aws_rds_cluster" "log_rds" {
+  apply_immediately       = true
+  cluster_identifier      = "${local.name}-cluster"
+  engine                  = "aurora-mysql"
+  # TODO(phboneff): make sure that we want to pin this
+  engine_version          = "8.0.mysql_aurora.3.05.2"
+  database_name           = "tessera"
+  master_username         = "root"
+  master_password         = "password"
+  skip_final_snapshot     = true
+  backup_retention_period = 0
+}
+
+resource "aws_rds_cluster_instance" "cluster_instances" {
+  count              = 1
+  identifier         = "${local.name}-writer-${count.index}"
+  cluster_identifier = aws_rds_cluster.log_rds.id
+  instance_class     = "db.r5.large"
+  engine             = aws_rds_cluster.log_rds.engine
+  engine_version     = aws_rds_cluster.log_rds.engine_version
+}

--- a/deployment/modules/aws/storage/main.tf
+++ b/deployment/modules/aws/storage/main.tf
@@ -36,12 +36,15 @@ resource "aws_rds_cluster" "log_rds" {
   engine_version          = "8.0.mysql_aurora.3.05.2"
   database_name           = "tessera"
   master_username         = "root"
+  # TODO(phboneff): move to either random strings / Secret Manager / IAM
   master_password         = "password"
   skip_final_snapshot     = true
   backup_retention_period = 0
 }
 
 resource "aws_rds_cluster_instance" "cluster_instances" {
+  # TODO(phboneff): make some of these variables and/or
+  # tweak some of these.
   count              = 1
   identifier         = "${local.name}-writer-${count.index}"
   cluster_identifier = aws_rds_cluster.log_rds.id

--- a/deployment/modules/aws/storage/variables.tf
+++ b/deployment/modules/aws/storage/variables.tf
@@ -1,0 +1,19 @@
+variable "prefix_name" {
+  description = "Common prefix to use when naming resources, ensures unicity of the s3 bucket name."
+  type        = string
+}
+
+variable "base_name" {
+  description = "Common name to use when naming resources"
+  type        = string
+}
+
+variable "region" {
+  description = "Region in which to create resources"
+  type        = string
+}
+
+variable "ephemeral" {
+  description = "Set to true if this is a throwaway/temporary log instance. Will set attributes on created resources to allow them to be disabled/deleted more easily."
+  type = bool
+}


### PR DESCRIPTION
Towards #312

This PR introduces Terraform for AWS storage backend. More work is underway for the other components, see #312.

Putting aside the fact that this runs on AWS (RDS + S3) rather than GCP (Spanner + GCS) , other differences are:
 - AWS doesn't really have a concept of human readable project IDs, project IDs are numbers, so I've introduced a human readable "prefix" used across resources instead
 - Terragrunt on GCP uses GCS precondition to lock state. That's not an option (yet?) on AWS, it uses a DynamoDB database