### PR TITLE
Add MigrationTarget lifecycle support

### DIFF
--- a/cmd/experimental/migrate/gcp/main.go
+++ b/cmd/experimental/migrate/gcp/main.go
@@ -1,0 +1,76 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// posix-migrate is a command-line tool for migrating data from a tlog-tiles
+// compliant log, into a Tessera log instance.
+package main
+
+import (
+	"context"
+	"flag"
+	"net/url"
+
+	"github.com/transparency-dev/trillian-tessera/client"
+	"github.com/transparency-dev/trillian-tessera/cmd/experimental/migrate/internal/migrate"
+	"github.com/transparency-dev/trillian-tessera/storage/gcp"
+	"k8s.io/klog/v2"
+)
+
+var (
+	bucket    = flag.String("bucket", "", "Bucket to use for storing log")
+	spanner   = flag.String("spanner", "", "Spanner resource URI ('projects/.../...')")
+	sourceURL = flag.String("source_url", "", "Base URL for the source log.")
+	stateDB   = flag.String("state_database", "migrate.sttate", "File to use for the temporary file used to track migration state.")
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+	ctx := context.Background()
+
+	srcURL, err := url.Parse(*sourceURL)
+	if err != nil {
+		klog.Exitf("Invalid --source_url %q: %v", *sourceURL, err)
+	}
+	src, err := client.NewHTTPFetcher(srcURL, nil)
+	if err != nil {
+		klog.Exitf("Failed to create HTTP fetcher: %v", err)
+	}
+
+	// Create our Tessera storage backend:
+	gcpCfg := storageConfigFromFlags()
+	st, err := gcp.NewMigrationTarget(ctx, gcpCfg)
+	if err != nil {
+		klog.Exitf("Failed to create new GCP storage: %v", err)
+	}
+
+	if err := migrate.Migrate(context.Background(), *stateDB, src.ReadCheckpoint, src.ReadTile, src.ReadEntryBundle, st); err != nil {
+		klog.Exitf("Migrate failed: %v", err)
+	}
+}
+
+// storageConfigFromFlags returns a gcp.Config struct populated with values
+// provided via flags.
+func storageConfigFromFlags() gcp.Config {
+	if *bucket == "" {
+		klog.Exit("--bucket must be set")
+	}
+	if *spanner == "" {
+		klog.Exit("--spanner must be set")
+	}
+	return gcp.Config{
+		Bucket:  *bucket,
+		Spanner: *spanner,
+	}
+}

--- a/cmd/experimental/migrate/internal/migrate/migrate.go
+++ b/cmd/experimental/migrate/internal/migrate/migrate.go
@@ -1,0 +1,184 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/client"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/klog/v2"
+)
+
+type migrate struct {
+	storage    MigrationStorage
+	getCP      client.CheckpointFetcherFunc
+	getTile    client.TileFetcherFunc
+	getEntries client.EntryBundleFetcherFunc
+
+	todo chan span
+
+	tilesToMigrate   uint64
+	bundlesToMigrate uint64
+	tilesMigrated    atomic.Uint64
+	bundlesMigrated  atomic.Uint64
+}
+
+// span represents the number of tiles at a given tile-level.
+type span struct {
+	level int
+	start uint64
+	N     uint64
+}
+
+type MigrationStorage interface {
+	SetTile(ctx context.Context, level, index uint64, partial uint8, tile []byte) error
+	SetEntryBundle(ctx context.Context, index uint64, partial uint8, bundle []byte) error
+	SetState(ctx context.Context, treeSize uint64, rootHash []byte) error
+}
+
+func Migrate(ctx context.Context, stateDB string, getCP client.CheckpointFetcherFunc, getTile client.TileFetcherFunc, getEntries client.EntryBundleFetcherFunc, storage MigrationStorage) error {
+	// TODO store state & resume
+	m := &migrate{
+		storage:    storage,
+		getCP:      getCP,
+		getTile:    getTile,
+		getEntries: getEntries,
+		todo:       make(chan span, 100),
+	}
+
+	// init
+	cp, err := getCP(ctx)
+	if err != nil {
+		return fmt.Errorf("fetch initial source checkpoint: %v", err)
+	}
+	bits := strings.Split(string(cp), "\n")
+	size, err := strconv.ParseUint(bits[1], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid CP size %q: %v", bits[1], err)
+	}
+	rootHash, err := base64.StdEncoding.DecodeString(bits[2])
+	if err != nil {
+		return fmt.Errorf("invalid checkpoint roothash %q: %v", bits[2], err)
+	}
+
+	// figure out what needs copying
+	go m.populateSpans(size)
+
+	// Print stats
+	go func() {
+		for {
+			time.Sleep(time.Second)
+			tn := m.tilesMigrated.Load()
+			tnp := float64(tn*100) / float64(m.tilesToMigrate)
+			bn := m.bundlesMigrated.Load()
+			bnp := float64(tn*100) / float64(m.bundlesToMigrate)
+			klog.Infof("tiles: %d (%.2f%%)  bundles: %d (%.2f%%)", tn, tnp, bn, bnp)
+		}
+	}()
+
+	// Do the copying
+	eg := errgroup.Group{}
+	for i := 0; i < 1000; i++ {
+		eg.Go(func() error {
+			return m.migrateRange(ctx)
+
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return fmt.Errorf("migrate failed to copy resources: %v", err)
+	}
+	return storage.SetState(ctx, size, rootHash)
+}
+
+func calcExpectedCounts(treeSize uint64) (uint64, uint64) {
+	tiles := uint64(0)
+	bundles := uint64(0)
+	levelSize := treeSize
+	for level := 0; levelSize > 0; level++ {
+		numFull, partial := levelSize/layout.TileWidth, levelSize%layout.TileWidth
+		n := numFull
+		if partial > 0 {
+			n++
+		}
+		tiles += n
+		if level == 0 {
+			bundles = n
+		}
+		levelSize >>= layout.TileHeight
+	}
+	return tiles, bundles
+}
+
+func (m *migrate) populateSpans(treeSize uint64) {
+	m.tilesToMigrate, m.bundlesToMigrate = calcExpectedCounts(treeSize)
+	klog.Infof("Spans for treeSize %d", treeSize)
+	klog.Infof("total resources to fetch %d tiles + %d bundles = %d", m.tilesToMigrate, m.bundlesToMigrate, m.tilesToMigrate+m.bundlesToMigrate)
+
+	levelSize := treeSize
+	for level := 0; levelSize > 0; level++ {
+		numFull, partial := levelSize/layout.TileWidth, levelSize%layout.TileWidth
+		for j := uint64(0); j < numFull; j++ {
+			m.todo <- span{level: level, start: j, N: layout.TileWidth}
+			if level == 0 {
+				m.todo <- span{level: -1, start: j, N: layout.TileWidth}
+			}
+		}
+		if partial > 0 {
+			m.todo <- span{level: level, start: numFull, N: partial}
+			if level == 0 {
+				m.todo <- span{level: -1, start: numFull, N: partial}
+			}
+
+		}
+		levelSize >>= layout.TileHeight
+	}
+	close(m.todo)
+}
+
+func (m *migrate) migrateRange(ctx context.Context) error {
+	for s := range m.todo {
+		if s.N == layout.TileWidth {
+			s.N = 0
+		}
+		if s.level == -1 {
+			d, err := m.getEntries(ctx, s.start, uint8(s.N))
+			if err != nil {
+				return fmt.Errorf("failed to fetch entrybundle %d (p=%d): %v", s.start, s.N, err)
+			}
+			if err := m.storage.SetEntryBundle(ctx, s.start, uint8(s.N), d); err != nil {
+				return fmt.Errorf("failed to store entrybundle %d (p=%d): %v", s.start, s.N, err)
+			}
+			m.bundlesMigrated.Add(1)
+		} else {
+			d, err := m.getTile(ctx, uint64(s.level), s.start, uint8(s.N))
+			if err != nil {
+				return fmt.Errorf("failed to fetch tile level %d index %d (p=%d): %v", s.level, s.start, s.N, err)
+			}
+			if err := m.storage.SetTile(ctx, uint64(s.level), s.start, uint8(s.N), d); err != nil {
+				return fmt.Errorf("failed to store tile level %d index %d (p=%d): %v", s.level, s.start, s.N, err)
+			}
+			m.tilesMigrated.Add(1)
+		}
+	}
+	return nil
+}

--- a/cmd/experimental/migrate/posix/main.go
+++ b/cmd/experimental/migrate/posix/main.go
@@ -19,8 +19,14 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
+	"io"
+	"net/http"
 	"net/url"
+	"strings"
 
+	tessera "github.com/transparency-dev/trillian-tessera"
+	"github.com/transparency-dev/trillian-tessera/api/layout"
 	"github.com/transparency-dev/trillian-tessera/client"
 	"github.com/transparency-dev/trillian-tessera/cmd/experimental/migrate/internal/migrate"
 	"github.com/transparency-dev/trillian-tessera/storage/posix"
@@ -46,14 +52,35 @@ func main() {
 	if err != nil {
 		klog.Exitf("Failed to create HTTP fetcher: %v", err)
 	}
+	// HACK CT:
+	readEntryBundle := func(ctx context.Context, i uint64, p uint8) ([]byte, error) {
+		up := strings.Replace(layout.EntriesPath(i, p), "entries", "data", 1)
+		reqURL, err := url.JoinPath(*sourceURL, up)
+		if err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		rsp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer rsp.Body.Close()
+		if rsp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GET %q: %v", req.URL.Path, rsp.Status)
+		}
+		return io.ReadAll(rsp.Body)
+	}
 
 	// Construct a new Tessera POSIX MigrationTarget log storage.
-	st, err := posix.NewMigrationTarget(ctx, *storageDir)
+	st, err := posix.NewMigrationTarget(ctx, *storageDir, tessera.WithCTLayout())
 	if err != nil {
 		klog.Exitf("Failed to construct storage: %v", err)
 	}
 
-	if err := migrate.Migrate(context.Background(), *stateDB, src.ReadCheckpoint, src.ReadTile, src.ReadEntryBundle, st); err != nil {
+	if err := migrate.Migrate(context.Background(), *stateDB, src.ReadCheckpoint, src.ReadTile, readEntryBundle, st); err != nil {
 		klog.Exitf("Migrate failed: %v", err)
 	}
 }

--- a/cmd/experimental/migrate/posix/main.go
+++ b/cmd/experimental/migrate/posix/main.go
@@ -1,0 +1,59 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// posix-migrate is a command-line tool for migrating data from a tlog-tiles
+// compliant log, into a Tessera log instance.
+package main
+
+import (
+	"context"
+	"flag"
+	"net/url"
+
+	"github.com/transparency-dev/trillian-tessera/client"
+	"github.com/transparency-dev/trillian-tessera/cmd/experimental/migrate/internal/migrate"
+	"github.com/transparency-dev/trillian-tessera/storage/posix"
+	"k8s.io/klog/v2"
+)
+
+var (
+	storageDir = flag.String("storage_dir", "", "Root directory to store log data.")
+	sourceURL  = flag.String("source_url", "", "Base URL for the source log.")
+	stateDB    = flag.String("state_database", "migrate.sttate", "File to use for the temporary file used to track migration state.")
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+	ctx := context.Background()
+
+	srcURL, err := url.Parse(*sourceURL)
+	if err != nil {
+		klog.Exitf("Invalid --source_url %q: %v", *sourceURL, err)
+	}
+	src, err := client.NewHTTPFetcher(srcURL, nil)
+	if err != nil {
+		klog.Exitf("Failed to create HTTP fetcher: %v", err)
+	}
+
+	// Construct a new Tessera POSIX MigrationTarget log storage.
+	st, err := posix.NewMigrationTarget(ctx, *storageDir)
+	if err != nil {
+		klog.Exitf("Failed to construct storage: %v", err)
+	}
+
+	if err := migrate.Migrate(context.Background(), *stateDB, src.ReadCheckpoint, src.ReadTile, src.ReadEntryBundle, st); err != nil {
+		klog.Exitf("Migrate failed: %v", err)
+	}
+}

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -993,10 +993,6 @@ func NewMigrationTarget(ctx context.Context, cfg Config, opts ...func(*options.S
 		entriesPath: opt.EntriesPath,
 	}
 
-	if err := r.init(ctx); err != nil {
-		return nil, fmt.Errorf("failed to initialise log storage: %v", err)
-	}
-
 	m := &MigrationStorage{
 		s:      r,
 		dbPool: seq.dbPool,

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -228,7 +228,11 @@ func TestTileRoundtrip(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			wantTile := makeTile(t, test.tileSize)
-			if err := s.setTile(ctx, test.level, test.index, test.logSize, wantTile); err != nil {
+			tRaw, err := wantTile.MarshalText()
+			if err != nil {
+				t.Fatalf("Failed to marshal tile: %v", err)
+			}
+			if err := s.setTile(ctx, test.level, test.index, layout.PartialTileSize(test.level, test.index, test.logSize), tRaw); err != nil {
 				t.Fatalf("setTile: %v", err)
 			}
 

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -207,16 +207,7 @@ func (s *Storage) sequenceBatch(ctx context.Context, entries []*tessera.Entry) e
 		}
 	}
 	writeBundle := func(bundleIndex uint64, partialSize uint8) error {
-		bf := filepath.Join(s.path, s.entriesPath(bundleIndex, partialSize))
-		if err := os.MkdirAll(filepath.Dir(bf), dirPerm); err != nil {
-			return fmt.Errorf("failed to make entries directory structure: %w", err)
-		}
-		if err := createExclusive(bf, currTile.Bytes()); err != nil {
-			if !errors.Is(err, os.ErrExist) {
-				return err
-			}
-		}
-		return nil
+		return s.writeBundle(ctx, bundleIndex, partialSize, currTile.Bytes())
 	}
 
 	seqEntries := make([]storage.SequencedEntry, 0, len(entries))
@@ -330,7 +321,7 @@ func (s *Storage) readTile(ctx context.Context, level, index uint64, p uint8) (*
 // Fully populated tiles are stored at the path corresponding to the level &
 // index parameters, partially populated (i.e. right-hand edge) tiles are
 // stored with a .xx suffix where xx is the number of "tile leaves" in hex.
-func (s *Storage) storeTile(_ context.Context, level, index, logSize uint64, tile *api.HashTile) error {
+func (s *Storage) storeTile(ctx context.Context, level, index, logSize uint64, tile *api.HashTile) error {
 	tileSize := uint64(len(tile.Nodes))
 	klog.V(2).Infof("StoreTile: level %d index %x ts: %x", level, index, tileSize)
 	if tileSize == 0 || tileSize > layout.TileWidth {
@@ -341,7 +332,11 @@ func (s *Storage) storeTile(_ context.Context, level, index, logSize uint64, til
 		return fmt.Errorf("failed to marshal tile: %w", err)
 	}
 
-	tPath := filepath.Join(s.path, layout.TilePath(level, index, layout.PartialTileSize(level, index, logSize)))
+	return s.writeTile(ctx, level, index, layout.PartialTileSize(level, index, logSize), t)
+}
+
+func (s *Storage) writeTile(_ context.Context, level, index uint64, partial uint8, t []byte) error {
+	tPath := filepath.Join(s.path, layout.TilePath(level, index, partial))
 	tDir := filepath.Dir(tPath)
 	if err := os.MkdirAll(tDir, dirPerm); err != nil {
 		return fmt.Errorf("failed to create directory %q: %w", tDir, err)
@@ -351,7 +346,7 @@ func (s *Storage) storeTile(_ context.Context, level, index, logSize uint64, til
 		return err
 	}
 
-	if tileSize == layout.TileWidth {
+	if partial == 0 {
 		partials, err := filepath.Glob(fmt.Sprintf("%s.p/*", tPath))
 		if err != nil {
 			return fmt.Errorf("failed to list partial tiles for clean up; %w", err)
@@ -373,6 +368,20 @@ func (s *Storage) storeTile(_ context.Context, level, index, logSize uint64, til
 		}
 	}
 
+	return nil
+}
+
+// writeBundle takes care of writing out the serialised entry bundle file.
+func (s *Storage) writeBundle(_ context.Context, index uint64, partial uint8, bundle []byte) error {
+	bf := filepath.Join(s.path, s.entriesPath(index, partial))
+	if err := os.MkdirAll(filepath.Dir(bf), dirPerm); err != nil {
+		return fmt.Errorf("failed to make entries directory structure: %w", err)
+	}
+	if err := createExclusive(bf, bundle); err != nil {
+		if !errors.Is(err, os.ErrExist) {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -496,4 +505,53 @@ func createExclusive(f string, d []byte) error {
 		return err
 	}
 	return nil
+}
+
+// NewMigrationTarget creates a new POSIX storage for the MigrationTarget lifecycle mode.
+// - path is a directory in which the log should be stored
+// - create must only be set when first creating the log, and will create the directory structure and an empty checkpoint
+func NewMigrationTarget(ctx context.Context, path string, opts ...func(*options.StorageOptions)) (*MigrationStorage, error) {
+	opt := storage.ResolveStorageOptions(opts...)
+
+	r := &MigrationStorage{
+		s: &Storage{
+			path:        path,
+			entriesPath: opt.EntriesPath,
+		},
+	}
+	klog.Infof("Initializing directory for POSIX log at %q", r.s.path)
+	if err := os.MkdirAll(filepath.Join(r.s.path, stateDir), dirPerm); err != nil {
+		return nil, fmt.Errorf("failed to create log directory: %q", err)
+	}
+
+	return r, nil
+}
+
+type MigrationStorage struct {
+	s *Storage
+}
+
+func (m *MigrationStorage) SetTile(ctx context.Context, level, index uint64, partial uint8, tile []byte) error {
+	return m.s.writeTile(ctx, index, level, partial, tile)
+}
+func (m *MigrationStorage) SetEntryBundle(ctx context.Context, index uint64, partial uint8, bundle []byte) error {
+	return m.s.writeBundle(ctx, index, partial, bundle)
+}
+func (m *MigrationStorage) SetState(ctx context.Context, treeSize uint64, rootHash []byte) error {
+	// Double locking:
+	// - The mutex `Lock()` ensures that multiple concurrent calls to this function within a task are serialised.
+	// - The POSIX `lockForTreeUpdate()` ensures that distinct tasks are serialised.
+	m.s.mu.Lock()
+	unlock, err := lockFile(filepath.Join(m.s.path, stateDir, "treeState.lock"))
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := unlock(); err != nil {
+			panic(err)
+		}
+		m.s.mu.Unlock()
+	}()
+
+	return m.s.writeTreeState(treeSize, rootHash)
 }


### PR DESCRIPTION
This PR adds an experimental `MigrationTarget` lifecycle type to the POSIX and GCP storage implementations, and adds an experimental tool for exercising them.

This code is exploring a mechanism to do a high-performance migration of data from one tlog-tiles compliant log into another; e.g. to allow Tessera operators to easily migrate their log from one storage infrastructure to another.

Rather than going through the sequencing "front door" or a pre-ordered type flow, this implementation operates at the level below, replicating static resources in an obscenely parallel fashion before updating the storage's private treeState. This means that, for example, the operator could, once migration was complete, run a Tessera-based frontend which operates in the `Appender` lifecycle mode (e.g. the conformance frontend) and have it take over the tree and [continue] to operate it as an append-only log in its new location.

The `main` files currently have a "HACK" commit each, which enables fetching from Static CT API compliant source logs - this is only because there aren't (m)any large publicly available tlog-tile compliant logs as yet.

Performance is resaonable: GCP migrated a log with 13712258 entries in 2m10s (~100k entries/s), and this would presumably scale further in a cloud -> cloud scenario with more migration workers.