### PR TITLE
Fix integration test expectations

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -134,7 +134,7 @@ func TestLiveLogIntegration(t *testing.T) {
 	errG := errgroup.Group{}
 	for i := range *testEntrySize {
 		errG.Go(func() error {
-			index, err := entryWriter.add(ctx, []byte(fmt.Sprint(i)))
+			index, err := entryWriter.add(ctx, []byte(fmt.Sprintf("%d", i)))
 			if err != nil {
 				return fmt.Errorf("entryWriter.add(%d): %v", i, err)
 			}
@@ -185,7 +185,7 @@ func TestLiveLogIntegration(t *testing.T) {
 			t.Errorf("client.GetEntryBundle: %v", err)
 		}
 
-		got, want := entryBundle.Entries[index%256], []byte(fmt.Sprint(data))
+		got, want := entryBundle.Entries[index%256], []byte(fmt.Sprintf("%d", data))
 		if !bytes.Equal(got, want) {
 			t.Errorf("Entry bundle (index: %d) got %v want %v", index, got, want)
 		}


### PR DESCRIPTION
This PR makes the integration test more resilient to the log behaviour introduced in #333.

Currently the integration test will likely work the first time it's run, but if it's run a second time against the same log, it will likely fail when fewer entries than it expected were added to the log due to deduping.

The changes in this PR remove that assumption about size of tree growth, but the test continues to verify that all entries are nonetheless present.