### PR TITLE
Bump workflows in prep for Go 1.23

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/cmd/conformance/mysql/docker/Dockerfile
+++ b/cmd/conformance/mysql/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.7-bookworm@sha256:027bd04b1d3b4529bf8ccebf62eb7eeeae7b7bef134a68bd419824e929ad93ad AS build
+FROM golang:1.23.4-bookworm@sha256:027bd04b1d3b4529bf8ccebf62eb7eeeae7b7bef134a68bd419824e929ad93ad AS build
 
 WORKDIR /build
 

--- a/cmd/conformance/mysql/docker/Dockerfile
+++ b/cmd/conformance/mysql/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-bookworm@sha256:027bd04b1d3b4529bf8ccebf62eb7eeeae7b7bef134a68bd419824e929ad93ad AS build
+FROM golang:1.23.4-bookworm@sha256:2e838582004fab0931693a3a84743ceccfbfeeafa8187e87291a1afea457ff7a AS build
 
 WORKDIR /build
 


### PR DESCRIPTION
This PR bumps GHA workflows in preparation for bumping the `go.mod` file to `1.23`.