### PR TITLE
[GCP] Add persistent anti-spam support to terraform

### DIFF
--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -66,7 +66,7 @@ func main() {
 	var antispam tessera.Antispam
 	// Persistent antispam is currently experimental, so there's no terraform or documentation yet!
 	if *persistentAntispam {
-		antispam, err = gcp_as.NewAntispam(ctx, fmt.Sprintf("%s_dedup", *spanner))
+		antispam, err = gcp_as.NewAntispam(ctx, fmt.Sprintf("%s-antispam", *spanner))
 		if err != nil {
 			klog.Exitf("Failed to create new GCP antispam storage: %v", err)
 		}

--- a/cmd/experimental/migrate/gcp/main.go
+++ b/cmd/experimental/migrate/gcp/main.go
@@ -81,7 +81,7 @@ func main() {
 	var antispam tessera.Antispam
 	// Persistent antispam is currently experimental, so there's no terraform or documentation yet!
 	if *persistentAntispam {
-		antispam, err = gcp_as.NewAntispam(ctx, fmt.Sprintf("%s_dedup", *spanner))
+		antispam, err = gcp_as.NewAntispam(ctx, fmt.Sprintf("%s-antispam", *spanner))
 		if err != nil {
 			klog.Exitf("Failed to create new GCP antispam storage: %v", err)
 		}

--- a/deployment/live/gcp/conformance/ci/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/ci/terragrunt.hcl
@@ -11,5 +11,6 @@ inputs = merge(
   include.root.locals,
   {
     base_name = get_env("TESSERA_BASE_NAME", "ci-conformance-${substr(uuid(), 0, 4)}")
+    enable_antispam = true
   }
 )

--- a/deployment/live/gcp/conformance/ci/terragrunt.hcl
+++ b/deployment/live/gcp/conformance/ci/terragrunt.hcl
@@ -10,7 +10,7 @@ include "root" {
 inputs = merge(
   include.root.locals,
   {
-    base_name = get_env("TESSERA_BASE_NAME", "ci-conformance-${substr(uuid(), 0, 4)}")
+    base_name       = get_env("TESSERA_BASE_NAME", "ci-conformance-${substr(uuid(), 0, 4)}")
     enable_antispam = true
   }
 )

--- a/deployment/modules/gcp/conformance/main.tf
+++ b/deployment/modules/gcp/conformance/main.tf
@@ -36,6 +36,7 @@ module "gcs" {
   project_id         = var.project_id
   bucket_readers     = local.readers
   log_writer_members = ["serviceAccount:${local.cloudrun_service_account}"]
+  create_antispam    = var.enable_antispam
   ephemeral          = true
 }
 
@@ -82,6 +83,7 @@ resource "google_cloud_run_v2_service" "default" {
         "--spanner=${local.spanner_db_full}",
         "--listen=:8080",
         "--signer=${var.signer}",
+        "--antispam=${var.enable_antispam}",
       ]
       ports {
         name           = "h2c"

--- a/deployment/modules/gcp/conformance/variables.tf
+++ b/deployment/modules/gcp/conformance/variables.tf
@@ -42,3 +42,8 @@ variable "conformance_readers" {
   description = "The list of users allowed to read the conformance t-log resources from GCS. If unset, only the project default service account will be able to read the t-log contents."
   type        = list(any)
 }
+
+variable "enable_antispam" {
+  description = "Set to true to enable persistent antispam feature on conformance instance."
+  type        = bool
+}

--- a/deployment/modules/gcp/gcs/main.tf
+++ b/deployment/modules/gcp/gcs/main.tf
@@ -62,7 +62,7 @@ resource "google_spanner_instance" "log_spanner" {
 
 resource "google_spanner_database" "log_db" {
   instance = google_spanner_instance.log_spanner.name
-  name     = "${var.base_name}-db"
+  name     = "${var.base_name}"
 
   deletion_protection = !var.ephemeral
 }
@@ -70,7 +70,7 @@ resource "google_spanner_database" "log_db" {
 resource "google_spanner_database" "log_antispam_db" {
   count    = var.create_antispam ? 1 : 0
   instance = google_spanner_instance.log_spanner.name
-  name     = "${var.base_name}-db_dedup"
+  name     = "${var.base_name}-antispam"
 
   deletion_protection = !var.ephemeral
 }

--- a/deployment/modules/gcp/gcs/main.tf
+++ b/deployment/modules/gcp/gcs/main.tf
@@ -67,9 +67,26 @@ resource "google_spanner_database" "log_db" {
   deletion_protection = !var.ephemeral
 }
 
+resource "google_spanner_database" "log_antispam_db" {
+  count    = var.create_antispam ? 1 : 0
+  instance = google_spanner_instance.log_spanner.name
+  name     = "${var.base_name}-db_dedup"
+
+  deletion_protection = !var.ephemeral
+}
+
 resource "google_spanner_database_iam_binding" "database" {
   instance = google_spanner_instance.log_spanner.name
   database = google_spanner_database.log_db.name
+  role     = "roles/spanner.databaseAdmin"
+
+  members = var.log_writer_members
+}
+
+resource "google_spanner_database_iam_binding" "database_antispam" {
+  count    = var.create_antispam ? 1 : 0
+  instance = google_spanner_instance.log_spanner.name
+  database = google_spanner_database.log_antispam_db[count.index].name
   role     = "roles/spanner.databaseAdmin"
 
   members = var.log_writer_members

--- a/deployment/modules/gcp/gcs/variables.tf
+++ b/deployment/modules/gcp/gcs/variables.tf
@@ -29,7 +29,12 @@ variable "log_writer_members" {
   type        = list(any)
 }
 
+variable "create_antispam" {
+  description = "Set to true to create the infrastructure required by the GCP antispam implementation"
+  type        = bool
+}
+
 variable "ephemeral" {
   description = "Set to true if this is a throwaway/temporary log instance. Will set attributes on created resources to allow them to be disabled/deleted more easily."
-  type = bool
+  type        = bool
 }

--- a/deployment/modules/gcp/gcs/variables.tf
+++ b/deployment/modules/gcp/gcs/variables.tf
@@ -30,7 +30,7 @@ variable "log_writer_members" {
 }
 
 variable "create_antispam" {
-  description = "Set to true to create the infrastructure required by the GCP antispam implementation"
+  description = "Set to true to create the infrastructure required by the GCP antispam implementation."
   type        = bool
 }
 


### PR DESCRIPTION
This PR adds support for:
 - the GCP terraform to optionally create infrastructure used by the GCP antispam implementation.
 - the conformance terraform to optionally create and use the GCP antispam support.

As a side-effect, the naming scheme for the Spanner databases has changed very slightly.
 
Towards #470 