### PR TITLE
Tighten up POSIX file operations

### DIFF
--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -584,7 +584,6 @@ func createIdempotent(p string, d []byte) error {
 	if err := createExclusive(p, d); err != nil {
 		if errors.Is(err, os.ErrExist) {
 			if r, err := os.ReadFile(p); err != nil {
-
 				return fmt.Errorf("file %q already exists, but unable to read it: %v", p, err)
 			} else if bytes.Equal(d, r) {
 				// Idempotent write

--- a/testdata/build_log.sh
+++ b/testdata/build_log.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # build_log.sh is a script for building a small test log.
 


### PR DESCRIPTION
This PR tightens the semantics of the file operations performed by the POSIX storage implementation.

It splits "writing files" across 3 narrower funcs which are then called by the storage driver depending on exactly which behaviour is intended.