### PR TITLE
[Shutdown] Implement Shutdown in a single location

### DIFF
--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -73,7 +73,7 @@ func main() {
 	if err != nil {
 		klog.Exitf("Failed to create new AWS storage: %v", err)
 	}
-	appender, _, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
+	appender, shutdown, _, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
 		WithCheckpointSigner(s, a...).
 		WithCheckpointInterval(*publishInterval).
 		WithBatching(1024, time.Second).
@@ -116,6 +116,9 @@ func main() {
 	}
 
 	if err := h1s.ListenAndServe(); err != nil {
+		if err := shutdown(ctx); err != nil {
+			klog.Exit(err)
+		}
 		klog.Exitf("ListenAndServe: %v", err)
 	}
 }

--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -72,7 +72,7 @@ func main() {
 		}
 	}
 
-	appender, _, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
+	appender, shutdown, _, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
 		WithCheckpointSigner(s, a...).
 		WithCheckpointInterval(10*time.Second).
 		WithBatching(1024, time.Second).
@@ -115,6 +115,9 @@ func main() {
 	}
 
 	if err := h1s.ListenAndServe(); err != nil {
+		if err := shutdown(ctx); err != nil {
+			klog.Exit(err)
+		}
 		klog.Exitf("ListenAndServe: %v", err)
 	}
 }

--- a/cmd/conformance/mysql/main.go
+++ b/cmd/conformance/mysql/main.go
@@ -67,7 +67,7 @@ func main() {
 		klog.Exitf("Failed to create new MySQL storage: %v", err)
 	}
 
-	appender, reader, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
+	appender, shutdown, reader, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
 		WithCheckpointSigner(noteSigner, additionalSigners...).
 		WithCheckpointInterval(*publishInterval).
 		WithAntispam(256, nil))
@@ -101,6 +101,9 @@ func main() {
 		"export READ_URL=http://localhost%s/ \n", *listen, *listen)
 	// Serve HTTP requests until the process is terminated
 	if err := http.ListenAndServe(*listen, http.DefaultServeMux); err != nil {
+		if err := shutdown(ctx); err != nil {
+			klog.Exit(err)
+		}
 		klog.Exitf("ListenAndServe: %v", err)
 	}
 }

--- a/cmd/conformance/posix/main.go
+++ b/cmd/conformance/posix/main.go
@@ -68,7 +68,7 @@ func main() {
 	if err != nil {
 		klog.Exitf("Failed to construct storage: %v", err)
 	}
-	appender, _, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
+	appender, shutdown, _, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
 		WithCheckpointSigner(s, a...).
 		WithBatching(256, time.Second).
 		WithAntispam(256, nil))
@@ -108,6 +108,9 @@ func main() {
 		"export READ_URL=http://localhost%s/ \n", *listen, *listen)
 	// Run the HTTP server with the single handler and block until this is terminated
 	if err := http.ListenAndServe(*listen, http.DefaultServeMux); err != nil {
+		if err := shutdown(ctx); err != nil {
+			klog.Exit(err)
+		}
 		klog.Exitf("ListenAndServe: %v", err)
 	}
 }

--- a/cmd/examples/posix-oneshot/main.go
+++ b/cmd/examples/posix-oneshot/main.go
@@ -115,13 +115,15 @@ func main() {
 	for _, entry := range indexFutures {
 		seq, _, err := await.Await(ctx, entry.f)
 		if err != nil {
-			klog.Exitf("failed to sequence %q: %q", entry.name, err)
+			klog.Exitf("Failed to sequence %q: %q", entry.name, err)
 		}
 		klog.Infof("%d: %v", seq, entry.name)
 	}
 
 	// 2) shutdown the appender
-	shutdown(ctx)
+	if err := shutdown(ctx); err != nil {
+		klog.Exitf("Failed to shut down cleanly: %v", err)
+	}
 }
 
 // Read log private key from file or environment variable

--- a/internal/witness/witness_test.go
+++ b/internal/witness/witness_test.go
@@ -178,7 +178,7 @@ func TestWitness_UpdateRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, reader, err := tessera.NewAppender(context.Background(), d, tessera.NewAppendOptions().WithCheckpointSigner(mustCreateSigner(t, wit1Skey)))
+	_, _, reader, err := tessera.NewAppender(context.Background(), d, tessera.NewAppendOptions().WithCheckpointSigner(mustCreateSigner(t, wit1Skey)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -31,6 +31,7 @@ var ErrNoMoreEntries = errors.New("no more entries")
 // LogReader provides read-only access to the log.
 type LogReader interface {
 	// ReadCheckpoint returns the latest checkpoint available.
+	// If no checkpoint is available then os.ErrNotExist should be returned.
 	ReadCheckpoint(ctx context.Context) ([]byte, error)
 
 	// ReadTile returns the raw marshalled tile at the given coordinates, if it exists.

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -281,9 +281,7 @@ func (a *Appender) Add(ctx context.Context, e *tessera.Entry) tessera.IndexFutur
 func (a *Appender) init(ctx context.Context) error {
 	_, err := a.logStore.ReadCheckpoint(ctx)
 	if err != nil {
-		// Do not use errors.Is. Keep errors.As to compare by type and not by value.
-		var nske *types.NoSuchKey
-		if errors.As(err, &nske) {
+		if errors.Is(err, os.ErrNotExist) {
 			// No checkpoint exists, do a forced (possibly empty) integration to create one in a safe
 			// way (calling updateCP directly here would not be safe as it's outside the transactional
 			// framework which prevents the tree from rolling backwards or otherwise forking).

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -434,7 +434,14 @@ type logResourceStore struct {
 }
 
 func (lr *logResourceStore) ReadCheckpoint(ctx context.Context) ([]byte, error) {
-	return lr.get(ctx, layout.CheckpointPath)
+	r, err := lr.get(ctx, layout.CheckpointPath)
+	if err != nil {
+		var nske *types.NoSuchKey
+		if errors.As(err, &nske) {
+			return r, os.ErrNotExist
+		}
+	}
+	return r, err
 }
 
 func (lr *logResourceStore) ReadTile(ctx context.Context, l, i uint64, p uint8) ([]byte, error) {

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -132,7 +132,13 @@ type LogReader struct {
 }
 
 func (lr *LogReader) ReadCheckpoint(ctx context.Context) ([]byte, error) {
-	return lr.lrs.getCheckpoint(ctx)
+	r, err := lr.lrs.getCheckpoint(ctx)
+	if err != nil {
+		if errors.Is(err, gcs.ErrObjectNotExist) {
+			return r, os.ErrNotExist
+		}
+	}
+	return r, err
 }
 
 func (lr *LogReader) ReadTile(ctx context.Context, l, i uint64, p uint8) ([]byte, error) {

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -678,7 +678,7 @@ func (a *appender) appendEntries(ctx context.Context, tx *sql.Tx, fromSeq uint64
 	return nil
 }
 
-func getTiles(ctx context.Context, tx *sql.Tx, tileIDs []storage.TileID, treeSize uint64) ([]*api.HashTile, error) {
+func getTiles(ctx context.Context, tx *sql.Tx, tileIDs []storage.TileID, _ uint64) ([]*api.HashTile, error) {
 	hashTiles := make([]*api.HashTile, len(tileIDs))
 	if len(tileIDs) == 0 {
 		return hashTiles, nil

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -157,7 +157,7 @@ func TestAppend(t *testing.T) {
 			if err != nil {
 				t.Fatalf("New: %v", err)
 			}
-			_, _, err = tessera.NewAppender(ctx, drv, test.opts)
+			_, _, _, err = tessera.NewAppender(ctx, drv, test.opts)
 			gotErr := err != nil
 			if gotErr != test.wantErr {
 				t.Errorf("got err: %v", err)
@@ -598,7 +598,7 @@ func newTestMySQLStorage(t *testing.T, ctx context.Context) (tessera.AddFn, tess
 		t.Fatalf("Failed to create mysql.Storage: %v", err)
 	}
 
-	a, r, err := tessera.NewAppender(ctx, s, tessera.NewAppendOptions().
+	a, _, r, err := tessera.NewAppender(ctx, s, tessera.NewAppendOptions().
 		WithCheckpointSigner(noteSigner).
 		WithCheckpointInterval(time.Second).
 		WithBatching(128, 100*time.Millisecond))

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -189,7 +190,11 @@ func (a *appender) Add(ctx context.Context, e *tessera.Entry) tessera.IndexFutur
 }
 
 func (l *logResourceStorage) ReadCheckpoint(_ context.Context) ([]byte, error) {
-	return os.ReadFile(filepath.Join(l.s.path, layout.CheckpointPath))
+	r, err := os.ReadFile(filepath.Join(l.s.path, layout.CheckpointPath))
+	if errors.Is(err, fs.ErrNotExist) {
+		return r, os.ErrNotExist
+	}
+	return r, err
 }
 
 // ReadEntryBundle retrieves the Nth entries bundle for a log of the given size.


### PR DESCRIPTION
This is a revised attempt at Shutdown that is intended to replace #524.
This implementation doesn't have the granular integration with the
channels in each implementation. Instead, it is implemented at the top
level of the appender lifecycle, and each driver doesn't need to have
very similar duplicated code for handling this.

The previous attempt was also trying to make it so that Shutdown would
close out channels and kill goroutines etc. This approach makes it clear
that the way to do this is to cancel the original context passed into
the appender.

Fixes #341.
