### PR TITLE
Defined witness policy configuration

### DIFF
--- a/witness.go
+++ b/witness.go
@@ -31,10 +31,10 @@ type policyComponent interface {
 	// witnesses involved in this policy component.
 	Satisfied(cp []byte) bool
 
-	// Urls returns the URLs for requesting a counter signature from all
+	// URLs returns the URLs for requesting a counter signature from all
 	// witnesses that are involved in determining the satisfaction of this
 	// PolicyComponent.
-	Urls() []*url.URL
+	URLs() []*url.URL
 }
 
 // NewWitness returns a Witness given a verifier key and the root URL for where this
@@ -45,7 +45,7 @@ func NewWitness(vkey string, witnessRoot *url.URL) (Witness, error) {
 		return Witness{}, err
 	}
 	// "key hash" MUST be a lowercase hex-encoded SHA-256 hash of a 32-byte Ed25519 public key.
-	// This expression cuts off the identity name and hash
+	// This expression cuts off the identity name and hash.
 	key64 := strings.SplitAfterN(vkey, "+", 3)[2]
 	key, err := base64.StdEncoding.DecodeString(key64)
 	if err != nil {
@@ -62,7 +62,7 @@ func NewWitness(vkey string, witnessRoot *url.URL) (Witness, error) {
 }
 
 // Witness represents a single witness that can be reached in order to perform a witnessing operation.
-// The Urls() method returns the URL where it can be reached for witnessing, and the Satisfied method
+// The URLs() method returns the URL where it can be reached for witnessing, and the Satisfied method
 // provides a predicate to check whether this witness has signed a checkpoint.
 type Witness struct {
 	Key note.Verifier
@@ -81,10 +81,10 @@ func (w Witness) Satisfied(cp []byte) bool {
 	return len(n.Sigs) == 1
 }
 
-// Urls returns the single URL at which this witness can be reached.
+// URLs returns the single URL at which this witness can be reached.
 // The return type is a slice in order to allow this method to match the same signature
 // of WitnessGroup.
-func (w Witness) Urls() []*url.URL {
+func (w Witness) URLs() []*url.URL {
 	return []*url.URL{w.Url}
 }
 
@@ -133,13 +133,13 @@ func (wg WitnessGroup) Satisfied(cp []byte) bool {
 	return false
 }
 
-// Urls returns the URLs for requesting a counter signature from all
+// URLs returns the URLs for requesting a counter signature from all
 // witnesses that are involved in determining the satisfaction of this
 // PolicyComponent.
-func (wg WitnessGroup) Urls() []*url.URL {
+func (wg WitnessGroup) URLs() []*url.URL {
 	urls := make([]*url.URL, 0)
 	for _, c := range wg.Components {
-		urls = append(urls, c.Urls()...)
+		urls = append(urls, c.URLs()...)
 	}
 	return urls
 }

--- a/witness.go
+++ b/witness.go
@@ -1,0 +1,145 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tessera
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"golang.org/x/mod/sumdb/note"
+)
+
+// policyComponent describes a component that makes up a policy. This is either a
+// single Witness, or a WitnessGroup.
+type policyComponent interface {
+	// Satisfied returns true if the checkpoint is signed by the quorum of
+	// witnesses involved in this policy component.
+	Satisfied(cp []byte) bool
+
+	// Urls returns the URLs for requesting a counter signature from all
+	// witnesses that are involved in determining the satisfaction of this
+	// PolicyComponent.
+	Urls() []*url.URL
+}
+
+// NewWitness returns a Witness given a verifier key and the root URL for where this
+// witness can be reached.
+func NewWitness(vkey string, witnessRoot *url.URL) (Witness, error) {
+	v, err := note.NewVerifier(vkey)
+	if err != nil {
+		return Witness{}, err
+	}
+	// "key hash" MUST be a lowercase hex-encoded SHA-256 hash of a 32-byte Ed25519 public key.
+	// This expression cuts off the identity name and hash
+	key64 := strings.SplitAfterN(vkey, "+", 3)[2]
+	key, err := base64.StdEncoding.DecodeString(key64)
+	if err != nil {
+		return Witness{}, err
+	}
+	h := sha256.Sum256(key)
+
+	u := witnessRoot.JoinPath(fmt.Sprintf("/%x/add", h))
+
+	return Witness{
+		Key: v,
+		Url: u,
+	}, err
+}
+
+// Witness represents a single witness that can be reached in order to perform a witnessing operation.
+// The Urls() method returns the URL where it can be reached for witnessing, and the Satisfied method
+// provides a predicate to check whether this witness has signed a checkpoint.
+type Witness struct {
+	Key note.Verifier
+	Url *url.URL
+}
+
+// Satisfied returns true if the checkpoint provided is signed by this witness.
+// This will return false if there is no signature, and also if the
+// checkpoint cannot be read as a valid note. It is up to the caller to ensure
+// that the input value represents a valid note.
+func (w Witness) Satisfied(cp []byte) bool {
+	n, err := note.Open(cp, note.VerifierList(w.Key))
+	if err != nil {
+		return false
+	}
+	return len(n.Sigs) == 1
+}
+
+// Urls returns the single URL at which this witness can be reached.
+// The return type is a slice in order to allow this method to match the same signature
+// of WitnessGroup.
+func (w Witness) Urls() []*url.URL {
+	return []*url.URL{w.Url}
+}
+
+// NewWitnessGroup creates a grouping of Witness or WitnessGroup with a configurable threshold
+// of these sub-components that need to be satisfied in order for this group to be satisfied.
+//
+// The threshold should only be set to less than the number of sub-components if these are
+// considered fungible.
+func NewWitnessGroup(n int, children ...policyComponent) WitnessGroup {
+	if n < 0 || n > len(children) {
+		panic(fmt.Errorf("threshold of %d outside bounds for children %s", n, children))
+	}
+	return WitnessGroup{
+		Components: children,
+		N:          n,
+	}
+}
+
+// WitnessGroup defines a group of witnesses, and a threshold of
+// signatures that must be met for this group to be satisfied.
+// Witnesses within a group should be fungible, e.g. all of the Armored
+// Witness devices form a logical group, and N should be picked to
+// represent a threshold of the quorum. For some users this will be a
+// simple majority, but other strategies are available.
+// N must be <= len(WitnessKeys).
+type WitnessGroup struct {
+	Components []policyComponent
+	N          int
+}
+
+// Satisfied returns true if the checkpoint provided has sufficient signatures
+// from the witnesses in this group to satisfy the threshold.
+// This will return false if there are insufficient signatures, and also if the
+// checkpoint cannot be read as a valid note. It is up to the caller to ensure
+// that the input value represents a valid note.
+func (wg WitnessGroup) Satisfied(cp []byte) bool {
+	satisfaction := 0
+	for _, c := range wg.Components {
+		if c.Satisfied(cp) {
+			satisfaction++
+		}
+		if satisfaction >= wg.N {
+			return true
+		}
+	}
+	return false
+}
+
+// Urls returns the URLs for requesting a counter signature from all
+// witnesses that are involved in determining the satisfaction of this
+// PolicyComponent.
+func (wg WitnessGroup) Urls() []*url.URL {
+	urls := make([]*url.URL, 0)
+	for _, c := range wg.Components {
+		urls = append(urls, c.Urls()...)
+	}
+	return urls
+}

--- a/witness_test.go
+++ b/witness_test.go
@@ -1,0 +1,202 @@
+package tessera_test
+
+import (
+	"net/url"
+	"slices"
+	"testing"
+
+	tessera "github.com/transparency-dev/trillian-tessera"
+	"golang.org/x/mod/sumdb/note"
+)
+
+const (
+	wit1_vkey = "Wit1+55ee4561+AVhZSmQj9+SoL+p/nN0Hh76xXmF7QcHfytUrI1XfSClk"
+	wit1_skey = "PRIVATE+KEY+Wit1+55ee4561+AeadRiG7XM4XiieCHzD8lxysXMwcViy5nYsoXURWGrlE"
+	wit2_vkey = "Wit2+85ecc407+AWVbwFJte9wMQIPSnEnj4KibeO6vSIOEDUTDp3o63c2x"
+	wit2_skey = "PRIVATE+KEY+Wit2+85ecc407+AfPTvxw5eUcqSgivo2vaiC7JPOMUZ/9baHPSDrWqgdGm"
+	wit3_vkey = "Wit3+d3ed3be7+ASb6Uz1+fxAcXkMvDd7nGa3FjDce7LxIKmbbTCT0MpVn"
+	wit3_skey = "PRIVATE+KEY+Wit3+d3ed3be7+AR2Kg8k6ccBr5QXz5SHtnkOS4UGQGEQaWi6Gfr6Mm3X5"
+)
+
+var (
+	bastion1, _ = url.Parse("https://b1.example.com/")
+	bastion2, _ = url.Parse("https://b2.example.com/")
+	wit1, _     = tessera.NewWitness(wit1_vkey, bastion1)
+	wit2, _     = tessera.NewWitness(wit2_vkey, bastion1)
+	wit3, _     = tessera.NewWitness(wit3_vkey, bastion2)
+	wit1Sign, _ = note.NewSigner(wit1_skey)
+	wit2Sign, _ = note.NewSigner(wit2_skey)
+	wit3Sign, _ = note.NewSigner(wit3_skey)
+)
+
+func TestWitnessGroup_Satisfied(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		group           tessera.WitnessGroup
+		signers         []note.Signer
+		expectSatisfied bool
+	}{
+		{
+			desc:            "One witness, required and provided",
+			group:           tessera.NewWitnessGroup(1, wit1),
+			signers:         []note.Signer{wit1Sign},
+			expectSatisfied: true,
+		},
+		{
+			desc:            "One witness, required and not provided",
+			group:           tessera.NewWitnessGroup(1, wit1),
+			signers:         []note.Signer{},
+			expectSatisfied: false,
+		},
+		{
+			desc:            "One witness, optional and provided",
+			group:           tessera.NewWitnessGroup(0, wit1),
+			signers:         []note.Signer{wit1Sign},
+			expectSatisfied: true,
+		},
+		{
+			desc:            "One witness, optional and not provided",
+			group:           tessera.NewWitnessGroup(0, wit1),
+			signers:         []note.Signer{},
+			expectSatisfied: true,
+		},
+		{
+			desc:            "One witness, required and provided, in required subgroup",
+			group:           tessera.NewWitnessGroup(1, tessera.NewWitnessGroup(1, wit1)),
+			signers:         []note.Signer{wit1Sign},
+			expectSatisfied: true,
+		},
+		{
+			desc:            "One witness, required and provided, in optional subgroup",
+			group:           tessera.NewWitnessGroup(0, tessera.NewWitnessGroup(1, wit1)),
+			signers:         []note.Signer{wit1Sign},
+			expectSatisfied: true,
+		},
+		{
+			desc:            "One witness, required and not provided, in required subgroup",
+			group:           tessera.NewWitnessGroup(1, tessera.NewWitnessGroup(1, wit1)),
+			signers:         []note.Signer{},
+			expectSatisfied: false,
+		},
+		{
+			desc:            "One witness, required and not provided, in optional subgroup",
+			group:           tessera.NewWitnessGroup(0, tessera.NewWitnessGroup(1, wit1)),
+			signers:         []note.Signer{},
+			expectSatisfied: true,
+		},
+		{
+			desc:            "One required, one of two required, all provided",
+			group:           tessera.NewWitnessGroup(2, wit1, tessera.NewWitnessGroup(1, wit2, wit3)),
+			signers:         []note.Signer{wit1Sign, wit2Sign, wit3Sign},
+			expectSatisfied: true,
+		},
+		{
+			desc:            "One required, one of two required, min provided",
+			group:           tessera.NewWitnessGroup(2, wit1, tessera.NewWitnessGroup(1, wit2, wit3)),
+			signers:         []note.Signer{wit1Sign, wit2Sign},
+			expectSatisfied: true,
+		},
+		{
+			desc:            "One required, one of two required, only first group satisfied",
+			group:           tessera.NewWitnessGroup(2, wit1, tessera.NewWitnessGroup(1, wit2, wit3)),
+			signers:         []note.Signer{wit1Sign},
+			expectSatisfied: false,
+		},
+		{
+			desc:            "One required, one of two required, only second group satisfied",
+			group:           tessera.NewWitnessGroup(2, wit1, tessera.NewWitnessGroup(1, wit2, wit3)),
+			signers:         []note.Signer{wit2Sign, wit3Sign},
+			expectSatisfied: false,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			n := &note.Note{
+				Text: "sign me\n",
+			}
+			cp, err := note.Sign(n, tC.signers...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := tC.group.Satisfied(cp), tC.expectSatisfied; got != want {
+				t.Errorf("Expected satisfied = %t but got %t", want, got)
+			}
+		})
+	}
+}
+
+func TestWitnessGroup_Urls(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		group        tessera.WitnessGroup
+		expectedUrls []string
+	}{
+		{
+			desc:         "witness 1",
+			group:        tessera.NewWitnessGroup(1, wit1),
+			expectedUrls: []string{"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add"},
+		},
+		{
+			desc:         "witness 2",
+			group:        tessera.NewWitnessGroup(1, wit2),
+			expectedUrls: []string{"https://b1.example.com/7a99cf3d04ea875d413c4b3fb70d74ef483efaf667eac56e35f0b96a112b1c84/add"},
+		},
+		{
+			desc:         "witness 3",
+			group:        tessera.NewWitnessGroup(1, wit3),
+			expectedUrls: []string{"https://b2.example.com/ae59f4e59ea1802501b6000f875f09eb49d267055d4a1df8b6d862edc004334c/add"},
+		},
+		{
+			desc:  "all witnesses in one group",
+			group: tessera.NewWitnessGroup(1, wit1, wit2, wit3),
+			expectedUrls: []string{
+				"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add",
+				"https://b1.example.com/7a99cf3d04ea875d413c4b3fb70d74ef483efaf667eac56e35f0b96a112b1c84/add",
+				"https://b2.example.com/ae59f4e59ea1802501b6000f875f09eb49d267055d4a1df8b6d862edc004334c/add",
+			},
+		},
+		{
+			desc:  "all witnesses with duplicates in nests", // This currently expects duplicates, but this behaviour may change
+			group: tessera.NewWitnessGroup(2, tessera.NewWitnessGroup(1, wit1, wit2), tessera.NewWitnessGroup(1, wit1, wit3)),
+			expectedUrls: []string{
+				"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add",
+				"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add",
+				"https://b1.example.com/7a99cf3d04ea875d413c4b3fb70d74ef483efaf667eac56e35f0b96a112b1c84/add",
+				"https://b2.example.com/ae59f4e59ea1802501b6000f875f09eb49d267055d4a1df8b6d862edc004334c/add",
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			gotUrls := tC.group.Urls()
+			gotStrings := make([]string, len(gotUrls))
+			for i, u := range gotUrls {
+				gotStrings[i] = u.String()
+			}
+			slices.Sort(gotStrings)
+			slices.Sort(tC.expectedUrls)
+
+			if !slices.Equal(gotStrings, tC.expectedUrls) {
+				t.Errorf("Expected %s but got %s", tC.expectedUrls, gotStrings)
+			}
+		})
+	}
+}
+
+// This is benchmarked because this may well get called a number of times, and there are potentially
+// other ways to implement this that don't involve so many note.Open calls.
+func BenchmarkWitnessGroupSatisfaction(b *testing.B) {
+	group := tessera.NewWitnessGroup(2, wit1, tessera.NewWitnessGroup(1, wit2, wit3))
+	n := &note.Note{
+		Text: "sign me\n",
+	}
+	cp, err := note.Sign(n, wit1Sign, wit2Sign, wit3Sign)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		if !group.Satisfied(cp) {
+			b.Fatal("Group should have been satisfied!")
+		}
+	}
+}

--- a/witness_test.go
+++ b/witness_test.go
@@ -125,31 +125,31 @@ func TestWitnessGroup_Satisfied(t *testing.T) {
 	}
 }
 
-func TestWitnessGroup_Urls(t *testing.T) {
+func TestWitnessGroup_URLs(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		group        tessera.WitnessGroup
-		expectedUrls []string
+		expectedURLs []string
 	}{
 		{
 			desc:         "witness 1",
 			group:        tessera.NewWitnessGroup(1, wit1),
-			expectedUrls: []string{"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add"},
+			expectedURLs: []string{"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add"},
 		},
 		{
 			desc:         "witness 2",
 			group:        tessera.NewWitnessGroup(1, wit2),
-			expectedUrls: []string{"https://b1.example.com/7a99cf3d04ea875d413c4b3fb70d74ef483efaf667eac56e35f0b96a112b1c84/add"},
+			expectedURLs: []string{"https://b1.example.com/7a99cf3d04ea875d413c4b3fb70d74ef483efaf667eac56e35f0b96a112b1c84/add"},
 		},
 		{
 			desc:         "witness 3",
 			group:        tessera.NewWitnessGroup(1, wit3),
-			expectedUrls: []string{"https://b2.example.com/ae59f4e59ea1802501b6000f875f09eb49d267055d4a1df8b6d862edc004334c/add"},
+			expectedURLs: []string{"https://b2.example.com/ae59f4e59ea1802501b6000f875f09eb49d267055d4a1df8b6d862edc004334c/add"},
 		},
 		{
 			desc:  "all witnesses in one group",
 			group: tessera.NewWitnessGroup(1, wit1, wit2, wit3),
-			expectedUrls: []string{
+			expectedURLs: []string{
 				"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add",
 				"https://b1.example.com/7a99cf3d04ea875d413c4b3fb70d74ef483efaf667eac56e35f0b96a112b1c84/add",
 				"https://b2.example.com/ae59f4e59ea1802501b6000f875f09eb49d267055d4a1df8b6d862edc004334c/add",
@@ -158,7 +158,7 @@ func TestWitnessGroup_Urls(t *testing.T) {
 		{
 			desc:  "all witnesses with duplicates in nests", // This currently expects duplicates, but this behaviour may change
 			group: tessera.NewWitnessGroup(2, tessera.NewWitnessGroup(1, wit1, wit2), tessera.NewWitnessGroup(1, wit1, wit3)),
-			expectedUrls: []string{
+			expectedURLs: []string{
 				"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add",
 				"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add",
 				"https://b1.example.com/7a99cf3d04ea875d413c4b3fb70d74ef483efaf667eac56e35f0b96a112b1c84/add",
@@ -168,16 +168,16 @@ func TestWitnessGroup_Urls(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			gotUrls := tC.group.Urls()
-			gotStrings := make([]string, len(gotUrls))
-			for i, u := range gotUrls {
+			gotURLs := tC.group.URLs()
+			gotStrings := make([]string, len(gotURLs))
+			for i, u := range gotURLs {
 				gotStrings[i] = u.String()
 			}
 			slices.Sort(gotStrings)
-			slices.Sort(tC.expectedUrls)
+			slices.Sort(tC.expectedURLs)
 
-			if !slices.Equal(gotStrings, tC.expectedUrls) {
-				t.Errorf("Expected %s but got %s", tC.expectedUrls, gotStrings)
+			if !slices.Equal(gotStrings, tC.expectedURLs) {
+				t.Errorf("Expected %s but got %s", tC.expectedURLs, gotStrings)
 			}
 		})
 	}


### PR DESCRIPTION
This allows the required witnesses to be defined and the theshold
policies that apply within each group. Arbitrarily nested structures can
be built, each with different numbers of signatures.

Each WitnessGroup provides the URLs at which the witness can be reached
to perform witnessing, and a function that determines if the group is
satisfied.

This format is consistent with the only other known witness policy
configuration format out there:
https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/main/doc/policy.md

Towards #309.
