### PR TITLE
Migration lifecycle options

### DIFF
--- a/cmd/experimental/migrate/gcp/main.go
+++ b/cmd/experimental/migrate/gcp/main.go
@@ -73,7 +73,7 @@ func main() {
 		klog.Exitf("Failed to create new GCP storage driver: %v", err)
 	}
 
-	m, err := tessera.NewMigrationTarget(ctx, driver, internal.BundleHasher, tessera.NewAppendOptions())
+	m, err := tessera.NewMigrationTarget(ctx, driver, internal.BundleHasher, tessera.NewMigrationOptions())
 	if err != nil {
 		klog.Exitf("Failed to create MigrationTarget: %v", err)
 	}

--- a/cmd/experimental/migrate/posix/main.go
+++ b/cmd/experimental/migrate/posix/main.go
@@ -69,7 +69,7 @@ func main() {
 		klog.Exitf("Failed to create new POSIX storage driver: %v", err)
 	}
 	// Create our Tessera migration target instance
-	st, err := tessera.NewMigrationTarget(ctx, driver, internal.BundleHasher, tessera.NewAppendOptions())
+	st, err := tessera.NewMigrationTarget(ctx, driver, internal.BundleHasher, tessera.NewMigrationOptions())
 	if err != nil {
 		klog.Exitf("Failed to create new POSIX storage: %v", err)
 	}

--- a/ct_only.go
+++ b/ct_only.go
@@ -67,6 +67,12 @@ func (o *AppendOptions) WithCTLayout() *AppendOptions {
 	return o
 }
 
+// WithCTLayout instructs the underlying storage to use a Static CT API compatible scheme for layout.
+func (o *MigrationOptions) WithCTLayout() *MigrationOptions {
+	o.entriesPath = ctEntriesPath
+	return o
+}
+
 func ctEntriesPath(n uint64, p uint8) string {
 	return fmt.Sprintf("tile/data/%s", layout.NWithSuffix(0, n, p))
 }

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -261,9 +261,9 @@ type UnbundlerFunc func(entryBundle []byte) ([][]byte, error)
 //
 // TODO(al): bundleHasher should be implicit from WithCTLayout being present or not.
 // TODO(al): AppendOptions should be somehow replaced - perhaps MigrationOptions, or some other way of limiting options to those which make sense for this lifecycle mode.
-func NewMigrationTarget(ctx context.Context, d Driver, bundleHasher UnbundlerFunc, opts *AppendOptions) (MigrationTarget, error) {
+func NewMigrationTarget(ctx context.Context, d Driver, bundleHasher UnbundlerFunc, opts *MigrationOptions) (MigrationTarget, error) {
 	type migrateLifecycle interface {
-		MigrationTarget(context.Context, UnbundlerFunc, *AppendOptions) (MigrationTarget, LogReader, error)
+		MigrationTarget(context.Context, UnbundlerFunc, *MigrationOptions) (MigrationTarget, LogReader, error)
 	}
 	lc, ok := d.(migrateLifecycle)
 	if !ok {
@@ -277,4 +277,25 @@ func NewMigrationTarget(ctx context.Context, d Driver, bundleHasher UnbundlerFun
 		go f(ctx, r)
 	}
 	return m, nil
+}
+
+func NewMigrationOptions() *MigrationOptions {
+	return &MigrationOptions{
+		entriesPath: layout.EntriesPath,
+	}
+}
+
+// MigrationOptions holds migration lifecycle settings for all storage implementations.
+type MigrationOptions struct {
+	// EntriesPath knows how to format entry bundle paths.
+	entriesPath func(n uint64, p uint8) string
+	followers   []func(context.Context, LogReader)
+}
+
+func (o MigrationOptions) EntriesPath() func(uint64, uint8) string {
+	return o.entriesPath
+}
+
+func (o MigrationOptions) Followers() []func(context.Context, LogReader) {
+	return o.followers
 }

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -287,7 +287,7 @@ func NewMigrationOptions() *MigrationOptions {
 
 // MigrationOptions holds migration lifecycle settings for all storage implementations.
 type MigrationOptions struct {
-	// EntriesPath knows how to format entry bundle paths.
+	// entriesPath knows how to format entry bundle paths.
 	entriesPath func(n uint64, p uint8) string
 	followers   []func(context.Context, LogReader)
 }

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -1317,7 +1317,7 @@ func (d *AntispamStorage) Populate(ctx context.Context, lr tessera.LogReader, bu
 }
 
 // MigrationTarget creates a new GCP storage for the MigrationTarget lifecycle mode.
-func (s *Storage) MigrationTarget(ctx context.Context, bundleHasher tessera.UnbundlerFunc, opts *tessera.AppendOptions) (tessera.MigrationTarget, tessera.LogReader, error) {
+func (s *Storage) MigrationTarget(ctx context.Context, bundleHasher tessera.UnbundlerFunc, opts *tessera.MigrationOptions) (tessera.MigrationTarget, tessera.LogReader, error) {
 	c, err := gcs.NewClient(ctx, gcs.WithJSONReads())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create GCS client: %v", err)
@@ -1337,7 +1337,7 @@ func (s *Storage) MigrationTarget(ctx context.Context, bundleHasher tessera.Unbu
 				gcsClient: c,
 				bucket:    s.cfg.Bucket,
 			},
-			entriesPath: layout.EntriesPath,
+			entriesPath: opts.EntriesPath(),
 		},
 	}
 

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -676,7 +676,7 @@ func createEx(p string, d []byte) error {
 }
 
 // MigrationTarget creates a new POSIX storage for the MigrationTarget lifecycle mode.
-func (s *Storage) MigrationTarget(ctx context.Context, bundleHasher tessera.UnbundlerFunc, opts *tessera.AppendOptions) (tessera.MigrationTarget, tessera.LogReader, error) {
+func (s *Storage) MigrationTarget(ctx context.Context, bundleHasher tessera.UnbundlerFunc, opts *tessera.MigrationOptions) (tessera.MigrationTarget, tessera.LogReader, error) {
 	r := &MigrationStorage{
 		s: s,
 		logStorage: &logResourceStorage{
@@ -684,7 +684,6 @@ func (s *Storage) MigrationTarget(ctx context.Context, bundleHasher tessera.Unbu
 			s:           s,
 		},
 		bundleHasher: bundleHasher,
-		entriesPath:  opts.EntriesPath(),
 	}
 	if err := r.initialise(); err != nil {
 		return nil, nil, err
@@ -697,7 +696,6 @@ type MigrationStorage struct {
 	s            *Storage
 	logStorage   *logResourceStorage
 	bundleHasher tessera.UnbundlerFunc
-	entriesPath  func(uint64, uint8) string
 	curSize      uint64
 }
 


### PR DESCRIPTION
This PR adds `MigrationOptions` to be used with the migration target lifecycle.