### PR TITLE
Storage implementations enforce minimum checkpoint intervals

### DIFF
--- a/await.go
+++ b/await.go
@@ -16,7 +16,9 @@ package tessera
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -111,7 +113,7 @@ func (a *IntegrationAwaiter) pollLoop(ctx context.Context, readCheckpoint func(c
 		// Note that for now, this releases all clients in the event of a single failure.
 		// If this causes problems, this could be changed to attempt retries.
 		rawCp, err := readCheckpoint(ctx)
-		if err != nil {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			a.releaseClientsErr(fmt.Errorf("readCheckpoint: %v", err))
 			continue
 		}

--- a/cmd/examples/posix-oneshot/main.go
+++ b/cmd/examples/posix-oneshot/main.go
@@ -46,7 +46,7 @@ const (
 	// Since this is a short-lived command-line tool, we set this to a relatively low value so that
 	// the tool can publish the new checkpoint and exit relatively quickly after integrating the entries
 	// into the tree.
-	checkpointInterval = 500 * time.Millisecond
+	checkpointInterval = time.Second
 )
 
 // entryInfo binds the actual bytes to be added as a leaf with a

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -59,8 +59,10 @@ import (
 )
 
 const (
-	logContType  = "application/octet-stream"
-	ckptContType = "text/plain; charset=utf-8"
+	entryBundleSize       = 256
+	logContType           = "application/octet-stream"
+	ckptContType          = "text/plain; charset=utf-8"
+	minCheckpointInterval = 1 * time.Second
 
 	DefaultPushbackMaxOutstanding = 4096
 	DefaultIntegrationSizeLimit   = 5 * 4096
@@ -127,6 +129,9 @@ func New(ctx context.Context, cfg Config, opts ...func(*options.StorageOptions))
 	opt := storage.ResolveStorageOptions(opts...)
 	if opt.PushbackMaxOutstanding == 0 {
 		opt.PushbackMaxOutstanding = DefaultPushbackMaxOutstanding
+	}
+	if opt.CheckpointInterval < minCheckpointInterval {
+		return nil, fmt.Errorf("requested CheckpointInterval (%v) is less than minimum permitted %v", opt.CheckpointInterval, minCheckpointInterval)
 	}
 
 	sdkConfig, err := config.LoadDefaultConfig(ctx)

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -62,7 +62,7 @@ const (
 	entryBundleSize       = 256
 	logContType           = "application/octet-stream"
 	ckptContType          = "text/plain; charset=utf-8"
-	minCheckpointInterval = 1 * time.Second
+	minCheckpointInterval = time.Second
 
 	DefaultPushbackMaxOutstanding = 4096
 	DefaultIntegrationSizeLimit   = 5 * 4096

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -51,6 +51,8 @@ const (
 	checkpointID    = 0
 	treeStateID     = 0
 	entryBundleSize = 256
+
+	minCheckpointInterval = time.Second
 )
 
 // Storage is a MySQL-based storage implementation for Tessera.
@@ -67,6 +69,10 @@ type Storage struct {
 // Note that `tessera.WithCheckpointSigner()` is mandatory in the `opts` argument.
 func New(ctx context.Context, db *sql.DB, opts ...func(*options.StorageOptions)) (*Storage, error) {
 	opt := storage.ResolveStorageOptions(opts...)
+	if opt.CheckpointInterval < minCheckpointInterval {
+		return nil, fmt.Errorf("requested CheckpointInterval too low - %v < %v", opt.CheckpointInterval, minCheckpointInterval)
+	}
+
 	s := &Storage{
 		db:            db,
 		newCheckpoint: opt.NewCP,

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -465,10 +465,10 @@ func newTestMySQLStorage(t *testing.T, ctx context.Context) *mysql.Storage {
 
 	s, err := mysql.New(ctx, testDB,
 		tessera.WithCheckpointSigner(noteSigner),
-		tessera.WithCheckpointInterval(200*time.Millisecond),
+		tessera.WithCheckpointInterval(time.Second),
 		tessera.WithBatching(128, 100*time.Millisecond))
 	if err != nil {
-		t.Errorf("Failed to create mysql.Storage: %v", err)
+		t.Fatalf("Failed to create mysql.Storage: %v", err)
 	}
 
 	return s

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -39,6 +39,8 @@ const (
 	dirPerm  = 0o755
 	filePerm = 0o644
 	stateDir = ".state"
+
+	minCheckpointInterval = time.Second
 )
 
 // Storage implements storage functions for a POSIX filesystem.
@@ -64,6 +66,9 @@ type NewTreeFunc func(size uint64, root []byte) error
 // - create must only be set when first creating the log, and will create the directory structure and an empty checkpoint
 func New(ctx context.Context, path string, create bool, opts ...func(*options.StorageOptions)) (*Storage, error) {
 	opt := storage.ResolveStorageOptions(opts...)
+	if opt.CheckpointInterval < minCheckpointInterval {
+		return nil, fmt.Errorf("requested CheckpointInterval (%v) is less than minimum permitted %v", opt.CheckpointInterval, minCheckpointInterval)
+	}
 
 	r := &Storage{
 		path:        path,


### PR DESCRIPTION
This PR defines minimum checkpoint publication intervals for the storage implementations, and they will now return an error if an invalid interval is set via the `WithCheckpointInterval` option.