### PR TITLE
Add richer Follower interface enabling clean shutdown & stats

### DIFF
--- a/cmd/experimental/migrate/aws/main.go
+++ b/cmd/experimental/migrate/aws/main.go
@@ -93,9 +93,6 @@ func main() {
 	if err := m.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, src.ReadEntryBundle); err != nil {
 		klog.Exitf("Migrate failed: %v", err)
 	}
-
-	// TODO(#341): wait for antispam follower to complete
-	<-make(chan bool)
 }
 
 // storageConfigFromFlags returns an aws.Config struct populated with values

--- a/cmd/experimental/migrate/gcp/main.go
+++ b/cmd/experimental/migrate/gcp/main.go
@@ -98,9 +98,6 @@ func main() {
 	if err := m.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, src.ReadEntryBundle); err != nil {
 		klog.Exitf("Migrate failed: %v", err)
 	}
-
-	// TODO(#341): wait for antispam follower to complete
-	<-make(chan bool)
 }
 
 // storageConfigFromFlags returns a gcp.Config struct populated with values

--- a/cmd/experimental/migrate/mysql/main.go
+++ b/cmd/experimental/migrate/mysql/main.go
@@ -89,9 +89,6 @@ func main() {
 	if err := m.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, src.ReadEntryBundle); err != nil {
 		klog.Exitf("Migrate failed: %v", err)
 	}
-
-	// TODO(#341): wait for any followers or other internal processes to complete
-	<-make(chan bool)
 }
 
 func initDatabaseSchema(ctx context.Context) {

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -83,6 +83,9 @@ type LogReader interface {
 
 // Follower describes the contract of something which is required to track the contents of the local log.
 type Follower interface {
+	// Name returns a human readable name for this follower.
+	Name() string
+
 	// Follow should be implemented so as to visit entries in the log in order, using the provided
 	// LogReader to access the entry bundles which contain them.
 	//

--- a/migrate_lifecycle.go
+++ b/migrate_lifecycle.go
@@ -83,8 +83,10 @@ type MigrationOptions struct {
 	// entriesPath knows how to format entry bundle paths.
 	entriesPath func(n uint64, p uint8) string
 	// bundleIDHasher knows how to create antispam leaf identities for entries in a serialised bundle.
+	// This field's value must not be updated once configured or weird and probably unwanted antispam behaviour is likely to occur.
 	bundleIDHasher func([]byte) ([][]byte, error)
 	// bundleLeafHasher knows how to create Merkle leaf hashes for the entries in a serialised bundle.
+	// This field's value must not be updated once configured or weird and probably unwanted integration behaviour is likely to occur.
 	bundleLeafHasher func([]byte) ([][]byte, error)
 	followers        []Follower
 }

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -95,6 +95,7 @@ func NewAntispam(ctx context.Context, spannerDB string, opts AntispamOpts) (*Ant
 	}
 
 	r := &AntispamStorage{
+		opts:   opts,
 		dbPool: db,
 	}
 

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -247,6 +247,10 @@ type follower struct {
 	bundleHasher func([]byte) ([][]byte, error)
 }
 
+func (f *follower) Name() string {
+	return "GCP antispam"
+}
+
 // Follow uses entry data from the log to populate the antispam storage.
 func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 	errOutOfSync := errors.New("out-of-sync")

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -99,18 +99,6 @@ func NewAntispam(ctx context.Context, spannerDB string, opts AntispamOpts) (*Ant
 		dbPool: db,
 	}
 
-	go func(ctx context.Context) {
-		t := time.NewTicker(time.Second)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				klog.V(1).Infof("ANTISPAM: # Writes %d, # Lookups %d, # DB hits %v", r.numWrites.Load(), r.numLookups.Load(), r.numHits.Load())
-			}
-		}
-	}(ctx)
-
 	return r, nil
 }
 


### PR DESCRIPTION
This PR defines a `Follower` interface which enables Tessera to know when it's safe to exit, e.g. during migration, we need to potentially wait for the antispam index to be fully populated.

Towards #436 