### PR TITLE
[Witnessing] Use witnessing in all drivers

### DIFF
--- a/internal/witness/witness_test.go
+++ b/internal/witness/witness_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package witness
+package witness_test
 
 import (
 	"bytes"
@@ -30,6 +30,7 @@ import (
 	"github.com/transparency-dev/formats/log"
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/internal/witness"
 	"github.com/transparency-dev/trillian-tessera/storage/posix"
 	"golang.org/x/mod/sumdb/note"
 )
@@ -151,7 +152,7 @@ func TestWitnessGateway_Update(t *testing.T) {
 		t.Run(tC.desc, func(t *testing.T) {
 			ctx := context.Background()
 
-			g := NewWitnessGateway(tC.group, ts.Client(), testLogTileFetcher)
+			g := witness.NewWitnessGateway(tC.group, ts.Client(), testLogTileFetcher)
 
 			witnessedCP, err := g.Witness(ctx, logSignedCheckpoint)
 			if got, want := err != nil, tC.wantErr; got != want {
@@ -238,7 +239,7 @@ func TestWitness_UpdateRequest(t *testing.T) {
 				t.Fatal(err)
 			}
 			group := tessera.NewWitnessGroup(1, wit1)
-			wg := NewWitnessGateway(group, ts.Client(), reader.ReadTile)
+			wg := witness.NewWitnessGateway(group, ts.Client(), reader.ReadTile)
 			_, err = wg.Witness(ctx, logSignedCheckpoint)
 			if got, want := err != nil, tC.wantErr; got != want {
 				t.Fatalf("got != want (%t != %t): %v", got, want, err)
@@ -309,7 +310,7 @@ func TestWitness_UpdateResponse(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			g := NewWitnessGateway(tessera.NewWitnessGroup(1, wit1), ts.Client(), testLogTileFetcher)
+			g := witness.NewWitnessGateway(tessera.NewWitnessGroup(1, wit1), ts.Client(), testLogTileFetcher)
 			witnessed, err := g.Witness(ctx, logSignedCheckpoint)
 			if got, want := err != nil, tC.wantErr; got != want {
 				t.Fatalf("got != want (%t != %t): %v", got, want, err)
@@ -378,7 +379,7 @@ func TestWitnessStateEvolution(t *testing.T) {
 
 	ctx := context.Background()
 
-	g := NewWitnessGateway(group, ts.Client(), testLogTileFetcher)
+	g := witness.NewWitnessGateway(group, ts.Client(), testLogTileFetcher)
 	// This call will trigger case 0 and then case 1 in the witness handler above.
 	// case 0 will return a response that notifies the log that its view of the witness size is wrong.
 	// This method will then update its size and make a second request with a consistency proof, triggering case 1.
@@ -442,8 +443,8 @@ func TestWitnessReusesProofs(t *testing.T) {
 		tf2.Add(1)
 		return testLogTileFetcher(ctx, level, index, p)
 	}
-	g1 := NewWitnessGateway(tessera.NewWitnessGroup(1, wit1), ts.Client(), cf1)
-	g2 := NewWitnessGateway(tessera.NewWitnessGroup(2, wit1, wit2), ts.Client(), cf2)
+	g1 := witness.NewWitnessGateway(tessera.NewWitnessGroup(1, wit1), ts.Client(), cf1)
+	g2 := witness.NewWitnessGateway(tessera.NewWitnessGroup(2, wit1, wit2), ts.Client(), cf2)
 
 	for i := range 10 {
 		logSignedCheckpoint, _ := loadCheckpoint(t, i)


### PR DESCRIPTION
All drivers now take set up witnessing as configured in the AppendOptions. If no options are provided then this is still set up, but does nothing. Towards #309.  This required changing the witness tests package to avoid a package cycle; the posix implementation now uses the witness, but the witness tests use posix.

This is based on #514, and that needs to be merged first.