### PR TITLE
Antispam WithOption

### DIFF
--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -78,7 +78,7 @@ func main() {
 		tessera.WithCheckpointInterval(*publishInterval),
 		tessera.WithBatching(1024, time.Second),
 		tessera.WithPushback(10*4096),
-		tessera.WithAppendDeduplication(tessera.InMemoryDedupe(256)))
+		tessera.WithAntispam(256, nil))
 	if err != nil {
 		klog.Exit(err)
 	}

--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -33,12 +33,12 @@ import (
 )
 
 var (
-	bucket            = flag.String("bucket", "", "Bucket to use for storing log")
-	listen            = flag.String("listen", ":2024", "Address:port to listen on")
-	spanner           = flag.String("spanner", "", "Spanner resource URI ('projects/.../...')")
-	signer            = flag.String("signer", "", "Note signer to use to sign checkpoints")
-	persistentDedup   = flag.Bool("gcp_dedup", false, "EXPERIMENTAL: Set to true to enable persistent dedupe storage")
-	additionalSigners = []string{}
+	bucket             = flag.String("bucket", "", "Bucket to use for storing log")
+	listen             = flag.String("listen", ":2024", "Address:port to listen on")
+	spanner            = flag.String("spanner", "", "Spanner resource URI ('projects/.../...')")
+	signer             = flag.String("signer", "", "Note signer to use to sign checkpoints")
+	persistentAntispam = flag.Bool("antispam", false, "EXPERIMENTAL: Set to true to enable GCP-based persistent antispam storage")
+	additionalSigners  = []string{}
 )
 
 func init() {
@@ -63,11 +63,11 @@ func main() {
 	}
 
 	var antispam tessera.Antispam
-	// PersistentDedup is currently experimental, so there's no terraform or documentation yet!
-	if *persistentDedup {
-		antispam, err = gcp.NewDedupe(ctx, fmt.Sprintf("%s_dedup", *spanner))
+	// Persistent antispam is currently experimental, so there's no terraform or documentation yet!
+	if *persistentAntispam {
+		antispam, err = gcp.NewAntispam(ctx, fmt.Sprintf("%s_dedup", *spanner))
 		if err != nil {
-			klog.Exitf("Failed to create new GCP dedupe: %v", err)
+			klog.Exitf("Failed to create new GCP antispam storage: %v", err)
 		}
 	}
 

--- a/cmd/conformance/mysql/main.go
+++ b/cmd/conformance/mysql/main.go
@@ -70,7 +70,7 @@ func main() {
 	appender, reader, err := tessera.NewAppender(ctx, driver,
 		tessera.WithCheckpointSigner(noteSigner, additionalSigners...),
 		tessera.WithCheckpointInterval(*publishInterval),
-		tessera.WithAppendDeduplication(tessera.InMemoryDedupe(256)))
+		tessera.WithAntispam(256, nil))
 	addFn := appender.Add
 	if err != nil {
 		klog.Exit(err)

--- a/cmd/conformance/posix/main.go
+++ b/cmd/conformance/posix/main.go
@@ -71,7 +71,7 @@ func main() {
 	appender, _, err := tessera.NewAppender(ctx, driver,
 		tessera.WithCheckpointSigner(s, a...),
 		tessera.WithBatching(256, time.Second),
-		tessera.WithAppendDeduplication(tessera.InMemoryDedupe(256)))
+		tessera.WithAntispam(256, nil))
 	if err != nil {
 		klog.Exit(err)
 	}

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -127,7 +127,7 @@ type Antispam interface {
 	// Populate should be a long-running function which uses the provided log reader to build the
 	// antispam index used by the dectorator above.
 	//
-	// Typically, implementations of this function  will tail the contents of the log using the provided
+	// Typically, implementations of this function will tail the contents of the log using the provided
 	// log reader to stream entry bundles from the log, and, for each entry bundle, use the
 	// provided bundle function to convert the bundle into a slice of identity hashes which
 	// corresponds to the entries the bundle contains. These hashes should then be used to populate

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -111,6 +111,9 @@ func NewAppender(ctx context.Context, d Driver, opts ...func(*AppendOptions)) (*
 	for i := len(resolved.AddDecorators) - 1; i >= 0; i-- {
 		a.Add = resolved.AddDecorators[i](a.Add)
 	}
+	for _, f := range resolved.Followers {
+		go f(ctx, r)
+	}
 	return a, r, nil
 }
 

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -70,8 +70,8 @@ type LogReader interface {
 	// Each call to `next` will return raw entry bundle bytes along with a RangeInfo struct which
 	// contains information on which entries within that bundle are to be considered valid.
 	//
-	// next will return ErrNoMoreEntries if it has reached the extent of the current tree, but
-	// later calls will resume returning entry bundles if the tree has grown in the meantime.
+	// next will hang if it has reached the extent of the current tree, and return once either
+	// the tree has grown and more entries are available, or cancel was called.
 	//
 	// next will cease iterating if either:
 	//   - it produces an error (e.g. via the underlying calls to the log storage)

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -434,6 +434,16 @@ func (lr *logResourceStore) ReadEntryBundle(ctx context.Context, i uint64, p uin
 	return lr.get(ctx, lr.entriesPath(i, p))
 }
 
+func (lr *logResourceStore) IntegratedSize(ctx context.Context) (uint64, error) {
+	return 0, errors.New("unimplemented")
+}
+
+func (lr *logResourceStore) StreamEntries(ctx context.Context, fromEntry uint64) (next func() (ri layout.RangeInfo, bundle []byte, err error), cancel func()) {
+	return func() (layout.RangeInfo, []byte, error) {
+		return layout.RangeInfo{}, nil, errors.New("unimplemented")
+	}, func() {}
+}
+
 // get returns the requested object.
 //
 // This is indended to be used to proxy read requests through the personality for debug/testing purposes.

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -495,20 +495,17 @@ func streamAdaptor(ctx context.Context, getSize getSizeFn, getBundle getBundleFn
 		if streamErr != nil {
 			return layout.RangeInfo{}, nil, streamErr
 		}
-		select {
-		case f, ok := <-bundles:
-			if !ok {
-				streamErr = errors.New("stream stopped")
-				return layout.RangeInfo{}, nil, streamErr
-			}
-			b := f()
-			if b.err != nil {
-				streamErr = b.err
-			}
-			return b.ri, b.b, b.err
-		default:
+
+		f, ok := <-bundles
+		if !ok {
+			streamErr = tessera.ErrNoMoreEntries
+			return layout.RangeInfo{}, nil, streamErr
 		}
-		return layout.RangeInfo{}, nil, tessera.ErrNoMoreEntries
+		b := f()
+		if b.err != nil {
+			streamErr = b.err
+		}
+		return b.ri, b.b, b.err
 	}
 	return next, cancel
 }

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -346,51 +346,82 @@ func TestBundleRoundtrip(t *testing.T) {
 	}
 }
 
-func TestStreamEntryRange(t *testing.T) {
+func TestStreamEntries(t *testing.T) {
 	ctx := context.Background()
 	m := newMemObjStore()
-	s := &logResourceStore{
-		objStore:    m,
-		entriesPath: layout.EntriesPath,
+
+	logSize1 := 12345
+	logSize2 := 100045
+
+	logSize := logSize1
+
+	s := &LogReader{
+		lrs: logResourceStore{
+			objStore:    m,
+			entriesPath: layout.EntriesPath,
+		},
+		integratedSize: func(context.Context) (uint64, error) { return uint64(logSize), nil },
 	}
 
-	logSize := 100045
-	wantBundles := [][]byte{}
-
-	for r, idx := logSize, uint64(0); r > 0; idx++ {
+	// Populate entry bundles:
+	// first to logSize1 (so we're sure we've got the partial bundle)
+	for r, idx := logSize1, uint64(0); r > 0; idx++ {
 		sz := layout.EntryBundleWidth
 		if sz > r {
 			sz = r
 		}
 		b := makeBundle(t, idx, sz)
-		if err := s.setEntryBundle(ctx, idx, uint8(sz), b); err != nil {
+		if err := s.lrs.setEntryBundle(ctx, idx, uint8(sz), b); err != nil {
 			t.Fatalf("setEntryBundle(%d): %v", idx, err)
 		}
-		wantBundles = append(wantBundles, b)
 		r -= sz
-
 	}
-	wantIdx := uint64(0)
-	next, stop := s.StreamEntryRange(ctx, 0, uint64(logSize), uint64(logSize))
-	defer stop()
+	// Then on to logSize2
+	for r, idx := logSize2, uint64(0); r > 0; idx++ {
+		sz := layout.EntryBundleWidth
+		if sz > r {
+			sz = r
+		}
+		b := makeBundle(t, idx, sz)
+		if err := s.lrs.setEntryBundle(ctx, idx, uint8(sz), b); err != nil {
+			t.Fatalf("setEntryBundle(%d): %v", idx, err)
+		}
+		r -= sz
+	}
+
+	// Finally, try to stream all the bundles back.
+	// We'll first try to stream up to logSize1, then when we reach it we'll
+	// make the tree appear to grow to logSize2 to test resuming.
+	seenEntries := uint64(0)
+	next, stop := s.StreamEntries(ctx, 0)
 
 	for {
-		gotRI, gotBundle, gotErr := next()
+		gotRI, _, gotErr := next()
 		if gotErr != nil {
-			t.Logf("gotErr after %d: %v", wantIdx, gotErr)
+			if errors.Is(gotErr, tessera.ErrNoMoreEntries) {
+				if seenEntries == uint64(logSize) {
+					// We've fetched all the entries from the original tree size, now we'll make
+					// the tree appear to have grown to the final size.
+					// The stream should start returning bundles again until we've consumed them all.
+					t.Log("Reached logSize, growing tree")
+					logSize = logSize2
+					time.Sleep(time.Second)
+				}
+				continue
+			}
+			t.Fatalf("gotErr after %d: %v", seenEntries, gotErr)
+		}
+		if e := gotRI.Index*layout.EntryBundleWidth + uint64(gotRI.First); e != seenEntries {
+			t.Fatalf("got idx %d, want %d", e, seenEntries)
+		}
+		seenEntries += uint64(gotRI.N)
+		t.Logf("got RI %d / %d", gotRI.Index, seenEntries)
+
+		if seenEntries == uint64(logSize2) {
+			// We've seen all the entries we created
+			stop()
 			break
 		}
-		if gotRI.Index != wantIdx {
-			t.Fatalf("got idx %d, want %d", gotRI.Index, wantIdx)
-		}
-		if diff := cmp.Diff(gotBundle, wantBundles[0]); diff != "" {
-			t.Fatalf("streamEntryBundles returned unexpected data: %s", diff)
-		}
-		wantBundles = wantBundles[1:]
-		wantIdx++
-	}
-	if l := len(wantBundles); l > 0 {
-		t.Fatalf("Expected %d more bundles", l)
 	}
 }
 

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -301,6 +301,16 @@ func (s *Storage) ReadEntryBundle(ctx context.Context, index uint64, p uint8) ([
 	return entryBundle, nil
 }
 
+func (s *Storage) IntegratedSize(ctx context.Context) (uint64, error) {
+	return 0, errors.New("unimplemented")
+}
+
+func (s *Storage) StreamEntries(ctx context.Context, fromEntry uint64) (next func() (ri layout.RangeInfo, bundle []byte, err error), cancel func()) {
+	return func() (layout.RangeInfo, []byte, error) {
+		return layout.RangeInfo{}, nil, errors.New("unimplemented")
+	}, func() {}
+}
+
 func (s *Storage) writeEntryBundle(ctx context.Context, tx *sql.Tx, index uint64, size uint32, entryBundle []byte) error {
 	if _, err := tx.ExecContext(ctx, replaceTiledLeavesSQL, index, size, entryBundle); err != nil {
 		klog.Errorf("Failed to execute replaceTiledLeavesSQL: %v", err)

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -189,6 +189,17 @@ func (l *logResourceStorage) ReadTile(_ context.Context, level, index uint64, p 
 	return os.ReadFile(filepath.Join(l.s.path, layout.TilePath(level, index, p)))
 }
 
+func (l *logResourceStorage) IntegratedSize(_ context.Context) (uint64, error) {
+	size, _, err := l.s.readTreeState()
+	return size, err
+}
+
+func (l *logResourceStorage) StreamEntries(ctx context.Context, fromEntry uint64) (next func() (ri layout.RangeInfo, bundle []byte, err error), cancel func()) {
+	return func() (layout.RangeInfo, []byte, error) {
+		return layout.RangeInfo{}, nil, errors.New("unimplemented")
+	}, func() {}
+}
+
 // sequenceBatch writes the entries from the provided batch into the entry bundle files of the log.
 //
 // This func starts filling entries bundles at the next available slot in the log, ensuring that the


### PR DESCRIPTION
This PR introduces a `WithAntispam` option which handles both the in-memory and an (optional) persistent antispam implementation.

Towards #469 