### PR TITLE
[Cleanup] Rename benchmark actions

### DIFF
--- a/.github/workflows/benchmark-go-main.yml
+++ b/.github/workflows/benchmark-go-main.yml
@@ -1,4 +1,4 @@
-name: Benchmark Go
+name: Benchmark Go (main)
 
 on:
   push:

--- a/.github/workflows/benchmark-go-pr.yml
+++ b/.github/workflows/benchmark-go-pr.yml
@@ -1,4 +1,4 @@
-name: Benchmark Go
+name: Benchmark Go (PR)
 
 on:
   pull_request:


### PR DESCRIPTION
These two actions had the same name in the GH actions tab and that makes it hard to glance at where the problem is, and communicate about it. Unique naming is good.
