### PR TITLE
[GCP] Make the GCP conformance deployment config more friendly

### DIFF
--- a/cmd/conformance/gcp/README.md
+++ b/cmd/conformance/gcp/README.md
@@ -1,0 +1,6 @@
+# Conformance testing binary for GCP
+
+This binary is primarily intended to be used for checking Tessera conformance on GCP.
+
+If you want to try running it yourself, please see the instructions in the 
+[README file in the /deployment/live/gcp/conformance directory](/deployment/live/gcp/conformance).

--- a/deployment/live/gcp/conformance/README.md
+++ b/deployment/live/gcp/conformance/README.md
@@ -12,7 +12,7 @@ reading from, and writing to, the log.
 ## Automatic deployment
 
 For the most part, this terragrunt config is automatically used as part of conformance
-testing by the [CloudBuild](/deployment/live/gcp/cloudbuild) pipeline, so doesn't generally
+testing by the [Cloud Build](/deployment/live/gcp/cloudbuild) pipeline, so doesn't generally
 need to be manually applied.
 
 ## Manual deployment 
@@ -28,57 +28,40 @@ You'll need the following tools installed:
    + [`opentofu`](https://opentofu.org/docs/intro/install/)
 - [`terragrunt`](https://terragrunt.gruntwork.io/docs/getting-started/install/)
 
+#### Google Cloud tooling
 
-### Process
+Ensure you've got already created a project you want to use, and have configured your local `gcloud`
+tool use use it, and authenticated as a principle with sufficient ACLs for the project:
 
-First ensure you've got the right Google Cloud project configured, and authenticate via `gcloud`
-as a principle with sufficient ACLs for the project:
 ```bash
-gcloud config get project
 gcloud config set project {YOUR PROJECT}
 gcloud auth application-default login
 ```
 
-You will need to build and push the image created by [/cmd/conformance/gcp/Dockerfile] somewhere.
-Google Artifact Registry is one option: https://cloud.google.com/build/docs/build-push-docker-image
-
-Note that it's not currently possible to _build_ the docker image with Google Cloud Build (this is because
-building from the root directory but referencing Dockerfile in a subdirectory isn't supported), but you can
-configure your local `docker` to get access to Artifact Registry using the gcloud CLI credential helper, and
-then build locally and push to Artifact Registry. Details on this can be found in the link above.
-
-```bash
-$ gcloud artifacts repositories create ${DOCKER_REPO_NAME} \
-        --repository-format=docker \
-        --location=us-central1 \
-        --description="My Tessera docker repo" \
-        --immutable-tags
-
-$ gcloud auth configure-docker us-central1-docker.pkg.dev
-
-$ docker build . -f ./cmd/conformance/gcp/Dockerfile --tag us-central1-docker.pkg.dev/${YOUR_GCP_PROJECT}/${DOCKER_REPO_NAME}/conformance:latest
-
-$ docker push us-central1-docker.pkg.dev/${YOUR_GCP_PROJECT}/${DOCKER_REPO_NAME}/conformance:latest
-
-```
+#### Set environment variables
 
 Set the required environment variables:
 ```bash
 # The ID of the Google Cloud Project you're deploying into
-export GOOGLE_PROJECT={VALUE}
+export GOOGLE_PROJECT=$(gcloud config get project)
 
-# This should be a note signer string
+# This should be a note signer string.
+# You can use the generate_keys tool to create a new signer & verifier pair:
+#   go run github.com/transparency-dev/serverless-log/cmd/generate_keys@HEAD --key_name="TestTessera" 
 export TESSERA_SIGNER={VALUE}
+
+# This is the name of the artifact registry docker repo to create/use.
+export DOCKER_REPO_NAME=tessera-docker
 
 # A docker image built from /cmd/conformance/gcp/Dockerfile
 # Use the name/tag from the docker image you built above.
-export TESSERA_CLOUD_RUN_DOCKER_IMAGE=us-central1-docker.pkg.dev/${YOUR_GCP_PROJECT}/${DOCKER_REPO_NAME}/conformance:latest
+export TESSERA_CLOUD_RUN_DOCKER_IMAGE=us-central1-docker.pkg.dev/${GOOGLE_PROJECT}/${DOCKER_REPO_NAME}/conformance:latest
 
 ```
 
-Optionally, set the envrionment variables below to customize the deployment:
+Optionally, set the environment variables below to customize the deployment:
 ```bash
-# GCP region to deply into (defaults to us-central1)
+# GCP region to deploy into (defaults to us-central1)
 export GOOGLE_REGION={VALUE} 
 
 # This is used as part of resource names, using this variable will allow you to have multiple deployments in a single project.
@@ -97,7 +80,50 @@ export TESSERA_READER={VALUE}
 export TESSERA_WRITER={VALUE}
 ```
 
+#### Set up artifact registry
+
+First, create a new artifact registry based Docker repo:
+
+```bash
+$ gcloud artifacts repositories create ${DOCKER_REPO_NAME} \
+        --repository-format=docker \
+        --location=us-central1 \
+        --description="My Tessera docker repo" \
+        --immutable-tags
+```
+
+Then authorize your local `docker` command to be able to interact with it:
+
+```bash
+$ gcloud auth configure-docker us-central1-docker.pkg.dev
+```
+
+### Process
+
+#### Build & push docker image
+
+You will need to build and push the image created by the
+[the /cmd/conformance/gcp/Dockerfile](/cmd/conformance/gcp/Dockerfile) somewhere.
+Google Artifact Registry is one option: https://cloud.google.com/build/docs/build-push-docker-image
+
+Note that it's not currently possible to _build_ the docker image with Google Cloud Build (this is because
+building from the root directory but referencing Dockerfile in a subdirectory isn't supported), but you can
+configure your local `docker` to get access to Artifact Registry using the gcloud CLI credential helper, and
+then build locally and push to Artifact Registry. Details on this can be found in the link above.
+
+```bash
+$ docker build . -f ./cmd/conformance/gcp/Dockerfile --tag us-central1-docker.pkg.dev/${YOUR_GCP_PROJECT}/${DOCKER_REPO_NAME}/conformance:latest
+
+$ docker push us-central1-docker.pkg.dev/${YOUR_GCP_PROJECT}/${DOCKER_REPO_NAME}/conformance:latest
+
+```
+
+#### Terragrunt apply
+
 Finally, apply the config using `terragrunt`:
+
  1. `cd` to the relevant directory for the environment to deploy/change (e.g. `ci`)
  2. Run `terragrunt apply`
 
+This should create all necessary infrastructure, and spin up a Cloud Run instance with the
+docker image you created above.

--- a/deployment/live/gcp/conformance/README.md
+++ b/deployment/live/gcp/conformance/README.md
@@ -1,12 +1,5 @@
 # GCP Conformance Configs
 
-## Prerequisites
-
-You'll need to have already configured/created whatever service accounts + IAM permissions
-you require, and update the terragrunt files here to match.
-
-## Overview
-
 This config uses the [gcp/conformance](/deployment/modules/gcp/conformance) module to
 define a conformance testing environment. At a high level, this environment consists of:
 - Spanner DB,
@@ -24,27 +17,87 @@ need to be manually applied.
 
 ## Manual deployment 
 
-First authenticate via `gcloud` as a principle with sufficient ACLs for
-the project:
+### Prerequisites
+
+You'll need the following tools installed:
+
+- [`docker`](https://docs.docker.com/engine/install/)
+- [`gcloud`](https://cloud.google.com/sdk/docs/install)
+- One of:
+   + [`terraform`](https://developer.hashicorp.com/terraform/install) or
+   + [`opentofu`](https://opentofu.org/docs/intro/install/)
+- [`terragrunt`](https://terragrunt.gruntwork.io/docs/getting-started/install/)
+
+
+### Process
+
+First ensure you've got the right Google Cloud project configured, and authenticate via `gcloud`
+as a principle with sufficient ACLs for the project:
 ```bash
+gcloud config get project
+gcloud config set project {YOUR PROJECT}
 gcloud auth application-default login
+```
+
+You will need to build and push the image created by [/cmd/conformance/gcp/Dockerfile] somewhere.
+Google Artifact Registry is one option: https://cloud.google.com/build/docs/build-push-docker-image
+
+Note that it's not currently possible to _build_ the docker image with Google Cloud Build (this is because
+building from the root directory but referencing Dockerfile in a subdirectory isn't supported), but you can
+configure your local `docker` to get access to Artifact Registry using the gcloud CLI credential helper, and
+then build locally and push to Artifact Registry. Details on this can be found in the link above.
+
+```bash
+$ gcloud artifacts repositories create ${DOCKER_REPO_NAME} \
+        --repository-format=docker \
+        --location=us-central1 \
+        --description="My Tessera docker repo" \
+        --immutable-tags
+
+$ gcloud auth configure-docker us-central1-docker.pkg.dev
+
+$ docker build . -f ./cmd/conformance/gcp/Dockerfile --tag us-central1-docker.pkg.dev/${YOUR_GCP_PROJECT}/${DOCKER_REPO_NAME}/conformance:latest
+
+$ docker push us-central1-docker.pkg.dev/${YOUR_GCP_PROJECT}/${DOCKER_REPO_NAME}/conformance:latest
+
 ```
 
 Set the required environment variables:
 ```bash
+# The ID of the Google Cloud Project you're deploying into
 export GOOGLE_PROJECT={VALUE}
-export TESSERA_SIGNER={VALUE} # This should be a note signer string
-export TESSERA_VERIFIER={VALUE} # This should be a note verifier string, correspoding to the provided signer.
+
+# This should be a note signer string
+export TESSERA_SIGNER={VALUE}
+
+# A docker image built from /cmd/conformance/gcp/Dockerfile
+# Use the name/tag from the docker image you built above.
+export TESSERA_CLOUD_RUN_DOCKER_IMAGE=us-central1-docker.pkg.dev/${YOUR_GCP_PROJECT}/${DOCKER_REPO_NAME}/conformance:latest
+
 ```
 
-Optionally, customize the GCP region (defaults to "us-central1"),
-and bucket name prefix (defaults to "conformance"):
+Optionally, set the envrionment variables below to customize the deployment:
 ```bash
-export GOOGLE_REGION={VALUE}
-export TESSERA_BASE_NAME={VALUE}
+# GCP region to deply into (defaults to us-central1)
+export GOOGLE_REGION={VALUE} 
+
+# This is used as part of resource names, using this variable will allow you to have multiple deployments in a single project.
+export TESSERA_BASE_NAME={VALUE} 
+
+# This allows you to specify the email of an existing service account which should be used by Cloud Run.
+# By default, the project's default service account will be used.
+export TESSERA_CLOUD_RUN_SERVICE_ACCOUNT={VALUE}
+
+# This allows configuration of which users are allowed to read from the GCS bucket containing the t-log tiles.
+# To make the bucket public, set this to "allUsers".
+export TESSERA_READER={VALUE}
+
+# This allows configuration of which users are allowed to make HTTP requests to the Cloud Run instance, e.g. to add entries to the t-log.
+# By default, only the project's default service account is permitted.
+export TESSERA_WRITER={VALUE}
 ```
 
-Terraforming the project can be done by:
+Finally, apply the config using `terragrunt`:
  1. `cd` to the relevant directory for the environment to deploy/change (e.g. `ci`)
  2. Run `terragrunt apply`
 

--- a/deployment/live/gcp/conformance/ci/README.md
+++ b/deployment/live/gcp/conformance/ci/README.md
@@ -1,0 +1,3 @@
+# GCP Conformance CI config
+
+See the [README in the parent directory](../README.md) for detailed instructions on how to use the config in this directory.

--- a/deployment/live/gcp/conformance/ci/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/ci/terragrunt.hcl
@@ -10,6 +10,5 @@ include "root" {
 inputs = merge(
   include.root.locals,
   {
-    server_docker_image = "us-central1-docker.pkg.dev/trillian-tessera/docker-prod/conformance-gcp:latest"
   }
 )

--- a/deployment/live/gcp/conformance/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/terragrunt.hcl
@@ -9,11 +9,11 @@ locals {
   base_name                    = get_env("TESSERA_BASE_NAME", "${local.env}-conformance")
   conformance_gcp_docker_image = "${local.location}-docker.pkg.dev/trillian-tessera/docker-${local.env}/conformance-gcp:latest"
   signer                       = get_env("TESSERA_SIGNER")
-  verifier                     = get_env("TESSERA_VERIFIER")
-  # Service accounts are managed externally:
-  conformance_writers          = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
-  conformance_readers          = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
-  cloudrun_service_account     = "cloudrun-${local.env}-sa@trillian-tessera.iam.gserviceaccount.com"
+  tessera_reader               = get_env("TESSERA_READER", "")
+  tessera_writer               = get_env("TESSERA_WRITER", "")
+  conformance_readers          = length(local.tessera_reader) > 0 ? [local.tessera_reader] : []
+  conformance_writers          = length(local.tessera_writer) > 0 ? [local.tessera_writer] : []
+  cloudrun_service_account     = get_env("TESSERA_CLOUD_RUN_SERVICE_ACCOUNT", "")
 }
 
 remote_state {

--- a/deployment/live/gcp/conformance/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/terragrunt.hcl
@@ -11,9 +11,9 @@ locals {
   signer                       = get_env("TESSERA_SIGNER")
   verifier                     = get_env("TESSERA_VERIFIER")
   # Service accounts are managed externally:
-  conformance_users        = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
-  bucket_readers           = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
-  cloudrun_service_account = "cloudrun-${local.env}-sa@trillian-tessera.iam.gserviceaccount.com"
+  conformance_writers          = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
+  conformance_readers          = ["serviceAccount:cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com"]
+  cloudrun_service_account     = "cloudrun-${local.env}-sa@trillian-tessera.iam.gserviceaccount.com"
 }
 
 remote_state {

--- a/deployment/live/gcp/conformance/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/terragrunt.hcl
@@ -3,17 +3,17 @@ terraform {
 }
 
 locals {
-  env                          = path_relative_to_include()
-  project_id                   = get_env("GOOGLE_PROJECT")
-  location                     = get_env("GOOGLE_REGION", "us-central1")
-  base_name                    = get_env("TESSERA_BASE_NAME", "${local.env}-conformance")
-  server_docker_image          = get_env("TESSERA_CLOUD_RUN_DOCKER_IMAGE")
-  signer                       = get_env("TESSERA_SIGNER")
-  tessera_reader               = get_env("TESSERA_READER", "")
-  tessera_writer               = get_env("TESSERA_WRITER", "")
-  conformance_readers          = length(local.tessera_reader) > 0 ? [local.tessera_reader] : []
-  conformance_writers          = length(local.tessera_writer) > 0 ? [local.tessera_writer] : []
-  cloudrun_service_account     = get_env("TESSERA_CLOUD_RUN_SERVICE_ACCOUNT", "")
+  env                      = path_relative_to_include()
+  project_id               = get_env("GOOGLE_PROJECT")
+  location                 = get_env("GOOGLE_REGION", "us-central1")
+  base_name                = get_env("TESSERA_BASE_NAME", "${local.env}-conformance")
+  server_docker_image      = get_env("TESSERA_CLOUD_RUN_DOCKER_IMAGE")
+  signer                   = get_env("TESSERA_SIGNER")
+  tessera_reader           = get_env("TESSERA_READER", "")
+  tessera_writer           = get_env("TESSERA_WRITER", "")
+  conformance_readers      = length(local.tessera_reader) > 0 ? [local.tessera_reader] : []
+  conformance_writers      = length(local.tessera_writer) > 0 ? [local.tessera_writer] : []
+  cloudrun_service_account = get_env("TESSERA_CLOUD_RUN_SERVICE_ACCOUNT", "")
 }
 
 remote_state {

--- a/deployment/live/gcp/conformance/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/terragrunt.hcl
@@ -4,10 +4,10 @@ terraform {
 
 locals {
   env                          = path_relative_to_include()
-  project_id                   = get_env("GOOGLE_PROJECT", "trillian-tessera")
+  project_id                   = get_env("GOOGLE_PROJECT")
   location                     = get_env("GOOGLE_REGION", "us-central1")
   base_name                    = get_env("TESSERA_BASE_NAME", "${local.env}-conformance")
-  conformance_gcp_docker_image = "${local.location}-docker.pkg.dev/trillian-tessera/docker-${local.env}/conformance-gcp:latest"
+  server_docker_image          = get_env("TESSERA_CLOUD_RUN_DOCKER_IMAGE")
   signer                       = get_env("TESSERA_SIGNER")
   tessera_reader               = get_env("TESSERA_READER", "")
   tessera_writer               = get_env("TESSERA_WRITER", "")

--- a/deployment/modules/gcp/cloudbuild/main.tf
+++ b/deployment/modules/gcp/cloudbuild/main.tf
@@ -44,6 +44,7 @@ resource "google_cloudbuild_trigger" "docker" {
       dir    = "deployment/live/gcp/conformance/ci"
       env = [
         "TESSERA_SIGNER=unused",
+        "TESSERA_CLOUD_RUN_DOCKER_IMAGE=${local.conformance_gcp_docker_image}:latest",
         "TESSERA_CLOUD_RUN_SERVICE_ACCOUNT=cloudrun-ci-sa@trillian-tessera.iam.gserviceaccount.com",
         "TESSERA_READER=cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com",
         "TESSERA_WRITER=cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com",
@@ -101,6 +102,7 @@ resource "google_cloudbuild_trigger" "docker" {
       dir    = "deployment/live/gcp/conformance/ci"
       env = [
         "GOOGLE_PROJECT=${var.project_id}",
+        "TESSERA_CLOUD_RUN_DOCKER_IMAGE=${local.conformance_gcp_docker_image}:latest",
         "TESSERA_CLOUD_RUN_SERVICE_ACCOUNT=cloudrun-ci-sa@trillian-tessera.iam.gserviceaccount.com",
         "TESSERA_READER=cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com",
         "TESSERA_WRITER=cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com",
@@ -170,9 +172,10 @@ resource "google_cloudbuild_trigger" "docker" {
       dir    = "deployment/live/gcp/conformance/ci"
       env = [
         "TESSERA_SIGNER=unused",
+        "TESSERA_CLOUD_RUN_DOCKER_IMAGE=${local.conformance_gcp_docker_image}:latest",
+        "TESSERA_CLOUD_RUN_SERVICE_ACCOUNT=cloudrun-ci-sa@trillian-tessera.iam.gserviceaccount.com",
         "TESSERA_READER=cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com",
         "TESSERA_WRITER=cloudbuild-prod-sa@trillian-tessera.iam.gserviceaccount.com",
-        "TESSERA_CLOUD_RUN_SERVICE_ACCOUNT=cloudrun-ci-sa@trillian-tessera.iam.gserviceaccount.com",
         "GOOGLE_PROJECT=${var.project_id}",
         "TF_IN_AUTOMATION=1",
         "TF_INPUT=false",

--- a/deployment/modules/gcp/conformance/main.tf
+++ b/deployment/modules/gcp/conformance/main.tf
@@ -13,7 +13,7 @@ data "google_compute_default_service_account" "default" {
 }
 
 locals {
-  readers = length(var.conformance_readers) < 0 ? var.conformance_readers : ["serviceAccount:${data.google_compute_default_service_account.default.email}"]
+  readers = length(var.conformance_readers) > 0 ? var.conformance_readers : ["serviceAccount:${data.google_compute_default_service_account.default.email}"]
   writers = length(var.conformance_writers) > 0 ? var.conformance_writers : ["serviceAccount:${data.google_compute_default_service_account.default.email}"]
   cloudrun_service_account = length(var.cloudrun_service_account) > 0 ? var.cloudrun_service_account : data.google_compute_default_service_account.default.email
 }

--- a/deployment/modules/gcp/conformance/variables.tf
+++ b/deployment/modules/gcp/conformance/variables.tf
@@ -29,16 +29,16 @@ variable "signer" {
 }
 
 variable "cloudrun_service_account" {
-  description = "The service account email to use for the CloudRun instance"
+  description = "The service account email to use for the CloudRun instance. If unset, uses the project default service account."
   type        = string
 }
 
 variable "conformance_users" {
-  description = "The list of users allowed to invoke calls to the conformance instance."
+  description = "The list of users allowed to invoke HTTP calls to the conformance Cloud Run instance. If unset, only the project default service account will be able to send requests."
   type        = list(any)
 }
 
 variable "bucket_readers" {
-  description = "The list of users allowed to read the conformance bucket contents"
+  description = "The list of users allowed to read the conformance t-log resources from GCS. If unset, only the project default service account will be able to read the t-log contents."
   type        = list(any)
 }

--- a/deployment/modules/gcp/conformance/variables.tf
+++ b/deployment/modules/gcp/conformance/variables.tf
@@ -33,12 +33,12 @@ variable "cloudrun_service_account" {
   type        = string
 }
 
-variable "conformance_users" {
+variable "conformance_writers" {
   description = "The list of users allowed to invoke HTTP calls to the conformance Cloud Run instance. If unset, only the project default service account will be able to send requests."
   type        = list(any)
 }
 
-variable "bucket_readers" {
+variable "conformance_readers" {
   description = "The list of users allowed to read the conformance t-log resources from GCS. If unset, only the project default service account will be able to read the t-log contents."
   type        = list(any)
 }


### PR DESCRIPTION
This PR makes the `terra{grunt,form}` config for deploying the GCP conformance environment more friendly for humans to use when exploring Tessera.

The main changes are:
- Service accounts are now optional
- Docker image to use for CloudRun can be specified
- Docs updated to guide humans along the path to deploy 