### PR TITLE
[Hammer] support more verbose checkpoint logging

### DIFF
--- a/internal/hammer/loadtest/hammer.go
+++ b/internal/hammer/loadtest/hammer.go
@@ -108,6 +108,8 @@ func (h *Hammer) updateCheckpointLoop(ctx context.Context) {
 			newSize := h.tracker.LatestConsistent.Size
 			if newSize > size {
 				klog.V(1).Infof("Updated checkpoint from %d to %d", size, newSize)
+			} else {
+				klog.V(2).Infof("Checkpoint size unchanged: %d", newSize)
 			}
 		}
 	}


### PR DESCRIPTION
If the checkpoint size isn't updating, this logging will at least allow visibility that the main loop is still running.
