### PR TITLE
[Hammer] Refactor to allow code reuse with CT

### DIFF
--- a/internal/hammer/hammer_test.go
+++ b/internal/hammer/hammer_test.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/transparency-dev/trillian-tessera/internal/hammer/loadtest"
 )
 
 func TestLeafGenerator(t *testing.T) {
@@ -52,10 +54,10 @@ func TestHammerAnalyser_Stats(t *testing.T) {
 
 	baseTime := time.Now().Add(-1 * time.Minute)
 	for i := 0; i < 10; i++ {
-		ha.seqLeafChan <- leafTime{
-			idx:        uint64(i),
-			queuedAt:   baseTime,
-			assignedAt: baseTime.Add(time.Duration(i) * time.Second),
+		ha.seqLeafChan <- loadtest.LeafTime{
+			Index:      uint64(i),
+			QueuedAt:   baseTime,
+			AssignedAt: baseTime.Add(time.Duration(i) * time.Second),
 		}
 	}
 	treeSize.setSize(10)


### PR DESCRIPTION
This isn't the full job, as the core of the hammer needs extracting from
hammer.go. This is a good start and sets the right direction for making
this a general purpose library for use in true tlog-tiles and the static
CT variation.
