### PR TITLE
Add schema compatibility version checking to GCP

### DIFF
--- a/deployment/modules/gcp/gcs/main.tf
+++ b/deployment/modules/gcp/gcs/main.tf
@@ -64,6 +64,7 @@ resource "google_spanner_database" "log_db" {
   instance = google_spanner_instance.log_spanner.name
   name     = "${var.base_name}-db"
   ddl = [
+    "CREATE TABLE Tessera (id INT64 NOT NULL, compatibilityVersion INT64 NOT NULL) PRIMARY KEY (id)",
     "CREATE TABLE SeqCoord (id INT64 NOT NULL, next INT64 NOT NULL,) PRIMARY KEY (id)",
     "CREATE TABLE Seq (id INT64 NOT NULL, seq INT64 NOT NULL, v BYTES(MAX),) PRIMARY KEY (id, seq)",
     "CREATE TABLE IntCoord (id INT64 NOT NULL, seq INT64 NOT NULL, rootHash BYTES(32)) PRIMARY KEY (id)",


### PR DESCRIPTION
This PR adds a table to the Spanner schema to record the notional _compatibility version_ at which the instance was created at/updated to, and makes the GCP storage driver refuse to work with versions other than the version the compiled code was intended to support.

Towards #450 