### PR TITLE
[MySQL] Check that the DB schema is compatible

### DIFF
--- a/storage/mysql/DESIGN.md
+++ b/storage/mysql/DESIGN.md
@@ -15,6 +15,10 @@ The DB layout has been designed such that serving any read request is a point lo
 
 ### Table Schema
 
+#### `Tessera`
+
+A single row that records the current version of the Tessera schema and data compatibility.
+
 #### `Checkpoint`
 
 A single row that records the current published checkpoint.

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS Tessera (
   -- id is expected to be always 0 to maintain a maximum of a single row.
   `id`                   TINYINT UNSIGNED NOT NULL,
   -- compatibilityVersion is the version of this schema and the data within it.
-  `compatibilityVersion` TINYINT UNSIGNED NOT NULL,
+  `compatibilityVersion` BIGINT UNSIGNED NOT NULL,
   PRIMARY KEY (`id`)
 );
 

--- a/storage/mysql/schema.sql
+++ b/storage/mysql/schema.sql
@@ -14,6 +14,19 @@
 
 -- MySQL version of the Trillian Tessera database schema.
 
+-- "Tessera" table stores a single row that is the version of this schema
+-- and the data formats within it. This is read at startup to prevent Tessera
+-- running against a database with an incompatible format.
+CREATE TABLE IF NOT EXISTS Tessera (
+  -- id is expected to be always 0 to maintain a maximum of a single row.
+  `id`                   TINYINT UNSIGNED NOT NULL,
+  -- compatibilityVersion is the version of this schema and the data within it.
+  `compatibilityVersion` TINYINT UNSIGNED NOT NULL,
+  PRIMARY KEY (`id`)
+);
+
+INSERT IGNORE INTO Tessera (`id`, `compatibilityVersion`) VALUES (0, 1);
+
 -- "Checkpoint" table stores a single row that records the latest _published_ checkpoint for the log.
 -- This is stored separately from the TreeState in order to enable publishing of commitments to updated tree states to happen
 -- on an indepentent timeframe to the internal updating of state.


### PR DESCRIPTION
The version is written at schema creation, and checked on startup. If they are different, it fails. Towards #450.
