### PR TITLE
Just use layout.PartialTileSize

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -286,7 +286,7 @@ func (n *nodeCache) GetNode(ctx context.Context, id compact.NodeID) ([]byte, err
 // GetEntryBundle fetches the entry bundle at the given _tile index_.
 func GetEntryBundle(ctx context.Context, f EntryBundleFetcherFunc, i, logSize uint64) (api.EntryBundle, error) {
 	bundle := api.EntryBundle{}
-	sRaw, err := f(ctx, i, uint8(logSize%layout.EntryBundleWidth))
+	sRaw, err := f(ctx, i, layout.PartialTileSize(0, i, logSize))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return bundle, fmt.Errorf("leaf bundle at index %d not found: %v", i, err)

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -288,13 +288,13 @@ func TestBundleRoundtrip(t *testing.T) {
 				t.Fatalf("setEntryBundle: %v", err)
 			}
 
-			expPath := layout.EntriesPath(test.index, uint8(test.logSize%layout.EntryBundleWidth))
+			expPath := layout.EntriesPath(test.index, layout.PartialTileSize(0, test.index, test.logSize))
 			_, ok := m.mem[expPath]
 			if !ok {
 				t.Fatalf("want bundle at %v but found none", expPath)
 			}
 
-			got, err := s.getEntryBundle(ctx, test.index, uint8(test.logSize%layout.EntryBundleWidth))
+			got, err := s.getEntryBundle(ctx, test.index, layout.PartialTileSize(0, test.index, test.logSize))
 			if err != nil {
 				t.Fatalf("getEntryBundle: %v", err)
 			}


### PR DESCRIPTION
This PR fixes a bug introduced in #393 where an incorrect value for entry bundle width is calculated, which will frequently result in an entry bundle incorrectly not being found.