### PR TITLE
Return current state of tree even if no work done

### DIFF
--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -1177,6 +1177,8 @@ func (m *MigrationStorage) buildTree(ctx context.Context, sourceSize uint64) (ui
 
 		if len(lh) == 0 {
 			klog.Infof("Integrate: nothing to do, nothing done")
+			// Set these to the current state of the tree so we reflect that in buildTree's return values.
+			newSize, newRoot = from, rootHash
 			return nil
 		}
 


### PR DESCRIPTION
This PR makes `MigrationStorage.buildTree` always return values which reflect the current state of the tree, even if no work was done. This removes the potential for confusion, as previously zero values would be returned in this case.