### PR TITLE
Implement Shutdown method on Appender

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -60,9 +60,8 @@ type IndexFuture func() (uint64, error)
 // in sequencing mode. This only has a single method, but other methods are likely to be added
 // such as a Shutdown method for #341.
 type Appender struct {
-	Add AddFn
-	// TODO(#341): add this method and implement it in all drivers
-	// Shutdown func(ctx context.Context)
+	Add      AddFn
+	Shutdown func(ctx context.Context) error
 }
 
 // NewAppender returns an Appender, which allows a personality to incrementally append new

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -60,7 +60,12 @@ type IndexFuture func() (uint64, error)
 // in sequencing mode. This only has a single method, but other methods are likely to be added
 // such as a Shutdown method for #341.
 type Appender struct {
-	Add      AddFn
+	Add AddFn
+	// Shutdown ensures that all calls to Add that have returned a value will be resolved. Any
+	// futures returned by _this appender_ which resolve to an index will be integrated and have
+	// a checkpoint that commits to them published if this returns successfully.
+	//
+	// After this returns, any calls to Add will fail.
 	Shutdown func(ctx context.Context) error
 }
 

--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -116,6 +116,9 @@ func main() {
 	}
 
 	if err := h1s.ListenAndServe(); err != nil {
+		if err := appender.Shutdown(ctx); err != nil {
+			klog.Exit(err)
+		}
 		klog.Exitf("ListenAndServe: %v", err)
 	}
 }

--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -115,6 +115,9 @@ func main() {
 	}
 
 	if err := h1s.ListenAndServe(); err != nil {
+		if err := appender.Shutdown(ctx); err != nil {
+			klog.Exit(err)
+		}
 		klog.Exitf("ListenAndServe: %v", err)
 	}
 }

--- a/cmd/conformance/mysql/main.go
+++ b/cmd/conformance/mysql/main.go
@@ -101,6 +101,9 @@ func main() {
 		"export READ_URL=http://localhost%s/ \n", *listen, *listen)
 	// Serve HTTP requests until the process is terminated
 	if err := http.ListenAndServe(*listen, http.DefaultServeMux); err != nil {
+		if err := appender.Shutdown(ctx); err != nil {
+			klog.Exit(err)
+		}
 		klog.Exitf("ListenAndServe: %v", err)
 	}
 }

--- a/cmd/conformance/posix/main.go
+++ b/cmd/conformance/posix/main.go
@@ -108,6 +108,9 @@ func main() {
 		"export READ_URL=http://localhost%s/ \n", *listen, *listen)
 	// Run the HTTP server with the single handler and block until this is terminated
 	if err := http.ListenAndServe(*listen, http.DefaultServeMux); err != nil {
+		if err := appender.Shutdown(ctx); err != nil {
+			klog.Exit(err)
+		}
 		klog.Exitf("ListenAndServe: %v", err)
 	}
 }

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -41,6 +41,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -53,6 +55,7 @@ import (
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/internal/parse"
 	"github.com/transparency-dev/trillian-tessera/internal/witness"
 	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
 	"golang.org/x/sync/errgroup"
@@ -203,10 +206,13 @@ func (s *Storage) Appender(ctx context.Context, opts *tessera.AppendOptions) (*t
 	go r.consumeEntriesTask(ctx)
 
 	// Kick off go-routine which handles the publication of checkpoints.
-	go r.publishCheckpointTask(ctx, opts.CheckpointInterval())
+	ctx, cancel := context.WithCancel(ctx)
+	r.done = ctx.Done()
+	go r.publishCheckpointTask(ctx, cancel, opts.CheckpointInterval())
 
 	return &tessera.Appender{
-		Add: r.Add,
+		Add:      r.Add,
+		Shutdown: r.Shutdown,
 	}, r.logStore, nil
 }
 
@@ -220,6 +226,19 @@ type Appender struct {
 	queue *storage.Queue
 
 	treeUpdated chan struct{}
+
+	// This mutex guards the stopped state. We use this instead of an atomic.Boolean
+	// to get the property that no readers of this state can have the lock when the
+	// write gets it. This means that no in-flight Add operations will be occurring on
+	// Shutdown.
+	mu      sync.RWMutex
+	stopped bool
+
+	// This channel will behave as per Context.Done() to signify that this appender is finished.
+	done <-chan struct{}
+
+	// largestIssued tracks the largest index allocated by this appender.
+	largestIssued atomic.Uint64
 }
 
 // sequenceEntriesTask periodically integrates newly sequenced entries.
@@ -256,14 +275,19 @@ func (a *Appender) consumeEntriesTask(ctx context.Context) {
 // of the tree, once per interval.
 //
 // This function does not return until the passed in context is done.
-func (a *Appender) publishCheckpointTask(ctx context.Context, interval time.Duration) {
+func (a *Appender) publishCheckpointTask(ctx context.Context, cancel func(), interval time.Duration) {
+	defer cancel()
 	t := time.NewTicker(interval)
 	defer t.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-a.treeUpdated:
+		case _, ok := <-a.treeUpdated:
+			if !ok {
+				// The channel was closed, which means we're shutting down.
+				return
+			}
 		case <-t.C:
 		}
 		if err := a.publishCheckpoint(ctx, interval); err != nil {
@@ -274,7 +298,76 @@ func (a *Appender) publishCheckpointTask(ctx context.Context, interval time.Dura
 
 // Add is the entrypoint for adding entries to a sequencing log.
 func (a *Appender) Add(ctx context.Context, e *tessera.Entry) tessera.IndexFuture {
-	return a.queue.Add(ctx, e)
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.stopped {
+		return func() (uint64, error) {
+			return 0, errors.New("appender has been shut down")
+		}
+	}
+	res := a.queue.Add(ctx, e)
+	return func() (uint64, error) {
+		i, err := res()
+		if err != nil {
+			return i, err
+		}
+
+		// https://github.com/golang/go/issues/63999 - atomically set largest issued index
+		old := a.largestIssued.Load()
+		for old < i && !a.largestIssued.CompareAndSwap(old, i) {
+			old = a.largestIssued.Load()
+		}
+
+		return i, err
+	}
+}
+
+// Shutdown ensures that all calls to Add that have returned a value will be resolved. Any
+// futures returned by _this appender_ which resolve to an index will be integrated and have
+// a checkpoint that commits to them published if this returns successfully.
+//
+// After this returns, any calls to Add will fail.
+func (a *Appender) Shutdown(ctx context.Context) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stopped = true
+	if err := a.queue.Close(ctx); err != nil {
+		return err
+	}
+	// At this point sequencing and integration is done, now to make sure a large
+	// enough checkpoint has been issued.
+	maxIndex := a.largestIssued.Load()
+	if maxIndex == 0 {
+		// special case no work done
+		close(a.treeUpdated)
+		<-a.done
+		return nil
+	}
+	for {
+		cp, err := a.logStore.ReadCheckpoint(ctx)
+		var nske *types.NoSuchKey
+		if err != nil && !errors.As(err, &nske) {
+			return err
+		}
+		if err == nil {
+			_, size, _, err := parse.CheckpointUnsafe(cp)
+			if err != nil {
+				return err
+			}
+			klog.V(1).Infof("Shutting down, waiting for checkpoint committing to size %d (current checkpoint is %d)", maxIndex, size)
+			if size > maxIndex {
+				close(a.treeUpdated)
+				<-a.done
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
 }
 
 // init ensures that the storage represents a log in a valid state.

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -211,7 +211,8 @@ func (s *Storage) Appender(ctx context.Context, opts *tessera.AppendOptions) (*t
 		return wg.Witness(ctx, cp)
 	}
 	return &tessera.Appender{
-		Add: a.Add,
+		Add:      a.Add,
+		Shutdown: a.Shutdown,
 	}, reader, nil
 }
 

--- a/storage/internal/queue.go
+++ b/storage/internal/queue.go
@@ -135,9 +135,6 @@ func (q *Queue) Close(ctx context.Context) error {
 
 	// Flush and close the buffer, which will trigger workers
 	// to process the entries.
-	if err := q.buf.Flush(); err != nil {
-		return err
-	}
 	if err := q.buf.Close(); err != nil {
 		return err
 	}

--- a/storage/internal/queue.go
+++ b/storage/internal/queue.go
@@ -63,11 +63,11 @@ type FlushFunc func(ctx context.Context, entries []*tessera.Entry) error
 // the same order as they were added, when either the oldest entry in the queue has been there
 // for maxAge, or the size of the queue reaches maxSize.
 func NewQueue(ctx context.Context, maxAge time.Duration, maxSize uint, f FlushFunc) *Queue {
-	ctx, cancel := context.WithCancel(ctx)
+	cctx, cancel := context.WithCancel(ctx)
 	q := &Queue{
 		flush: f,
 		work:  make(chan []*queueItem, 1),
-		done:  ctx.Done(),
+		done:  cctx.Done(),
 	}
 
 	// The underlying queue implementation blocks additions during a flush.

--- a/storage/internal/queue.go
+++ b/storage/internal/queue.go
@@ -126,6 +126,8 @@ func (q *Queue) Add(ctx context.Context, e *tessera.Entry) tessera.IndexFuture {
 	return qi.f
 }
 
+// Close ensures that all work in the queue is flushed and processed. After this is done,
+// the Queue will be locked for any more calls to Add.
 func (q *Queue) Close(ctx context.Context) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/storage/internal/queue_test.go
+++ b/storage/internal/queue_test.go
@@ -96,42 +96,45 @@ func TestQueue(t *testing.T) {
 	}
 }
 
-func TestAwaitShutdown(t *testing.T) {
-	numItems := 77
-	ctx := context.Background()
-	assignMu := sync.Mutex{}
-	assignedItems := make([]*tessera.Entry, numItems)
-	assignedIndex := uint64(0)
+// This test loops because a poor implementation could race and sometimes pass.
+func TestAwaitShutdownRaces(t *testing.T) {
+	for range 5 {
+		numItems := 33
+		ctx := context.Background()
+		assignMu := sync.Mutex{}
+		assignedItems := make([]*tessera.Entry, numItems)
+		assignedIndex := uint64(0)
 
-	// flushFunc mimics sequencing storage - it takes entries, assigns them to
-	// positions in assignedItems.
-	flushFunc := func(_ context.Context, entries []*tessera.Entry) error {
-		assignMu.Lock()
-		defer assignMu.Unlock()
+		// flushFunc mimics sequencing storage - it takes entries, assigns them to
+		// positions in assignedItems.
+		flushFunc := func(_ context.Context, entries []*tessera.Entry) error {
+			assignMu.Lock()
+			defer assignMu.Unlock()
 
-		for _, e := range entries {
-			_ = e.MarshalBundleData(assignedIndex)
-			assignedItems[assignedIndex] = e
-			assignedIndex++
+			for _, e := range entries {
+				_ = e.MarshalBundleData(assignedIndex)
+				assignedItems[assignedIndex] = e
+				assignedIndex++
+			}
+			return nil
 		}
-		return nil
-	}
 
-	q := storage.NewQueue(ctx, time.Second, 20, flushFunc)
+		q := storage.NewQueue(ctx, time.Second, 20, flushFunc)
 
-	adds := make([]tessera.IndexFuture, numItems)
-	wantEntries := make([]*tessera.Entry, numItems)
-	for i := uint64(0); i < uint64(numItems); i++ {
-		d := []byte(fmt.Sprintf("item %d", i))
-		wantEntries[i] = tessera.NewEntry(d)
-		adds[i] = q.Add(ctx, wantEntries[i])
-	}
-	if err := q.Close(ctx); err != nil {
-		t.Fatal(err)
-	}
-	for i, r := range assignedItems {
-		if r == nil {
-			t.Fatalf("found nil index at %d", i)
+		adds := make([]tessera.IndexFuture, numItems)
+		wantEntries := make([]*tessera.Entry, numItems)
+		for i := uint64(0); i < uint64(numItems); i++ {
+			d := []byte(fmt.Sprintf("item %d", i))
+			wantEntries[i] = tessera.NewEntry(d)
+			adds[i] = q.Add(ctx, wantEntries[i])
+		}
+		if err := q.Close(ctx); err != nil {
+			t.Fatal(err)
+		}
+		for i, r := range assignedItems {
+			if r == nil {
+				t.Fatalf("found nil index at %d", i)
+			}
 		}
 	}
 }

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -27,6 +27,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -34,6 +36,7 @@ import (
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/internal/parse"
 	"github.com/transparency-dev/trillian-tessera/internal/witness"
 	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
 	"k8s.io/klog/v2"
@@ -109,14 +112,21 @@ func (s *Storage) Appender(ctx context.Context, opts *tessera.AppendOptions) (*t
 	}
 	a.cpUpdated <- struct{}{}
 
+	ctx, cancel := context.WithCancel(ctx)
+	a.done = ctx.Done()
 	go func(ctx context.Context, i time.Duration) {
+		defer cancel()
 		t := time.NewTicker(i)
 		defer t.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-a.cpUpdated:
+			case _, ok := <-a.cpUpdated:
+				if !ok {
+					// The channel was closed, which means we're shutting down.
+					return
+				}
 			case <-t.C:
 			}
 			if err := a.publishCheckpoint(ctx, i); err != nil {
@@ -494,6 +504,19 @@ type appender struct {
 	queue         *storage.Queue
 	newCheckpoint func(uint64, []byte) ([]byte, error)
 	cpUpdated     chan struct{}
+
+	// This mutex guards the stopped state. We use this instead of an atomic.Boolean
+	// to get the property that no readers of this state can have the lock when the
+	// write gets it. This means that no in-flight Add operations will be occurring on
+	// Shutdown.
+	mu      sync.RWMutex
+	stopped bool
+
+	// This channel will behave as per Context.Done() to signify that this appender is finished.
+	done <-chan struct{}
+
+	// largestIssued tracks the largest index allocated by this appender.
+	largestIssued atomic.Uint64
 }
 
 // publishCheckpoint creates a new checkpoint for the given size and root hash, and stores it in the
@@ -539,7 +562,75 @@ func (a *appender) publishCheckpoint(ctx context.Context, interval time.Duration
 
 // Add is the entrypoint for adding entries to a sequencing log.
 func (a *appender) Add(ctx context.Context, entry *tessera.Entry) tessera.IndexFuture {
-	return a.queue.Add(ctx, entry)
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.stopped {
+		return func() (uint64, error) {
+			return 0, errors.New("appender has been shut down")
+		}
+	}
+	res := a.queue.Add(ctx, entry)
+	return func() (uint64, error) {
+		i, err := res()
+		if err != nil {
+			return i, err
+		}
+
+		// https://github.com/golang/go/issues/63999 - atomically set largest issued index
+		old := a.largestIssued.Load()
+		for old < i && !a.largestIssued.CompareAndSwap(old, i) {
+			old = a.largestIssued.Load()
+		}
+
+		return i, err
+	}
+}
+
+// Shutdown ensures that all calls to Add that have returned a value will be resolved. Any
+// futures returned by _this appender_ which resolve to an index will be integrated and have
+// a checkpoint that commits to them published if this returns successfully.
+//
+// After this returns, any calls to Add will fail.
+func (a *appender) Shutdown(ctx context.Context) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stopped = true
+	if err := a.queue.Close(ctx); err != nil {
+		return err
+	}
+	// At this point sequencing and integration is done, now to make sure a large
+	// enough checkpoint has been issued.
+	maxIndex := a.largestIssued.Load()
+	if maxIndex == 0 {
+		// special case no work done
+		close(a.cpUpdated)
+		<-a.done
+		return nil
+	}
+	for {
+		cp, err := a.s.ReadCheckpoint(ctx)
+		if err != nil && err != os.ErrNotExist {
+			return err
+		}
+		if err == nil {
+			_, size, _, err := parse.CheckpointUnsafe(cp)
+			if err != nil {
+				return err
+			}
+			klog.V(1).Infof("Shutting down, waiting for checkpoint committing to size %d (current checkpoint is %d)", maxIndex, size)
+			if size > maxIndex {
+				close(a.cpUpdated)
+				<-a.done
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
 }
 
 // sequenceBatch writes the entries from the provided batch into the entry bundle files of the log.

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -136,7 +136,8 @@ func (s *Storage) Appender(ctx context.Context, opts *tessera.AppendOptions) (*t
 	}(ctx, opts.CheckpointInterval())
 
 	return &tessera.Appender{
-		Add: a.Add,
+		Add:      a.Add,
+		Shutdown: a.Shutdown,
 	}, s, nil
 }
 


### PR DESCRIPTION
Towards #341.

This API allows users of an appender to ensure that everything they've sent to this object is committed to before the process terminates.

Out of scope for this change is to make it so that it globally waits for items added via any other appenders to become integrated. The plan for this is to implement a draining lifecycle state, which can better ensure that the queue stays empty.

Raising as a draft because it's late in the day and I'd like to have another look tomorrow morning to make sure this isn't bonkers. There's a bit of duplication here that I'd like to make sure is reasonable. OTOH, raising the PR now so that the tests can run and it can be looked at in principle if reviewers get the time.
