### PR TITLE
Add antispam support to migration lifecycle

### DIFF
--- a/cmd/experimental/migrate/gcp/main.go
+++ b/cmd/experimental/migrate/gcp/main.go
@@ -95,6 +95,9 @@ func main() {
 	if err := internal.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, src.ReadEntryBundle, m); err != nil {
 		klog.Exitf("Migrate failed: %v", err)
 	}
+
+	// TODO(#341): wait for antispam follower to complete
+	<-make(chan bool)
 }
 
 // storageConfigFromFlags returns a gcp.Config struct populated with values

--- a/migrate_lifecycle.go
+++ b/migrate_lifecycle.go
@@ -90,3 +90,12 @@ func (o MigrationOptions) EntriesPath() func(uint64, uint8) string {
 func (o MigrationOptions) Followers() []func(context.Context, LogReader) {
 	return o.followers
 }
+
+func (o *MigrationOptions) WithAntispam(as Antispam) *MigrationOptions {
+	if as != nil {
+		o.followers = append(o.followers, func(ctx context.Context, lr LogReader) {
+			as.Populate(ctx, lr, defaultIDHasher)
+		})
+	}
+	return o
+}

--- a/migrate_lifecycle.go
+++ b/migrate_lifecycle.go
@@ -91,6 +91,11 @@ func (o MigrationOptions) Followers() []func(context.Context, LogReader) {
 	return o.followers
 }
 
+// WithAntispam configures the migration target to *populate* the provided antispam storage using
+// the data being migrated into the target tree.
+//
+// Note that since the tree is being _migrated_, the resulting target tree must match the structure
+// of the source tree and so no attempt is made to reject/deduplicate entries.
 func (o *MigrationOptions) WithAntispam(as Antispam) *MigrationOptions {
 	if as != nil {
 		o.followers = append(o.followers, func(ctx context.Context, lr LogReader) {

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -1218,7 +1218,7 @@ func (d *AntispamStorage) Populate(ctx context.Context, lr tessera.LogReader, bu
 				}
 
 				// TODO(al): Maybe make these configurable.
-				const batchSize = 64
+				const batchSize = 40
 				const pushBackThreshold = batchSize * 16
 				d.pushBack.Store(size-followFrom > pushBackThreshold)
 


### PR DESCRIPTION
This PR adds an antispam option to the Migration lifecycle, and shows its use in the GCP migrate tool.

Towards #469 