### PR TITLE
Update CT support to match lifecycle change

### DIFF
--- a/ct_only.go
+++ b/ct_only.go
@@ -30,19 +30,19 @@ type Storage interface {
 	Add(context.Context, *Entry) IndexFuture
 }
 
-// NewCertificateTransparencySequencedWriter returns a function which knows how to add a CT-specific entry type to the log.
+// NewCertificateTransparencyAppender returns a function which knows how to add a CT-specific entry type to the log.
 //
 // This entry point MUST ONLY be used for CT logs participating in the CT ecosystem.
 // It should not be used as the basis for any other/new transparency application as this protocol:
 // a) embodies some techniques which are not considered to be best practice (it does this to retain backawards-compatibility with RFC6962)
 // b) is not compatible with the https://c2sp.org/tlog-tiles API which we _very strongly_ encourage you to use instead.
 //
-// Users of this MUST NOT call `Add` on the underlying storage directly.
+// Users of this MUST NOT call `Add` on the underlying Appender directly.
 //
 // Returns a future, which resolves to the assigned index in the log, or an error.
-func NewCertificateTransparencySequencedWriter(s Storage) func(context.Context, *ctonly.Entry) IndexFuture {
+func NewCertificateTransparencyAppender(a *Appender) func(context.Context, *ctonly.Entry) IndexFuture {
 	return func(ctx context.Context, e *ctonly.Entry) IndexFuture {
-		return s.Add(ctx, convertCTEntry(e))
+		return a.Add(ctx, convertCTEntry(e))
 	}
 }
 


### PR DESCRIPTION
Track changes in lifecycle API introduced in #482 