### PR TITLE
Relax go version requirements

### DIFF
--- a/cmd/conformance/mysql/docker/Dockerfile
+++ b/cmd/conformance/mysql/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.7-bookworm@sha256:027bd04b1d3b4529bf8ccebf62eb7eeeae7b7bef134a68bd419824e929ad93ad AS build
+FROM golang:1.22.10-bookworm@sha256:027bd04b1d3b4529bf8ccebf62eb7eeeae7b7bef134a68bd419824e929ad93ad AS build
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/transparency-dev/trillian-tessera
 
-go 1.22.7
+go 1.22.0
+
+toolchain go1.22.10
 
 require (
 	cloud.google.com/go/spanner v1.73.0


### PR DESCRIPTION
This PR relaxes the go version requirement to allow users of the module to use any patch version of 1.22, with a local toolchain recommendation of 1.22.10.

Rationale similar to google/trillian#3713