### PR TITLE
Replace `os.IsNotExist(err)` with `errors.Is(err, fs.ErrNotExist)`

### DIFF
--- a/cmd/conformance/mysql/main.go
+++ b/cmd/conformance/mysql/main.go
@@ -18,9 +18,11 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"time"
@@ -168,7 +170,7 @@ func configureTilesReadAPI(mux *http.ServeMux, storage *mysql.Storage) {
 		inferredMinTreeSize := (index*256 + width) << (level * 8)
 		tile, err := storage.ReadTile(r.Context(), level, index, inferredMinTreeSize)
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, fs.ErrNotExist) {
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -22,6 +22,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 	"time"
@@ -123,7 +124,7 @@ func (s *Storage) maybeInitTree(ctx context.Context) error {
 	}()
 
 	treeState, err := s.readTreeState(ctx, tx)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		klog.Errorf("Failed to read tree state: %v", err)
 		return err
 	}

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -24,8 +24,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"os"
 	"testing"
 	"time"
@@ -238,7 +240,7 @@ func TestGetTile(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tile, err := s.ReadTile(ctx, test.level, test.index, test.treeSize)
 			if err != nil {
-				if notFound, wantNotFound := os.IsNotExist(err), test.wantNotFound; notFound != wantNotFound {
+				if notFound, wantNotFound := errors.Is(err, fs.ErrNotExist), test.wantNotFound; notFound != wantNotFound {
 					t.Errorf("wantNotFound %v but notFound %v", wantNotFound, notFound)
 				}
 				if test.wantNotFound {
@@ -274,7 +276,7 @@ func TestReadMissingTile(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tile, err := s.ReadTile(ctx, test.level, test.index, test.width)
 			if err != nil {
-				if os.IsNotExist(err) {
+				if errors.Is(err, fs.ErrNotExist) {
 					// this is success for this test
 					return
 				}
@@ -307,7 +309,7 @@ func TestReadMissingEntryBundle(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			entryBundle, err := s.ReadEntryBundle(ctx, test.index, test.index)
 			if err != nil {
-				if os.IsNotExist(err) {
+				if errors.Is(err, fs.ErrNotExist) {
 					// this is success for this test
 					return
 				}


### PR DESCRIPTION
IsNotExist returns a boolean indicating whether its argument is known to report that a file or directory does not exist. It is satisfied by [ErrNotExist](https://golang.google.cn/pkg/os/#ErrNotExist) as well as some syscall errors.

This function predates [errors.Is](https://golang.google.cn/pkg/errors/#Is). It only supports errors returned by the os package. New code should use errors.Is(err, fs.ErrNotExist).

https://golang.google.cn/pkg/os/#IsNotExist