### PR TITLE
[MySQL] make the tests go faster

### DIFF
--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -179,12 +179,14 @@ func TestGetTile(t *testing.T) {
 			func() error {
 				_, _, err := awaiter.Await(ctx, s.Add(ctx, tessera.NewEntry([]byte(fmt.Sprintf("TestGetTile %d", i)))))
 				if err != nil {
-					return fmt.Errorf("Failed to prep test with entry: %v", err)
+					return fmt.Errorf("failed to prep test with entry: %v", err)
 				}
 				return nil
 			})
 	}
-	wg.Wait()
+	if err := wg.Wait(); err != nil {
+		t.Fatalf("Failed to set up database with required leaves: %v", err)
+	}
 
 	for _, test := range []struct {
 		name                   string


### PR DESCRIPTION
Awaiting in the loop was causing this to take ages as it was doing one leaf at a time. They now happen in parallel, and we make sure they're all done before we allow the read parts of the test to start.
