### PR TITLE
wrap errors from spanner calls inside txn

### DIFF
--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -770,11 +770,11 @@ func (s *spannerSequencer) assignEntries(ctx context.Context, entries []*tessera
 		// First we need to grab the next available sequence number from the SeqCoord table.
 		row, err := txn.ReadRowWithOptions(ctx, "SeqCoord", spanner.Key{0}, []string{"id", "next"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 		if err != nil {
-			return fmt.Errorf("failed to read SeqCoord: %v", err)
+			return fmt.Errorf("failed to read SeqCoord: %w", err)
 		}
 		var id int64
 		if err := row.Columns(&id, &next); err != nil {
-			return fmt.Errorf("failed to parse id column: %v", err)
+			return fmt.Errorf("failed to parse id column: %w", err)
 		}
 
 		// Check whether there are too many outstanding entries and we should apply
@@ -811,7 +811,7 @@ func (s *spannerSequencer) assignEntries(ctx context.Context, entries []*tessera
 			spanner.Update("SeqCoord", []string{"id", "next"}, []interface{}{0, int64(next) + int64(num)}),
 		}
 		if err := txn.BufferWrite(m); err != nil {
-			return fmt.Errorf("failed to apply TX: %v", err)
+			return fmt.Errorf("failed to apply TX: %w", err)
 		}
 
 		return nil
@@ -841,7 +841,7 @@ func (s *spannerSequencer) consumeEntries(ctx context.Context, limit uint64, f c
 		var fromSeq int64 // Spanner doesn't support uint64
 		var rootHash []byte
 		if err := row.Columns(&fromSeq, &rootHash); err != nil {
-			return fmt.Errorf("failed to read integration coordination info: %v", err)
+			return fmt.Errorf("failed to read integration coordination info: %w", err)
 		}
 		klog.V(1).Infof("Consuming from %d", fromSeq)
 
@@ -864,7 +864,7 @@ func (s *spannerSequencer) consumeEntries(ctx context.Context, limit uint64, f c
 			var vGob []byte
 			var seq int64 // spanner doesn't have uint64
 			if err := row.Columns(&seq, &vGob); err != nil {
-				return fmt.Errorf("failed to scan seq row: %v", err)
+				return fmt.Errorf("failed to scan seq row: %w", err)
 			}
 
 			if orderCheck != seq {
@@ -1201,7 +1201,7 @@ func (d *AntispamStorage) Populate(ctx context.Context, lr tessera.LogReader, bu
 
 				var f int64 // Spanner doesn't support uint64
 				if err := row.Columns(&f); err != nil {
-					return fmt.Errorf("failed to read follow coordination info: %v", err)
+					return fmt.Errorf("failed to read follow coordination info: %w", err)
 				}
 				followFrom := uint64(f)
 				if followFrom >= size {
@@ -1446,7 +1446,7 @@ func (m *MigrationStorage) buildTree(ctx context.Context, sourceSize uint64) (ui
 		var fromSeq int64 // Spanner doesn't support uint64
 		var rootHash []byte
 		if err := row.Columns(&fromSeq, &rootHash); err != nil {
-			return fmt.Errorf("failed to read integration coordination info: %v", err)
+			return fmt.Errorf("failed to read integration coordination info: %w", err)
 		}
 
 		from := uint64(fromSeq)


### PR DESCRIPTION
Fixes: #497 

I only wrapped the calls within a transaction that were calling spanner APIs so that those return codes would get bubbled up to the transaction layer... without a mock of spanner this will be hard to test.