### PR TITLE
Added and updated benchmarks

### DIFF
--- a/api/state_test.go
+++ b/api/state_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -142,5 +143,21 @@ func TestLeafBundle_UnmarshalText(t *testing.T) {
 				t.Errorf("wantErr: %t, got %v", test.wantErr, err)
 			}
 		})
+	}
+}
+
+func BenchmarkLeafBundle_UnmarshalText(b *testing.B) {
+	bs := bytes.Buffer{}
+	for i := range 222 {
+		// Create leaves of different lengths for interest in the parsing / memory allocation
+		leafStr := strings.Repeat(fmt.Sprintf("Leaf %d", i), i%20)
+		_, _ = bs.Write(tessera.NewEntry([]byte(leafStr)).MarshalBundleData(uint64(i)))
+	}
+	rawBundle := bs.Bytes()
+	for i := 0; i < b.N; i++ {
+		tile := api.EntryBundle{}
+		if err := tile.UnmarshalText(rawBundle); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/storage/internal/integrate_test.go
+++ b/storage/internal/integrate_test.go
@@ -170,9 +170,8 @@ func BenchmarkIntegrate(b *testing.B) {
 	m := newMemTileStore[api.HashTile]()
 
 	chunkSize := 200
-	numChunks := 256
 	seq := uint64(0)
-	for chunk := 0; chunk < numChunks; chunk++ {
+	for chunk := 0; chunk < b.N; chunk++ {
 		oldSeq := seq
 		c := make([]SequencedEntry, chunkSize)
 		for i := range c {


### PR DESCRIPTION
Parsing entry bundles needs to be fast, so locked that in with a benchmark. While looking at other benchmarks, I noticed integrate wasn't using b.N, so wired that into the test instead of constant we already had to control the number of loops.
