### PR TITLE
Integrate operates in terms of hashes

### DIFF
--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -428,7 +428,11 @@ func (s *Storage) integrate(ctx context.Context, fromSeq uint64, entries []stora
 	})
 
 	errG.Go(func() error {
-		newSize, root, tiles, err := storage.Integrate(ctx, getTiles, fromSeq, entries)
+		lh := make([][]byte, len(entries))
+		for i, e := range entries {
+			lh[i] = e.LeafHash
+		}
+		newSize, root, tiles, err := storage.Integrate(ctx, getTiles, fromSeq, lh)
 		if err != nil {
 			return fmt.Errorf("Integrate: %v", err)
 		}

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -382,7 +382,11 @@ func (s *Storage) integrate(ctx context.Context, fromSeq uint64, entries []stora
 			return n, nil
 		}
 
-		newSize, root, tiles, err := storage.Integrate(ctx, getTiles, fromSeq, entries)
+		lh := make([][]byte, len(entries))
+		for i, e := range entries {
+			lh[i] = e.LeafHash
+		}
+		newSize, root, tiles, err := storage.Integrate(ctx, getTiles, fromSeq, lh)
 		if err != nil {
 			return fmt.Errorf("Integrate: %v", err)
 		}

--- a/storage/internal/integrate_test.go
+++ b/storage/internal/integrate_test.go
@@ -130,14 +130,11 @@ func TestIntegrate(t *testing.T) {
 	seq := uint64(0)
 	for chunk := 0; chunk < numChunks; chunk++ {
 		oldSeq := seq
-		c := make([]SequencedEntry, chunkSize)
+		c := make([][]byte, chunkSize)
 		for i := range c {
 			leaf := []byte{byte(seq)}
 			entry := tessera.NewEntry(leaf)
-			c[i] = SequencedEntry{
-				BundleData: entry.MarshalBundleData(seq),
-				LeafHash:   entry.LeafHash(),
-			}
+			c[i] = entry.LeafHash()
 			if err := cr.Append(rfc6962.DefaultHasher.HashLeaf(leaf), nil); err != nil {
 				t.Fatalf("compact Append: %v", err)
 			}
@@ -173,14 +170,11 @@ func BenchmarkIntegrate(b *testing.B) {
 	seq := uint64(0)
 	for chunk := 0; chunk < b.N; chunk++ {
 		oldSeq := seq
-		c := make([]SequencedEntry, chunkSize)
+		c := make([][]byte, chunkSize)
 		for i := range c {
 			leaf := []byte{byte(seq)}
 			entry := tessera.NewEntry(leaf)
-			c[i] = SequencedEntry{
-				BundleData: entry.MarshalBundleData(seq),
-				LeafHash:   entry.LeafHash(),
-			}
+			c[i] = entry.LeafHash()
 			seq++
 		}
 		_, _, gotTiles, err := Integrate(ctx, m.getTiles, oldSeq, c)

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -501,7 +501,11 @@ func (s *Storage) integrate(ctx context.Context, tx *sql.Tx, fromSeq uint64, ent
 		}
 	}
 
-	newSize, newRoot, tiles, err := storage.Integrate(ctx, getTiles, fromSeq, sequencedEntries)
+	lh := make([][]byte, len(sequencedEntries))
+	for i, e := range sequencedEntries {
+		lh[i] = e.LeafHash
+	}
+	newSize, newRoot, tiles, err := storage.Integrate(ctx, getTiles, fromSeq, lh)
 	if err != nil {
 		return fmt.Errorf("tb.Integrate: %v", err)
 	}


### PR DESCRIPTION
This PR updates the integration helper to only require knowledge of leaf hashes, it should not need to know anything else about the leaves.

This minor change helps with modularity, and opens the door to using the helper in other log lifecycle modes (e.g. migration #436 ).
