### PR TITLE
Extract tighter-scoped integrate funcs in storage impls

### DIFF
--- a/storage/aws/README.md
+++ b/storage/aws/README.md
@@ -41,7 +41,7 @@ This table is used to coordinate integration of sequenced batches in the `Seq` t
    1. selects next from `SeqCoord` with for update ← this blocks other FE from writing their pools, but only for a short duration.
    1. Inserts batch of entries into `Seq` with key `SeqCoord.next`
    1. Update `SeqCoord` with `next+=len(batch)`
-1. Integrators periodically integrate new sequenced entries into the tree:
+1. Newly sequenced entries are periodically appended to the tree:
    In a transaction:
    1. select `seq` from `IntCoord` with for update ← this blocks other integrators from proceeding.
    1. Select one or more consecutive batches from `Seq` for update, starting at `IntCoord.seq`

--- a/storage/gcp/README.md
+++ b/storage/gcp/README.md
@@ -41,7 +41,7 @@ This table is used to coordinate integration of sequenced batches in the `Seq` t
    1. selects next from `SeqCoord` with for update ← this blocks other FE from writing their pools, but only for a short duration.
    1. Inserts batch of entries into `Seq` with key `SeqCoord.next`
    1. Update `SeqCoord` with `next+=len(batch)`
-1. Integrators periodically integrate new sequenced entries into the tree:
+1. Newly sequenced entries are periodically appended to the tree:
    In a transaction:
    1. select `seq` from `IntCoord` with for update ← this blocks other integrators from proceeding.
    1. Select one or more consecutive batches from `Seq` for update, starting at `IntCoord.seq`

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -228,7 +228,11 @@ func TestTileRoundtrip(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			wantTile := makeTile(t, test.tileSize)
-			if err := s.setTile(ctx, test.level, test.index, test.logSize, wantTile); err != nil {
+			tRaw, err := wantTile.MarshalText()
+			if err != nil {
+				t.Fatalf("Failed to marshal tile: %v", err)
+			}
+			if err := s.setTile(ctx, test.level, test.index, layout.PartialTileSize(test.level, test.index, test.logSize), tRaw); err != nil {
 				t.Fatalf("setTile: %v", err)
 			}
 

--- a/storage/posix/README.md
+++ b/storage/posix/README.md
@@ -33,7 +33,7 @@ of actions we can avoid corrupt or partially written files being part of the tre
 
 1. Leaves are submitted by the binary built using Tessera via a call the storage's `Add` func.
 1. The storage library batches these entries up, and, after a configurable period of time has elapsed
-   or the batch reaches a configurable size threshold, the batch is sequenced and integrated into the tree:
+   or the batch reaches a configurable size threshold, the batch is sequenced and appended to the tree:
    1. An advisory lock is taken on `.state/treeState.lock` file.
       This helps prevent multiple frontends from stepping on each other, but isn't necesary for safety.
    1. Flushed entries are assigned contiguous sequence numbers, and written out into entry bundle files.


### PR DESCRIPTION
This PR pulls the act of updating the merkle tree resources out into separate funcs.

This helps with readability by reducing the size/tightening the scope of some of the funcs in storage implementations (MySQL in particular was getting quite large), but also aids in supporting other lifecycle modes (e.g. for #414). 

No functional changes.