### PR TITLE
Fix storage design doc broken links

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -94,9 +94,9 @@ can easily be constructed by third parties.
 Each of the provided storage implementations has an associated "one-pager" design doc which offers
 a detailed explanation of how it works:
 
-* [GCP](gcp_storage.md)
-* [MySQL](mysql_storage.md)
-* [POSIX filesystem](posix_storage.md)
+* [GCP](/storage/gcp/README.md)
+* [MySQL](/storage/mysql/DESIGN.md)
+* [POSIX filesystem](/storage/posix/README.md)
 
 Every storage implementation is required to expose a small number of fairly high-level APIs:
 

--- a/storage/mysql/README.md
+++ b/storage/mysql/README.md
@@ -4,7 +4,7 @@ This directory contains the implementation of a storage backend for Trillian Tes
 
 ## Design
 
-See [MySQL storage design documentation](/docs/design/mysql_storage.md).
+See [MySQL storage design documentation](/storage/mysql/DESIGN.md).
 
 ### Requirements
 


### PR DESCRIPTION
The links to the storage design are broken after moving them around in https://github.com/transparency-dev/trillian-tessera/pull/350.