### PR TITLE
[MySQL] complete entry bundle implementation

### DIFF
--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -315,7 +315,7 @@ func (s *Storage) ReadEntryBundle(ctx context.Context, index uint64, p uint8) ([
 	}
 
 	if requestedSize > size {
-		return nil, os.ErrNotExist
+		return nil, fmt.Errorf("bundle with %d entries requested, but only %d available: %w", requestedSize, size, os.ErrNotExist)
 	}
 
 	return entryBundle, nil

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -438,9 +438,9 @@ func TestEntryBundleRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Errorf("Add got err: %v", err)
 			}
-			entryBundleRaw, err := s.ReadEntryBundle(ctx, entryIndex/256, uint8(entryIndex%layout.TileWidth))
+			entryBundleRaw, err := s.ReadEntryBundle(ctx, entryIndex/256, uint8(entryIndex+1%layout.EntryBundleWidth))
 			if err != nil {
-				t.Errorf("ReadEntryBundle got err: %v", err)
+				t.Fatalf("ReadEntryBundle got err: %v", err)
 			}
 
 			bundle := api.EntryBundle{}

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -438,7 +438,7 @@ func TestEntryBundleRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Errorf("Add got err: %v", err)
 			}
-			entryBundleRaw, err := s.ReadEntryBundle(ctx, entryIndex/256, uint8(entryIndex+1%layout.EntryBundleWidth))
+			entryBundleRaw, err := s.ReadEntryBundle(ctx, entryIndex/256, layout.PartialTileSize(0, entryIndex, entryIndex+1))
 			if err != nil {
 				t.Fatalf("ReadEntryBundle got err: %v", err)
 			}

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -19,7 +19,7 @@
 -- on an indepentent timeframe to the internal updating of state.
 CREATE TABLE IF NOT EXISTS `Checkpoint` (
   -- id is expected to be always 0 to maintain a maximum of a single row.
-  `id`    INT UNSIGNED NOT NULL,
+  `id`    TINYINT UNSIGNED NOT NULL,
   -- note is the text signed by one or more keys in the checkpoint format. See https://c2sp.org/tlog-checkpoint and https://c2sp.org/signed-note.
   `note`  MEDIUMBLOB NOT NULL,
   -- published_at is the millisecond UNIX timestamp of when this row was written.
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS `Checkpoint` (
 -- This is not the same thing as a Checkpoint, which is a signed commitment to such a state.
 CREATE TABLE IF NOT EXISTS `TreeState` (
   -- id is expected to be always 0 to maintain a maximum of a single row.
-  `id`    INT UNSIGNED NOT NULL,
+  `id`    TINYINT UNSIGNED NOT NULL,
   -- size is the extent of the currently integrated tree.
   `size`  BIGINT UNSIGNED NOT NULL,
   -- root is the root hash of the tree at the size stored in `size`.
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS `TreeState` (
 -- "Subtree" table is an internal tile consisting of hashes. There is one row for each internal tile, and this is updated until it is completed, at which point it is immutable.
 CREATE TABLE IF NOT EXISTS `Subtree` (
   -- level is the level of the tile.
-  `level` INT UNSIGNED NOT NULL,
+  `level` TINYINT UNSIGNED NOT NULL,
   -- index is the index of the tile.
   `index` BIGINT UNSIGNED NOT NULL,
   -- nodes stores the hashes of the leaves.

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS `Subtree` (
 CREATE TABLE IF NOT EXISTS `TiledLeaves` (
   `tile_index` BIGINT UNSIGNED NOT NULL,
   -- size is the number of entries serialized into this leaf bundle.
-  `size`       INT UNSIGNED NOT NULL,
+  `size`       SMALLINT UNSIGNED NOT NULL,
   `data`       LONGBLOB NOT NULL,
   PRIMARY KEY(`tile_index`)
 );

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -53,6 +53,8 @@ CREATE TABLE IF NOT EXISTS `Subtree` (
 -- "TiledLeaves" table stores the data committed to by the leaves of the tree. Follows the same evolution as Subtree.
 CREATE TABLE IF NOT EXISTS `TiledLeaves` (
   `tile_index` BIGINT UNSIGNED NOT NULL,
+  -- size is the number of entries serialized into this leaf bundle.
+  `size`       INT UNSIGNED NOT NULL,
   `data`       LONGBLOB NOT NULL,
   PRIMARY KEY(`tile_index`)
 );


### PR DESCRIPTION
MySQL API now checks that the number of entries returned in a bundle is not smaller than the number requested. It does this by parsing the entry bundle. This could be optimized by storing the bundle size in the table.

Now this is fixed, the conformance personality is updated to set cache headers on the entry bundles to allow aggressive caching. Also fixed the checkpoint implementation to never cache, and handle not found properly.

This fixes #364.
