### PR TITLE
[GCP Terraform] improved stability for deployment

### DIFF
--- a/deployment/modules/gcp/conformance/main.tf
+++ b/deployment/modules/gcp/conformance/main.tf
@@ -7,14 +7,19 @@ terraform {
       version = "6.1.0"
     }
   }
+
+  required_version = "= 1.9.8"
 }
 
 data "google_compute_default_service_account" "default" {
+  depends_on = [
+    google_project_service.compute_engine,
+  ]
 }
 
 locals {
-  readers = length(var.conformance_readers) > 0 ? var.conformance_readers : ["serviceAccount:${data.google_compute_default_service_account.default.email}"]
-  writers = length(var.conformance_writers) > 0 ? var.conformance_writers : ["serviceAccount:${data.google_compute_default_service_account.default.email}"]
+  readers                  = length(var.conformance_readers) > 0 ? var.conformance_readers : ["serviceAccount:${data.google_compute_default_service_account.default.email}"]
+  writers                  = length(var.conformance_writers) > 0 ? var.conformance_writers : ["serviceAccount:${data.google_compute_default_service_account.default.email}"]
   cloudrun_service_account = length(var.cloudrun_service_account) > 0 ? var.cloudrun_service_account : data.google_compute_default_service_account.default.email
 }
 
@@ -46,6 +51,11 @@ resource "google_project_service" "cloudrun_api" {
 
 resource "google_project_service" "compute_engine" {
   service            = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "spanner_api" {
+  service            = "spanner.googleapis.com"
   disable_on_destroy = false
 }
 

--- a/deployment/modules/gcp/conformance/main.tf
+++ b/deployment/modules/gcp/conformance/main.tf
@@ -54,11 +54,6 @@ resource "google_project_service" "compute_engine" {
   disable_on_destroy = false
 }
 
-resource "google_project_service" "spanner_api" {
-  service            = "spanner.googleapis.com"
-  disable_on_destroy = false
-}
-
 locals {
   spanner_db_full = "projects/${var.project_id}/instances/${module.gcs.log_spanner_instance.name}/databases/${module.gcs.log_spanner_db.name}"
 }


### PR DESCRIPTION
Added missing API, and pinned the version of terraform to a known working version. 1.10.0 was recently released which breaks this in a hard to debug way.
