### PR TITLE
Replace GCP dedup with follower-style implementation

### DIFF
--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -79,6 +79,7 @@ func main() {
 		}
 		dedups = append(dedups, dd.Decorator())
 
+		// TODO(al): Figure out how this will be for realz.
 		follower, ok := driver.(gcp.LogFollower)
 		if !ok {
 			klog.Exitf("Storage driver %T doesn't support LogFollower", driver)

--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -84,7 +84,11 @@ func main() {
 			klog.Exitf("Storage driver %T doesn't support LogFollower", driver)
 		}
 		// Start populating the dedupe data:
-		go dd.Populate(ctx, follower, idHasher)
+		go func() {
+			if err := dd.Populate(ctx, follower, idHasher); err != nil {
+				klog.Exitf("Populate: %v", err)
+			}
+		}()
 	}
 
 	addFn, _, err := tessera.NewAppender(driver, dedups...)

--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -71,11 +71,11 @@ func main() {
 	dedups = append(dedups, tessera.InMemoryDedupe(256))
 	// PersistentDedup is currently experimental, so there's no terraform or documentation yet!
 	if *persistentDedup {
-		fn, err := gcp.NewDedupe(ctx, fmt.Sprintf("%s_dedup", *spanner))
+		dd, err := gcp.NewDedupe(ctx, fmt.Sprintf("%s_dedup", *spanner))
 		if err != nil {
 			klog.Exitf("Failed to create new GCP dedupe: %v", err)
 		}
-		dedups = append(dedups, fn)
+		dedups = append(dedups, dd.Decorator())
 	}
 
 	addFn, _, err := tessera.NewAppender(driver, dedups...)

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -357,7 +357,7 @@ func (s *Storage) IntegratedSize(ctx context.Context) (uint64, error) {
 // This implementation is intended to be relatively performant compared to the naive approach of serially fetching
 // and yielding each bundle in turn, and is intended for use cases where the caller is actively consuming large
 // sections of the log contents.
-func (s *Storage) StreamEntryRange(ctx context.Context, fromEntry, N, treeSize uint64) (func() (ri layout.RangeInfo, bundle []byte, err error), func()) {
+func (s *Storage) StreamEntryRange(ctx context.Context, fromEntry, N, treeSize uint64) (next func() (ri layout.RangeInfo, bundle []byte, err error), cancel func()) {
 	klog.Infof("StreamEntryRange from %d, N %d, treeSize %d", fromEntry, N, treeSize)
 
 	return streamAdaptor(ctx, s.getEntryBundle, fromEntry, N, treeSize)

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -351,6 +351,9 @@ func (s *Storage) IntegratedSize(ctx context.Context) (uint64, error) {
 
 // StreamEntryRange provides a mechanism to quickly read sequential entry bundles covering a range of entries [fromEntry, fromEntry+N).
 //
+// Note that input parameters reference the raw leaf indices, and these will be returned bundled according to the tiles spec along with
+// "RangeInfo" structs with information about which entries in each bundle are within the requested range.
+//
 // Returns a "next" function, which can be used to retrieve subsequent entry bundles, and a "cancel" function which must be
 // called when no further bundles are required.
 //

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -35,6 +35,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"net/http"
 	"os"
 	"sync"
@@ -332,6 +333,82 @@ func (s *Storage) getTiles(ctx context.Context, tileIDs []storage.TileID, logSiz
 	}
 	return r, nil
 
+}
+
+// streamEntryBundles returns an iterator over the entry bundles in the range [fromBundle, fromBundle+N).
+// The yielded range is truncated at the extent of the currently integrated tree, or if an error is encountered
+// while fetching entry bundle data.
+//
+// This implementation is intended to be relatively performant compared to the naive approach of serially fetching
+// and yielding each bundle in turn, and is intended for use cases where the caller is actively consuming large
+// sections of the log contents.
+func (s *Storage) streamEntryBundles(ctx context.Context, fromBundle, N, treeSize uint64) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		// bundleOrErr represents a fetched entry bunlde and its params, or an error if we couldn't fetch it for
+		// some reason.
+		type bundleOrErr struct {
+			b   []byte
+			err error
+		}
+		// TODO(al): this should probably be configurable
+		nWorkers := 10
+
+		// bundles will be filled with futures for in-order entry bundles by the worker
+		// go routines below.
+		// This channel will be drained by the loop at the bottom of this func which
+		// yields the bundles to the caller.
+		bundles := make(chan func() bundleOrErr, nWorkers)
+		exit := make(chan struct{})
+		defer close(exit)
+
+		// Fetch entry bundle resources in parallel.
+		// We use a limited number of tokens here to prevent this from
+		// consuming an unbounded amount of resources.
+		go func() {
+			defer close(bundles)
+
+			// We'll limit ourselves to nWorkers worth of on-going work using these tokens:
+			tokens := make(chan struct{}, nWorkers)
+			for range nWorkers {
+				tokens <- struct{}{}
+			}
+
+			// For each bundle, pop a future into the bundles channel and kick off an async request
+			// to resolve it.
+			for idx, limit := fromBundle, (fromBundle+N)/layout.EntryBundleWidth+1; idx < limit; idx++ {
+				select {
+				case <-exit:
+					return
+				case <-tokens:
+					// We'll return a token below, once the bundle is fetched _and_ is being yielded.
+				}
+
+				c := make(chan bundleOrErr, 1)
+				go func() {
+					b, err := s.getEntryBundle(ctx, idx, layout.PartialTileSize(0, idx, treeSize))
+					c <- bundleOrErr{b: b, err: err}
+				}()
+
+				f := func() bundleOrErr {
+					b := <-c
+					// We're about to yield a value, so we can now return the token and unblock another fetch.
+					tokens <- struct{}{}
+					return b
+				}
+
+				bundles <- f
+			}
+		}()
+
+		// Now that the bundles channel is being asynchronously populated, we can start yielding
+		// values out to the caller.
+		for f := range bundles {
+			b := f()
+			if ok := yield(b.b, b.err); !ok || b.err != nil {
+				return
+			}
+		}
+	}
 }
 
 // getEntryBundle returns the serialised entry bundle at the location described by the given index and partial size.

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -333,7 +333,8 @@ func (s *Storage) getTiles(ctx context.Context, tileIDs []storage.TileID, logSiz
 	return r, nil
 }
 
-func (s *Storage) State(ctx context.Context) (uint64, error) {
+// IntegratedSize returns the current size of the integrated tree.
+func (s *Storage) IntegratedSize(ctx context.Context) (uint64, error) {
 	size, _, err := s.sequencer.currentTree(ctx)
 	return size, err
 }
@@ -1086,9 +1087,9 @@ func (e *entryStreamReader[T]) Next() (uint64, T, error) {
 //
 // TODO(al): factor this out into higher layer when it's ready.
 type LogFollower interface {
-	// State returns the size of the currently integrated tree.
+	// IntegratedSize returns the size of the currently integrated tree.
 	// Note that this _may_ be larger than the currently _published_ checkpoint.
-	State(ctx context.Context) (uint64, error)
+	IntegratedSize(ctx context.Context) (uint64, error)
 
 	// StreamEntryBundles returns functions which act like a pull iterator for subsequent entry bundles starting at the given index.
 	//
@@ -1118,9 +1119,9 @@ func (d *DedupStorage) Populate(ctx context.Context, lf LogFollower, bundleFn Bu
 			return ctx.Err()
 		case <-t.C:
 		}
-		size, err := lf.State(ctx)
+		size, err := lf.IntegratedSize(ctx)
 		if err != nil {
-			klog.Errorf("Populate: State(): %v", err)
+			klog.Errorf("Populate: IntegratedSize(): %v", err)
 			continue
 		}
 

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -347,7 +347,7 @@ func (s *Storage) State(ctx context.Context) (uint64, error) {
 // and yielding each bundle in turn, and is intended for use cases where the caller is actively consuming large
 // sections of the log contents.
 func (s *Storage) StreamEntryRange(ctx context.Context, fromEntry, N, treeSize uint64) (func() (ri layout.RangeInfo, bundle []byte, err error), func()) {
-	klog.V(1).Infof("StreamEntryRange from %d, N %d, treeSize %d", fromEntry, N, treeSize)
+	klog.Infof("StreamEntryRange from %d, N %d, treeSize %d", fromEntry, N, treeSize)
 
 	return streamAdaptor(ctx, s.getEntryBundle, fromEntry, N, treeSize)
 }
@@ -1175,7 +1175,7 @@ func (d *DedupStorage) Populate(ctx context.Context, lf LogFollower, bundleFn Bu
 					return fmt.Errorf("failed to read follow coordination info: %v", err)
 				}
 				followFrom := uint64(f)
-				if followFrom == size {
+				if followFrom >= size {
 					workDone = false
 					return nil
 				}

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -386,7 +386,9 @@ func streamAdaptor(ctx context.Context, getBundle getBundleFn, fromEntry, N, tre
 		b   []byte
 		err error
 	}
-	// TODO(al): this should probably be configurable
+	// TODO(al): this should probably be configurable - it's primarily intended to act as a means to balance throughput against
+	//           consumption of resources, but such balancing needs to be mindful of the nature of the source infrastructure, and
+	//           how concurrent requests affect performance (e.g. GCS buckets vs. files on a single disk).
 	nWorkers := 10
 
 	// bundles will be filled with futures for in-order entry bundles by the worker

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -961,7 +961,6 @@ func NewDedupe(ctx context.Context, spannerDB string) (*DedupStorage, error) {
 	}
 
 	r := &DedupStorage{
-		ctx:    ctx,
 		dbPool: dedupDB,
 	}
 
@@ -981,7 +980,6 @@ func NewDedupe(ctx context.Context, spannerDB string) (*DedupStorage, error) {
 }
 
 type DedupStorage struct {
-	ctx    context.Context
 	dbPool *spanner.Client
 
 	pushBack atomic.Bool

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -372,14 +372,14 @@ type getBundleFn func(ctx context.Context, bundleIdx uint64, partial uint8) ([]b
 // If the adaptor encounters an error while reading an entry bundle, the encountered error will be returned by the corresponding call to next,
 // and the stream will be stopped - further calls to next will continue to return errors.
 //
-// When the caller has finished consuming entrybundles (either because of an error being returned via next, or having consumed all the bundles it needs),
-// it MUST call the returned close function to release resources.
+// When the caller has finished consuming entry bundles (either because of an error being returned via next, or having consumed all the bundles it needs),
+// it MUST call the returned cancel function to release resources.
 //
 // This adaptor is optimised for the case where calling getBundle has some appreciable latency, and works
 // around that by maintaining a read-ahead cache of subsequent bundles.
 // TODO(al): consider whether this should be factored out as a storage mix-in.
 func streamAdaptor(ctx context.Context, getBundle getBundleFn, fromEntry, N, treeSize uint64) (next func() (ri layout.RangeInfo, bundle []byte, err error), cancel func()) {
-	// bundleOrErr represents a fetched entry bunlde and its params, or an error if we couldn't fetch it for
+	// bundleOrErr represents a fetched entry bundle and its params, or an error if we couldn't fetch it for
 	// some reason.
 	type bundleOrErr struct {
 		ri  layout.RangeInfo

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -1053,6 +1053,7 @@ type dedupeMapping struct {
 // code to dedup against the stored data.
 func (d *DedupStorage) Decorator() func(f tessera.AddFn) tessera.AddFn {
 	return func(delegate tessera.AddFn) tessera.AddFn {
+		// TODO(al): return ErrPushback if the Follower is too far behind the current size of the log.
 		return func(ctx context.Context, e *tessera.Entry) tessera.IndexFuture {
 			idx, err := d.index(ctx, e.Identity())
 			if err != nil {


### PR DESCRIPTION
This PR updates the experimental GCP dedup implementation with a (still experimental) version which populates its database by tailing the log, as opposed to the with many potentially-competing transactions it does currently.

This approximately doubles the throughput when running on the same infrastructure.

Towards #470