### PR TITLE
Expose migrate functionality to applications built with Tessera

### DIFF
--- a/cmd/experimental/migrate/gcp/main.go
+++ b/cmd/experimental/migrate/gcp/main.go
@@ -27,7 +27,6 @@ import (
 
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/client"
-	"github.com/transparency-dev/trillian-tessera/cmd/experimental/migrate/internal"
 	"github.com/transparency-dev/trillian-tessera/storage/gcp"
 	gcp_as "github.com/transparency-dev/trillian-tessera/storage/gcp/antispam"
 	"k8s.io/klog/v2"
@@ -93,7 +92,7 @@ func main() {
 		klog.Exitf("Failed to create MigrationTarget: %v", err)
 	}
 
-	if err := internal.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, src.ReadEntryBundle, m); err != nil {
+	if err := tessera.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, src.ReadEntryBundle, m); err != nil {
 		klog.Exitf("Migrate failed: %v", err)
 	}
 

--- a/cmd/experimental/migrate/mysql/main.go
+++ b/cmd/experimental/migrate/mysql/main.go
@@ -29,7 +29,6 @@ import (
 
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/client"
-	"github.com/transparency-dev/trillian-tessera/cmd/experimental/migrate/internal"
 	"github.com/transparency-dev/trillian-tessera/storage/mysql"
 	"k8s.io/klog/v2"
 )
@@ -87,7 +86,7 @@ func main() {
 		klog.Exitf("Failed to create MigrationTarget: %v", err)
 	}
 
-	if err := internal.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, src.ReadEntryBundle, m); err != nil {
+	if err := tessera.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, src.ReadEntryBundle, m); err != nil {
 		klog.Exitf("Migrate failed: %v", err)
 	}
 

--- a/cmd/experimental/migrate/posix/main.go
+++ b/cmd/experimental/migrate/posix/main.go
@@ -26,7 +26,6 @@ import (
 
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/client"
-	"github.com/transparency-dev/trillian-tessera/cmd/experimental/migrate/internal"
 	"github.com/transparency-dev/trillian-tessera/storage/posix"
 	"k8s.io/klog/v2"
 )
@@ -74,7 +73,7 @@ func main() {
 		klog.Exitf("Failed to create new POSIX storage: %v", err)
 	}
 
-	if err := internal.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, src.ReadEntryBundle, st); err != nil {
+	if err := tessera.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, src.ReadEntryBundle, st); err != nil {
 		klog.Exitf("Migrate failed: %v", err)
 	}
 }

--- a/migrate.go
+++ b/migrate.go
@@ -187,8 +187,8 @@ func (m *copier) migrateWorker(ctx context.Context) error {
 			retry.Attempts(10),
 			retry.DelayType(retry.BackOffDelay))
 		if err != nil {
-			return err
 			klog.Infof("retry: %v", err)
+			return err
 		}
 	}
 	return nil

--- a/migrate.go
+++ b/migrate.go
@@ -172,10 +172,14 @@ func (m *copier) migrateWorker(ctx context.Context) error {
 		err := retry.Do(func() error {
 			d, err := m.getEntries(ctx, b.Index, uint8(b.Partial))
 			if err != nil {
-				return fmt.Errorf("failed to fetch entrybundle %d (p=%d): %v", b.Index, b.Partial, err)
+				wErr := fmt.Errorf("failed to fetch entrybundle %d (p=%d): %v", b.Index, b.Partial, err)
+				klog.Infof("%v", wErr)
+				return wErr
 			}
 			if err := m.storage.SetEntryBundle(ctx, b.Index, b.Partial, d); err != nil {
-				return fmt.Errorf("failed to store entrybundle %d (p=%d): %v", b.Index, b.Partial, err)
+				wErr := fmt.Errorf("failed to store entrybundle %d (p=%d): %v", b.Index, b.Partial, err)
+				klog.Infof("%v", wErr)
+				return wErr
 			}
 			m.bundlesMigrated.Add(1)
 			return nil
@@ -184,6 +188,7 @@ func (m *copier) migrateWorker(ctx context.Context) error {
 			retry.DelayType(retry.BackOffDelay))
 		if err != nil {
 			return err
+			klog.Infof("retry: %v", err)
 		}
 	}
 	return nil

--- a/migrate.go
+++ b/migrate.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package tessera
 
 import (
 	"bytes"

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -754,14 +754,14 @@ func integrate(ctx context.Context, tx *sql.Tx, fromSeq uint64, lh [][]byte, wri
 // MigrationTarget creates a new MySQL storage for the MigrationTarget lifecycle mode.
 //
 // bundleHasher must return Merkle leaf hashes for entry bundles it's passed.
-func (s *Storage) MigrationTarget(ctx context.Context, bundleHasher tessera.UnbundlerFunc, opts *tessera.MigrationOptions) (tessera.MigrationTarget, tessera.LogReader, error) {
+func (s *Storage) MigrationTarget(ctx context.Context, opts *tessera.MigrationOptions) (tessera.MigrationTarget, tessera.LogReader, error) {
 	if err := s.maybeInitTree(ctx); err != nil {
 		return nil, nil, fmt.Errorf("maybeInitTree: %v", err)
 	}
 
 	return &MigrationStorage{
 		s:            s,
-		bundleHasher: bundleHasher,
+		bundleHasher: opts.LeafHasher(),
 	}, s, nil
 }
 


### PR DESCRIPTION
This PR exposes the underlying feature used by the experimental migrate commands for use by applications directly.

This is enables "higher level" migration tools to be built - e.g. a Static CT migration tool which will migrate other specified resources in addition to the ones which form the Merkle tree.

Towards #523 