### PR TITLE
Add CT support for migration

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -108,6 +108,7 @@ func NewAppendOptions() *AppendOptions {
 		batchMaxSize:           DefaultBatchMaxSize,
 		batchMaxAge:            DefaultBatchMaxAge,
 		entriesPath:            layout.EntriesPath,
+		bundleIDHasher:         defaultIDHasher,
 		checkpointInterval:     DefaultCheckpointInterval,
 		addDecorators:          make([]func(AddFn) AddFn, 0),
 		pushbackMaxOutstanding: DefaultPushbackMaxOutstanding,
@@ -126,6 +127,8 @@ type AppendOptions struct {
 
 	// EntriesPath knows how to format entry bundle paths.
 	entriesPath func(n uint64, p uint8) string
+	// bundleIDHasher knows how to create antispam leaf identities for entries in a serialised bundle.
+	bundleIDHasher func([]byte) ([][]byte, error)
 
 	checkpointInterval time.Duration
 	witnesses          WitnessGroup

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -97,7 +97,7 @@ func (o *AppendOptions) WithAntispam(inMemEntries uint, as Antispam) *AppendOpti
 	if as != nil {
 		o.addDecorators = append(o.addDecorators, as.Decorator())
 		o.followers = append(o.followers, func(ctx context.Context, lr LogReader) {
-			as.Populate(ctx, lr, defaultIDHasher)
+			as.Populate(ctx, lr, o.bundleIDHasher)
 		})
 	}
 	return o

--- a/cmd/experimental/migrate/gcp/main.go
+++ b/cmd/experimental/migrate/gcp/main.go
@@ -88,7 +88,7 @@ func main() {
 		opts.WithAntispam(antispam)
 	}
 
-	m, err := tessera.NewMigrationTarget(ctx, driver, internal.BundleHasher, opts)
+	m, err := tessera.NewMigrationTarget(ctx, driver, opts)
 	if err != nil {
 		klog.Exitf("Failed to create MigrationTarget: %v", err)
 	}

--- a/cmd/experimental/migrate/mysql/main.go
+++ b/cmd/experimental/migrate/mysql/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	opts := tessera.NewMigrationOptions()
 
-	m, err := tessera.NewMigrationTarget(ctx, driver, internal.BundleHasher, opts)
+	m, err := tessera.NewMigrationTarget(ctx, driver, opts)
 	if err != nil {
 		klog.Exitf("Failed to create MigrationTarget: %v", err)
 	}

--- a/cmd/experimental/migrate/posix/main.go
+++ b/cmd/experimental/migrate/posix/main.go
@@ -69,7 +69,7 @@ func main() {
 		klog.Exitf("Failed to create new POSIX storage driver: %v", err)
 	}
 	// Create our Tessera migration target instance
-	st, err := tessera.NewMigrationTarget(ctx, driver, internal.BundleHasher, tessera.NewMigrationOptions())
+	st, err := tessera.NewMigrationTarget(ctx, driver, tessera.NewMigrationOptions())
 	if err != nil {
 		klog.Exitf("Failed to create new POSIX storage: %v", err)
 	}

--- a/ct_only.go
+++ b/ct_only.go
@@ -16,10 +16,13 @@ package tessera
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 
+	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
 	"github.com/transparency-dev/trillian-tessera/ctonly"
+	"golang.org/x/crypto/cryptobyte"
 )
 
 // Storage described the expected functions from Tessera storage implementations.
@@ -64,15 +67,182 @@ func convertCTEntry(e *ctonly.Entry) *Entry {
 // WithCTLayout instructs the underlying storage to use a Static CT API compatible scheme for layout.
 func (o *AppendOptions) WithCTLayout() *AppendOptions {
 	o.entriesPath = ctEntriesPath
+	o.bundleIDHasher = ctBundleIDHasher
 	return o
 }
 
 // WithCTLayout instructs the underlying storage to use a Static CT API compatible scheme for layout.
 func (o *MigrationOptions) WithCTLayout() *MigrationOptions {
 	o.entriesPath = ctEntriesPath
+	o.bundleIDHasher = ctBundleIDHasher
+	o.bundleLeafHasher = ctMerkleLeafHasher
 	return o
 }
 
 func ctEntriesPath(n uint64, p uint8) string {
 	return fmt.Sprintf("tile/data/%s", layout.NWithSuffix(0, n, p))
+}
+
+// ctBundleIDHasher knows how to calculate antispam identity hashes for entries in a Static-CT formatted entry bundle.
+func ctBundleIDHasher(bundle []byte) ([][]byte, error) {
+	r := make([][]byte, 0, layout.EntryBundleWidth)
+	b := cryptobyte.String(bundle)
+	for i := 0; i < layout.EntryBundleWidth && !b.Empty(); i++ {
+		// Timestamp
+		if !b.Skip(8) {
+			return nil, fmt.Errorf("failed to read timestamp of entry index %d of bundle", i)
+		}
+
+		var entryType uint16
+		if !b.ReadUint16(&entryType) {
+			return nil, fmt.Errorf("failed to read entry type of entry index %d of bundle", i)
+		}
+
+		switch entryType {
+		case 0: // X509 entry
+			cert := cryptobyte.String{}
+			if !b.ReadUint24LengthPrefixed(&cert) {
+				return nil, fmt.Errorf("failed to read certificate at entry index %d of bundle", i)
+			}
+
+			// For x509 entries we hash (just) the x509 certificate for identity.
+			h := sha256.Sum256(cert)
+			r = append(r, h[:])
+
+			// Must continue below to consume all the remaining bytes in the entry.
+
+		case 1: // Precert entry
+			// IssuerKeyHash
+			if !b.Skip(sha256.Size) {
+				return nil, fmt.Errorf("failed to read issuer key hash at entry index %d of bundle", i)
+			}
+			tbs := cryptobyte.String{}
+			if !b.ReadUint24LengthPrefixed(&tbs) {
+				return nil, fmt.Errorf("failed to read precert tbs at entry index %d of bundle", i)
+			}
+
+		default:
+			return nil, fmt.Errorf("unknown entry type at entry index %d of bundle", i)
+		}
+
+		ignore := cryptobyte.String{}
+		if !b.ReadUint16LengthPrefixed(&ignore) {
+			return nil, fmt.Errorf("failed to read SCT extensions at entry index %d of bundle", i)
+		}
+
+		if entryType == 1 {
+			precert := cryptobyte.String{}
+			if !b.ReadUint24LengthPrefixed(&precert) {
+				return nil, fmt.Errorf("failed to read precert at entry index %d of bundle", i)
+			}
+			// For Precert entries we hash (just) the full precertificate for identity.
+			h := sha256.Sum256(precert)
+			r = append(r, h[:])
+
+		}
+		if !b.ReadUint16LengthPrefixed(&ignore) {
+			return nil, fmt.Errorf("failed to read chain fingerprints at entry index %d of bundle", i)
+		}
+	}
+	if !b.Empty() {
+		return nil, fmt.Errorf("unexpected %d bytes of trailing data in entry bundle", len(b))
+	}
+	return r, nil
+}
+
+// copyBytes copies N bytes between from and to.
+func copyBytes(from *cryptobyte.String, to *cryptobyte.Builder, N int) bool {
+	b := make([]byte, N)
+	if !from.ReadBytes(&b, N) {
+		return false
+	}
+	to.AddBytes(b)
+	return true
+}
+
+// copyUint16LengthPrefixed copies a uint16 length and value between from and to.
+func copyUint16LengthPrefixed(from *cryptobyte.String, to *cryptobyte.Builder) bool {
+	b := cryptobyte.String{}
+	if !from.ReadUint16LengthPrefixed(&b) {
+		return false
+	}
+	to.AddUint16LengthPrefixed(func(c *cryptobyte.Builder) {
+		c.AddBytes(b)
+	})
+	return true
+}
+
+// copyUint24LengthPrefixed copies a uint24 length and value between from and to.
+func copyUint24LengthPrefixed(from *cryptobyte.String, to *cryptobyte.Builder) bool {
+	b := cryptobyte.String{}
+	if !from.ReadUint24LengthPrefixed(&b) {
+		return false
+	}
+	to.AddUint24LengthPrefixed(func(c *cryptobyte.Builder) {
+		c.AddBytes(b)
+	})
+	return true
+}
+
+// ctMerkleLeafHasher knows how to calculate RFC6962 Merkle leaf hashes for entries in a Static-CT formatted entry bundle.
+func ctMerkleLeafHasher(bundle []byte) ([][]byte, error) {
+	r := make([][]byte, 0, layout.EntryBundleWidth)
+	b := cryptobyte.String(bundle)
+	for i := 0; i < layout.EntryBundleWidth && !b.Empty(); i++ {
+		preimage := &cryptobyte.Builder{}
+		preimage.AddUint8(0 /* version = v1 */)
+		preimage.AddUint8(0 /* leaf_type = timestamped_entry */)
+
+		// Timestamp
+		if !copyBytes(&b, preimage, 8) {
+			return nil, fmt.Errorf("failed to copy timestamp of entry index %d of bundle", i)
+		}
+
+		var entryType uint16
+		if !b.ReadUint16(&entryType) {
+			return nil, fmt.Errorf("failed to read entry type of entry index %d of bundle", i)
+		}
+		preimage.AddUint16(entryType)
+
+		switch entryType {
+		case 0: // X509 entry
+			if !copyUint24LengthPrefixed(&b, preimage) {
+				return nil, fmt.Errorf("failed to copy certificate at entry index %d of bundle", i)
+			}
+
+		case 1: // Precert entry
+			// IssuerKeyHash
+			if !copyBytes(&b, preimage, sha256.Size) {
+				return nil, fmt.Errorf("failed to copy issuer key hash at entry index %d of bundle", i)
+			}
+
+			if !copyUint24LengthPrefixed(&b, preimage) {
+				return nil, fmt.Errorf("failed to copy precert tbs at entry index %d of bundle", i)
+			}
+
+		default:
+			return nil, fmt.Errorf("unknown entry type 0x%x at entry index %d of bundle", entryType, i)
+		}
+
+		if !copyUint16LengthPrefixed(&b, preimage) {
+			return nil, fmt.Errorf("failed to copy SCT extensions at entry index %d of bundle", i)
+		}
+
+		ignore := cryptobyte.String{}
+		if entryType == 1 {
+			if !b.ReadUint24LengthPrefixed(&ignore) {
+				return nil, fmt.Errorf("failed to read precert at entry index %d of bundle", i)
+			}
+		}
+		if !b.ReadUint16LengthPrefixed(&ignore) {
+			return nil, fmt.Errorf("failed to read chain fingerprints at entry index %d of bundle", i)
+		}
+
+		h := rfc6962.DefaultHasher.HashLeaf(preimage.BytesOrPanic())
+		r = append(r, h)
+	}
+	if !b.Empty() {
+		return nil, fmt.Errorf("unexpected %d bytes of trailing data in entry bundle", len(b))
+	}
+	return r, nil
 }

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
 )
@@ -110,6 +111,20 @@ func defaultIDHasher(bundle []byte) ([][]byte, error) {
 	r := make([][]byte, 0, len(eb.Entries))
 	for _, e := range eb.Entries {
 		h := sha256.Sum256(e)
+		r = append(r, h[:])
+	}
+	return r, nil
+}
+
+// defaultMerkleLeafHasher parses a C2SP tlog-tile bundle and returns the Merkle leaf hashes of each entry it contains.
+func defaultMerkleLeafHasher(bundle []byte) ([][]byte, error) {
+	eb := &api.EntryBundle{}
+	if err := eb.UnmarshalText(bundle); err != nil {
+		return nil, fmt.Errorf("unmarshal: %v", err)
+	}
+	r := make([][]byte, 0, len(eb.Entries))
+	for _, e := range eb.Entries {
+		h := rfc6962.DefaultHasher.HashLeaf(e)
 		r = append(r, h[:])
 	}
 	return r, nil

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -1023,7 +1023,7 @@ func (s *gcsStorage) lastModified(ctx context.Context, obj string) (time.Time, e
 }
 
 // MigrationTarget creates a new GCP storage for the MigrationTarget lifecycle mode.
-func (s *Storage) MigrationTarget(ctx context.Context, bundleHasher tessera.UnbundlerFunc, opts *tessera.MigrationOptions) (tessera.MigrationTarget, tessera.LogReader, error) {
+func (s *Storage) MigrationTarget(ctx context.Context, opts *tessera.MigrationOptions) (tessera.MigrationTarget, tessera.LogReader, error) {
 	c, err := gcs.NewClient(ctx, gcs.WithJSONReads())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create GCS client: %v", err)
@@ -1036,7 +1036,7 @@ func (s *Storage) MigrationTarget(ctx context.Context, bundleHasher tessera.Unbu
 	m := &MigrationStorage{
 		s:            s,
 		dbPool:       seq.dbPool,
-		bundleHasher: bundleHasher,
+		bundleHasher: opts.LeafHasher(),
 		sequencer:    seq,
 		logStore: &logResourceStore{
 			objStore: &gcsStorage{


### PR DESCRIPTION
This PR adds necessary hooks and implementations for TesseraCT to implement a CT-specific tool for migrating [static-ct](https://c2sp.org/static-ct) compliant logs.

Towards #495 