### PR TITLE
Remove color from terragrunt/terraform log in GCP Cloud Build

### DIFF
--- a/deployment/modules/gcp/cloudbuild/main.tf
+++ b/deployment/modules/gcp/cloudbuild/main.tf
@@ -39,7 +39,7 @@ resource "google_cloudbuild_trigger" "docker" {
       id         = "preclean_env"
       name       = "alpine/terragrunt"
       script     = <<EOT
-        terragrunt --terragrunt-non-interactive destroy -auto-approve 2>&1
+        terragrunt --terragrunt-non-interactive --terragrunt-no-color destroy -auto-approve -no-color 2>&1
       EOT
       dir = "deployment/live/gcp/conformance/ci"
       env = [
@@ -94,7 +94,7 @@ resource "google_cloudbuild_trigger" "docker" {
       name   = "alpine/terragrunt"
       script = <<EOT
         export TESSERA_SIGNER=$(cat /workspace/key.sec)
-        terragrunt --terragrunt-non-interactive apply -auto-approve 2>&1
+        terragrunt --terragrunt-non-interactive --terragrunt-no-color apply -auto-approve -no-color 2>&1
       EOT
       dir    = "deployment/live/gcp/conformance/ci"
       env = [
@@ -160,7 +160,7 @@ resource "google_cloudbuild_trigger" "docker" {
       id         = "terraform_destroy_conformance_ci"
       name       = "alpine/terragrunt"
       script     = <<EOT
-        terragrunt --terragrunt-non-interactive destroy -auto-approve 2>&1
+        terragrunt --terragrunt-non-interactive --terragrunt-no-color destroy -auto-approve -no-color 2>&1
       EOT
       dir = "deployment/live/gcp/conformance/ci"
       env = [


### PR DESCRIPTION
The existing Cloud Build log is full of the color formatting sequences in the output. Removing them improves the log readability.

```
2024-11-20 16:36:08.304 GMT
Step #0 - "preclean_env": [0;90m16:36:08.303 [0m[0;37mSTDOUT [0m[0;36mterraform: [0m[0m[1mInitializing the backend...[0m[0m
2024-11-20 16:36:08.386 GMT
Step #0 - "preclean_env": [0;90m16:36:08.385 [0m[0;37mSTDOUT [0m[0;36mterraform: [0m[0m[32m[0m
2024-11-20 16:36:08.386 GMT
Step #0 - "preclean_env": [0;90m16:36:08.385 [0m[0;37mSTDOUT [0m[0;36mterraform: [0mSuccessfully configured the backend "gcs"! Terraform will automatically
2024-11-20 16:36:08.386 GMT
Step #0 - "preclean_env": [0;90m16:36:08.386 [0m[0;37mSTDOUT [0m[0;36mterraform: [0muse this backend unless the backend configuration changes.[0m[0m
2024-11-20 16:36:08.565 GMT
Step #0 - "preclean_env": [0;90m16:36:08.565 [0m[0;37mSTDOUT [0m[0;36mterraform: [0m[0m[1mInitializing modules...[0m[0m
2024-11-20 16:36:08.567 GMT
Step #0 - "preclean_env": [0;90m16:36:08.567 [0m[0;37mSTDOUT [0m[0;36mterraform: [0m- gcs in ../gcs
2024-11-20 16:36:08.568 GMT
Step #0 - "preclean_env": [0;90m16:36:08.568 [0m[0;37mSTDOUT [0m[0;36mterraform: [0m[0m[1mInitializing provider plugins...[0m[0m
2024-11-20 16:36:08.568 GMT
Step #0 - "preclean_env": [0;90m16:36:08.568 [0m[0;37mSTDOUT [0m[0;36mterraform: [0m- Reusing previous version of hashicorp/google from the dependency lock file
2024-11-20 16:36:08.872 GMT
Step #0 - "preclean_env": [0;90m16:36:08.872 [0m[0;37mSTDOUT [0m[0;36mterraform: [0m- Installing hashicorp/g
```