### PR TITLE
Remove public from mysql conformance cache-control

### DIFF
--- a/cmd/conformance/mysql/main.go
+++ b/cmd/conformance/mysql/main.go
@@ -182,7 +182,7 @@ func configureTilesReadAPI(mux *http.ServeMux, storage *mysql.Storage) {
 			return
 		}
 
-		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		w.Header().Set("Cache-Control", "max-age=31536000, immutable")
 
 		if _, err := w.Write(tile); err != nil {
 			klog.Errorf("/tile/{level}/{index...}: %v", err)


### PR DESCRIPTION
This PR removes the `public` component of the `Cache-Control` header served by the MySQL conformance FE.

AFAICT `public` is the default, and only really needs to be added if the response is to a request which required the `Authorization` header, and that response should be made cacheable by public caches.

From https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#public :
> If a request doesn't have an Authorization header, or you are already using s-maxage or must-revalidate in the response, then you don't need to use public.