### PR TITLE
[Hammer] Moved more common functionality into loadtest package

### DIFF
--- a/internal/hammer/loadtest/analysis.go
+++ b/internal/hammer/loadtest/analysis.go
@@ -1,0 +1,143 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	movingaverage "github.com/RobinUS2/golang-moving-average"
+	"k8s.io/klog/v2"
+)
+
+func NewHammerAnalyser(treeSizeFn func() uint64) *HammerAnalyser {
+	leafSampleChan := make(chan LeafTime, 100)
+	errChan := make(chan error, 20)
+	return &HammerAnalyser{
+		treeSizeFn:      treeSizeFn,
+		SeqLeafChan:     leafSampleChan,
+		ErrChan:         errChan,
+		IntegrationTime: movingaverage.Concurrent(movingaverage.New(30)),
+		QueueTime:       movingaverage.Concurrent(movingaverage.New(30)),
+	}
+}
+
+// HammerAnalyser is responsible for measuring and interpreting the result of hammering.
+type HammerAnalyser struct {
+	treeSizeFn  func() uint64
+	SeqLeafChan chan LeafTime
+	ErrChan     chan error
+
+	QueueTime       *movingaverage.ConcurrentMovingAverage
+	IntegrationTime *movingaverage.ConcurrentMovingAverage
+}
+
+func (a *HammerAnalyser) Run(ctx context.Context) {
+	go a.updateStatsLoop(ctx)
+	go a.errorLoop(ctx)
+}
+
+func (a *HammerAnalyser) updateStatsLoop(ctx context.Context) {
+	tick := time.NewTicker(100 * time.Millisecond)
+	size := a.treeSizeFn()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+		}
+		newSize := a.treeSizeFn()
+		if newSize <= size {
+			continue
+		}
+		now := time.Now()
+		totalLatency := time.Duration(0)
+		queueLatency := time.Duration(0)
+		numLeaves := 0
+		var sample *LeafTime
+	ReadLoop:
+		for {
+			if sample == nil {
+				select {
+				case l, ok := <-a.SeqLeafChan:
+					if !ok {
+						break ReadLoop
+					}
+					sample = &l
+				default:
+					break ReadLoop
+				}
+			}
+			// Stop considering leaf times once we've caught up with that cross
+			// either the current checkpoint or "now":
+			// - leaves with indices beyond the tree size we're considering are not integrated yet, so we can't calculate their TTI
+			// - leaves which were queued before "now", but not assigned by "now" should also be ignored as they don't fall into this epoch (and would contribute a -ve latency if they were included).
+			if sample.Index >= newSize || sample.AssignedAt.After(now) {
+				break
+			}
+			queueLatency += sample.AssignedAt.Sub(sample.QueuedAt)
+			// totalLatency is skewed towards being higher than perhaps it may technically be by:
+			// - the tick interval of this goroutine,
+			// - the tick interval of the goroutine which updates the LogStateTracker,
+			// - any latency in writes to the log becoming visible for reads.
+			// But it's probably good enough for now.
+			totalLatency += now.Sub(sample.QueuedAt)
+
+			numLeaves++
+			sample = nil
+		}
+		if numLeaves > 0 {
+			a.IntegrationTime.Add(float64(totalLatency/time.Millisecond) / float64(numLeaves))
+			a.QueueTime.Add(float64(queueLatency/time.Millisecond) / float64(numLeaves))
+		}
+	}
+}
+
+func (a *HammerAnalyser) errorLoop(ctx context.Context) {
+	tick := time.NewTicker(time.Second)
+	pbCount := 0
+	lastErr := ""
+	lastErrCount := 0
+	for {
+		select {
+		case <-ctx.Done(): //context cancelled
+			return
+		case <-tick.C:
+			if pbCount > 0 {
+				klog.Warningf("%d requests received pushback from log", pbCount)
+				pbCount = 0
+			}
+			if lastErrCount > 0 {
+				klog.Warningf("(%d x) %s", lastErrCount, lastErr)
+				lastErrCount = 0
+
+			}
+		case err := <-a.ErrChan:
+			if errors.Is(err, ErrRetry) {
+				pbCount++
+				continue
+			}
+			es := err.Error()
+			if es != lastErr && lastErrCount > 0 {
+				klog.Warningf("(%d x) %s", lastErrCount, lastErr)
+				lastErr = es
+				lastErrCount = 0
+				continue
+			}
+			lastErrCount++
+		}
+	}
+}

--- a/internal/hammer/loadtest/analysis_test.go
+++ b/internal/hammer/loadtest/analysis_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestHammerAnalyser_Stats(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var treeSize treeSizeState
+	ha := NewHammerAnalyser(treeSize.getSize)
+
+	go ha.updateStatsLoop(ctx)
+
+	time.Sleep(100 * time.Millisecond)
+
+	baseTime := time.Now().Add(-1 * time.Minute)
+	for i := 0; i < 10; i++ {
+		ha.SeqLeafChan <- LeafTime{
+			Index:      uint64(i),
+			QueuedAt:   baseTime,
+			AssignedAt: baseTime.Add(time.Duration(i) * time.Second),
+		}
+	}
+	treeSize.setSize(10)
+	time.Sleep(500 * time.Millisecond)
+
+	avg := ha.QueueTime.Avg()
+	if want := float64(4500); avg != want {
+		t.Errorf("integration time avg: got != want (%f != %f)", avg, want)
+	}
+}
+
+type treeSizeState struct {
+	size uint64
+	mux  sync.RWMutex
+}
+
+func (s *treeSizeState) getSize() uint64 {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	return s.size
+}
+
+func (s *treeSizeState) setSize(size uint64) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.size = size
+}

--- a/internal/hammer/loadtest/hammer.go
+++ b/internal/hammer/loadtest/hammer.go
@@ -1,0 +1,114 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/transparency-dev/trillian-tessera/client"
+
+	"k8s.io/klog/v2"
+)
+
+type HammerOpts struct {
+	MaxReadOpsPerSecond  int
+	MaxWriteOpsPerSecond int
+
+	NumReadersRandom int
+	NumReadersFull   int
+	NumWriters       int
+}
+
+func NewHammer(tracker *client.LogStateTracker, f client.EntryBundleFetcherFunc, w LeafWriter, gen func() []byte, seqLeafChan chan<- LeafTime, errChan chan<- error, opts HammerOpts) *Hammer {
+	readThrottle := NewThrottle(opts.MaxReadOpsPerSecond)
+	writeThrottle := NewThrottle(opts.MaxWriteOpsPerSecond)
+
+	randomReaders := NewWorkerPool(func() Worker {
+		return NewLeafReader(tracker, f, RandomNextLeaf(), readThrottle.TokenChan, errChan)
+	})
+	fullReaders := NewWorkerPool(func() Worker {
+		return NewLeafReader(tracker, f, MonotonicallyIncreasingNextLeaf(), readThrottle.TokenChan, errChan)
+	})
+	writers := NewWorkerPool(func() Worker {
+		return NewLogWriter(w, gen, writeThrottle.TokenChan, errChan, seqLeafChan)
+	})
+
+	return &Hammer{
+		opts:          opts,
+		randomReaders: randomReaders,
+		fullReaders:   fullReaders,
+		writers:       writers,
+		readThrottle:  readThrottle,
+		writeThrottle: writeThrottle,
+		tracker:       tracker,
+	}
+}
+
+// Hammer is responsible for coordinating the operations against the log in the form
+// of write and read operations. The work of analysing the results of hammering should
+// live outside of this class.
+type Hammer struct {
+	opts          HammerOpts
+	randomReaders WorkerPool
+	fullReaders   WorkerPool
+	writers       WorkerPool
+	readThrottle  *Throttle
+	writeThrottle *Throttle
+	tracker       *client.LogStateTracker
+}
+
+func (h *Hammer) Run(ctx context.Context) {
+	// Kick off readers & writers
+	for i := 0; i < h.opts.NumReadersRandom; i++ {
+		h.randomReaders.Grow(ctx)
+	}
+	for i := 0; i < h.opts.NumReadersFull; i++ {
+		h.fullReaders.Grow(ctx)
+	}
+	for i := 0; i < h.opts.NumWriters; i++ {
+		h.writers.Grow(ctx)
+	}
+
+	go h.readThrottle.Run(ctx)
+	go h.writeThrottle.Run(ctx)
+
+	go h.updateCheckpointLoop(ctx)
+}
+
+func (h *Hammer) updateCheckpointLoop(ctx context.Context) {
+	tick := time.NewTicker(500 * time.Millisecond)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			size := h.tracker.LatestConsistent.Size
+			_, _, _, err := h.tracker.Update(ctx)
+			if err != nil {
+				klog.Warning(err)
+				inconsistentErr := client.ErrInconsistency{}
+				if errors.As(err, &inconsistentErr) {
+					klog.Fatalf("Last Good Checkpoint:\n%s\n\nFirst Bad Checkpoint:\n%s\n\n%v", string(inconsistentErr.SmallerRaw), string(inconsistentErr.LargerRaw), inconsistentErr)
+				}
+			}
+			newSize := h.tracker.LatestConsistent.Size
+			if newSize > size {
+				klog.V(1).Infof("Updated checkpoint from %d to %d", size, newSize)
+			}
+		}
+	}
+}

--- a/internal/hammer/loadtest/throttle.go
+++ b/internal/hammer/loadtest/throttle.go
@@ -1,0 +1,97 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+func NewThrottle(opsPerSecond int) *Throttle {
+	return &Throttle{
+		opsPerSecond: opsPerSecond,
+		TokenChan:    make(chan bool, opsPerSecond),
+	}
+}
+
+type Throttle struct {
+	TokenChan    chan bool
+	mu           sync.Mutex
+	opsPerSecond int
+
+	oversupply int
+}
+
+func (t *Throttle) Increase() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	tokenCount := t.opsPerSecond
+	delta := float64(tokenCount) * 0.1
+	if delta < 1 {
+		delta = 1
+	}
+	t.opsPerSecond = tokenCount + int(delta)
+}
+
+func (t *Throttle) Decrease() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	tokenCount := t.opsPerSecond
+	if tokenCount <= 1 {
+		return
+	}
+	delta := float64(tokenCount) * 0.1
+	if delta < 1 {
+		delta = 1
+	}
+	t.opsPerSecond = tokenCount - int(delta)
+}
+
+func (t *Throttle) Run(ctx context.Context) {
+	interval := time.Second
+	ticker := time.NewTicker(interval)
+	for {
+		select {
+		case <-ctx.Done(): //context cancelled
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(ctx, interval)
+			t.supplyTokens(ctx)
+			cancel()
+		}
+	}
+}
+
+func (t *Throttle) supplyTokens(ctx context.Context) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	tokenCount := t.opsPerSecond
+	for i := 0; i < t.opsPerSecond; i++ {
+		select {
+		case t.TokenChan <- true:
+			tokenCount--
+		case <-ctx.Done():
+			t.oversupply = tokenCount
+			return
+		}
+	}
+	t.oversupply = 0
+}
+
+func (t *Throttle) String() string {
+	return fmt.Sprintf("Current max: %d/s. Oversupply in last second: %d", t.opsPerSecond, t.oversupply)
+}

--- a/internal/hammer/loadtest/tui.go
+++ b/internal/hammer/loadtest/tui.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package loadtest
 
 import (
 	"context"
@@ -36,7 +36,7 @@ type tuiController struct {
 	helpView   *tview.TextView
 }
 
-func newController(h *Hammer, a *HammerAnalyser) *tuiController {
+func NewController(h *Hammer, a *HammerAnalyser) *tuiController {
 	c := tuiController{
 		hammer:   h,
 		analyser: a,
@@ -143,9 +143,9 @@ func (c *tuiController) updateStatsLoop(ctx context.Context, interval time.Durat
 				qps,
 				time.Duration(maSlots*int(interval))/time.Second)
 			queueLine := fmt.Sprintf("Time-in-queue: %s",
-				formatMovingAverage(c.analyser.queueTime))
+				formatMovingAverage(c.analyser.QueueTime))
 			integrateLine := fmt.Sprintf("Observed-time-to-integrate: %s",
-				formatMovingAverage(c.analyser.integrationTime))
+				formatMovingAverage(c.analyser.IntegrationTime))
 			text := strings.Join([]string{readWorkersLine, writeWorkersLine, treeSizeLine, queueLine, integrateLine}, "\n")
 			c.statusView.SetText(text)
 			c.app.Draw()


### PR DESCRIPTION
This is a rough approximation of what a library version of the hammer
could look like. The remaining code in the outer `main` package is now
the tlog-tiles specific stuff. The code in the `loadtest` package should
be configurable to use with Static CT.

Towards https://github.com/transparency-dev/static-ct/issues/59.
