### PR TITLE
[API] Refactoring to make appender API future-proof

### DIFF
--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -78,7 +78,8 @@ func main() {
 	if err != nil {
 		klog.Exitf("Failed to create new AWS storage: %v", err)
 	}
-	addFn, _, err := tessera.NewAppender(driver, tessera.InMemoryDedupe(256))
+	appender, _, err := tessera.NewAppender(driver, tessera.WithAppendDeduplication(tessera.InMemoryDedupe(256)))
+	addFn := appender.Add
 	if err != nil {
 		klog.Exit(err)
 	}

--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -92,7 +92,8 @@ func main() {
 		}()
 	}
 
-	addFn, _, err := tessera.NewAppender(driver, dedups...)
+	appender, _, err := tessera.NewAppender(driver, tessera.WithAppendDeduplication(dedups...))
+	addFn := appender.Add
 	if err != nil {
 		klog.Exit(err)
 	}

--- a/cmd/conformance/mysql/main.go
+++ b/cmd/conformance/mysql/main.go
@@ -70,7 +70,8 @@ func main() {
 		klog.Exitf("Failed to create new MySQL storage: %v", err)
 	}
 
-	addFn, reader, err := tessera.NewAppender(driver, tessera.InMemoryDedupe(256))
+	appender, reader, err := tessera.NewAppender(driver, tessera.WithAppendDeduplication(tessera.InMemoryDedupe(256)))
+	addFn := appender.Add
 	if err != nil {
 		klog.Exit(err)
 	}

--- a/cmd/conformance/posix/main.go
+++ b/cmd/conformance/posix/main.go
@@ -69,7 +69,8 @@ func main() {
 	if err != nil {
 		klog.Exitf("Failed to construct storage: %v", err)
 	}
-	addFn, _, err := tessera.NewAppender(driver, tessera.InMemoryDedupe(256))
+	appender, _, err := tessera.NewAppender(driver, tessera.WithAppendDeduplication(tessera.InMemoryDedupe(256)))
+	addFn := appender.Add
 	if err != nil {
 		klog.Exit(err)
 	}

--- a/cmd/examples/posix-oneshot/main.go
+++ b/cmd/examples/posix-oneshot/main.go
@@ -95,7 +95,8 @@ func main() {
 	if err != nil {
 		klog.Exitf("Failed to construct storage: %v", err)
 	}
-	addFn, r, err := tessera.NewAppender(driver)
+	appender, r, err := tessera.NewAppender(driver)
+	addFn := appender.Add
 	if err != nil {
 		klog.Exit(err)
 	}

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -44,27 +44,62 @@ type LogReader interface {
 	ReadEntryBundle(ctx context.Context, index uint64, p uint8) ([]byte, error)
 }
 
+// Appender allows personalities access to the lifecycle methods associated with logs
+// in sequencing mode. This only has a single method, but other methods are likely to be added
+// such as a Shutdown method for #341.
+type Appender struct {
+	Add      AddFn
+	// TODO(#341): add this method and implement it in all drivers
+	// Shutdown func(ctx context.Context)
+}
+
 // NewAppender returns an Appender, which allows a personality to incrementally append new
 // leaves to the log and to read from it.
 //
 // decorators provides a list of optional constructor functions that will return decorators
 // that wrap the base appender. This can be used to provide deduplication. Decorators will be
 // called in-order, and the last in the chain will be the base appender.
-func NewAppender(d Driver, decorators ...func(AddFn) AddFn) (AddFn, LogReader, error) {
+// TODO(mhutchinson): switch the decorators over to a WithOpt for future flexibility.
+func NewAppender(d Driver, opts ...func(*appendOptions)) (*Appender, LogReader, error) {
+	resolved := resolveAppendOpts(opts...)
 	type appender interface {
 		Add(ctx context.Context, entry *Entry) IndexFuture
+		// Shutdown(ctx context.Context)
 	}
 	a, ok := d.(appender)
 	if !ok {
 		return nil, nil, fmt.Errorf("driver %T does not implement Appender", d)
 	}
 	add := a.Add
-	for i := len(decorators) - 1; i >= 0; i-- {
-		add = decorators[i](add)
+	for i := len(resolved.addDecorators) - 1; i >= 0; i-- {
+		add = resolved.addDecorators[i](add)
 	}
 	reader, ok := d.(LogReader)
 	if !ok {
 		return nil, nil, fmt.Errorf("driver %T does not implement LogReader", d)
 	}
-	return add, reader, nil
+	return &Appender{
+		Add:      add,
+		// Shutdown: a.Shutdown,
+	}, reader, nil
+}
+
+func WithAppendDeduplication(decorators ...func(AddFn) AddFn) func(*appendOptions) {
+	return func(o *appendOptions) {
+		o.addDecorators = decorators
+	}
+}
+
+type appendOptions struct {
+	addDecorators []func(AddFn) AddFn
+}
+
+func resolveAppendOpts(opts ...func(*appendOptions)) appendOptions {
+	defaults := &appendOptions{
+		addDecorators: make([]func(AddFn) AddFn, 0),
+	}
+	for _, opt := range opts {
+		opt(defaults)
+	}
+	return *defaults
 }

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -475,5 +475,5 @@ func newTestMySQLStorage(t *testing.T, ctx context.Context) (tessera.AddFn, tess
 	if err != nil {
 		t.Fatal(err)
 	}
-	return a, r
+	return a.Add, r
 }


### PR DESCRIPTION
The inflexibility of this was noticed while looking at options to fix https://github.com/transparency-dev/trillian-tessera/issues/341. This PR includes a comment indicating that in future we want to add a Shutdown method, but more interesting are the other changes that:
  a) move the dedupe decorators behind an options, and
  b) making Appender more than just a function to allow new methods (such as Shutdown) to be added in the future.
