### PR TITLE
Rename GCB trigger to better match the intended purpose

### DIFF
--- a/deployment/modules/gcp/cloudbuild/main.tf
+++ b/deployment/modules/gcp/cloudbuild/main.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 resource "google_cloudbuild_trigger" "docker" {
-  name            = "build-docker-${var.env}"
+  name            = "GCP-integration-test-${var.env}"
   service_account = "projects/${var.project_id}/serviceAccounts/${var.service_account}"
   location        = var.region
 


### PR DESCRIPTION
This PR renames the cloud build trigger to be more descriptive of what it's doing.
