### PR TITLE
[Benchmarks] Comment on PRs with benchmark scores

### DIFF
--- a/.github/workflows/benchmark-go-main.yml
+++ b/.github/workflows/benchmark-go-main.yml
@@ -1,0 +1,38 @@
+name: Benchmark Go
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  # deployments permission to deploy GitHub pages website
+  deployments: write
+  # contents permission to update benchmark contents in gh-pages branch
+  contents: write
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.1.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run benchmark
+        run: set -o pipefail; go test ./... -benchmem -run=^$ -bench . | tee output.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4
+        with:
+          tool: 'go'
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: "150%"
+          fail-on-alert: true

--- a/.github/workflows/benchmark-go-pr.yml
+++ b/.github/workflows/benchmark-go-pr.yml
@@ -31,6 +31,7 @@ jobs:
           tool: 'go'
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
           alert-threshold: "150%"
           fail-on-alert: true
           comment-on-alert: true # notify on PR if alert triggers

--- a/.github/workflows/benchmark-go-pr.yml
+++ b/.github/workflows/benchmark-go-pr.yml
@@ -1,18 +1,11 @@
 name: Benchmark Go
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
 
 permissions:
-  # deployments permission to deploy GitHub pages website
-  deployments: write
-  # contents permission to update benchmark contents in gh-pages branch
-  contents: write
   # allow posting comments to pull request
   pull-requests: write
 
@@ -38,7 +31,6 @@ jobs:
           tool: 'go'
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
           alert-threshold: "150%"
           fail-on-alert: true
           comment-on-alert: true # notify on PR if alert triggers

--- a/.github/workflows/benchmark-go.yml
+++ b/.github/workflows/benchmark-go.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   # deployments permission to deploy GitHub pages website
@@ -37,5 +40,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           alert-threshold: "150%"
-          comment-on-alert: true
           fail-on-alert: true
+          comment-on-alert: true # notify on PR if alert triggers
+          summary-always: true # always comment on PRs to leave job summary


### PR DESCRIPTION
This should always leave a comment with a summary of benchmark results. Furthermore, if the alert threshold is triggered then it will leave another comment making it clear that this has happened.

I fully expect that we'll want to disable at least one of these, and possibly tune the alert threshold. But by starting with too much, it will be fast to see and back this off to a useful level.
