### PR TITLE
Standardize logging when publishing a checkpoint

### DIFF
--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -326,6 +326,9 @@ func (a *Appender) publishCheckpoint(ctx context.Context, minStaleness time.Dura
 	if err := a.logStore.setCheckpoint(ctx, cpRaw); err != nil {
 		return fmt.Errorf("writeCheckpoint: %v", err)
 	}
+
+	klog.V(2).Infof("Published latest checkpoint: %d, %x", size, root)
+
 	return nil
 }
 

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -326,6 +326,9 @@ func (a *Appender) publishCheckpoint(ctx context.Context, minStaleness time.Dura
 	if err := a.logStore.setCheckpoint(ctx, cpRaw); err != nil {
 		return fmt.Errorf("writeCheckpoint: %v", err)
 	}
+
+	klog.V(2).Infof("Published latest checkpoint: %d, %x", size, root)
+
 	return nil
 
 }

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -534,6 +534,8 @@ func (a *appender) publishCheckpoint(ctx context.Context, interval time.Duration
 		return err
 	}
 
+	klog.V(2).Infof("Published latest checkpoint: %d, %x", treeState.size, treeState.root)
+
 	return tx.Commit()
 }
 

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -343,7 +343,7 @@ func doIntegrate(ctx context.Context, fromSeq uint64, leafHashes [][]byte, ls *l
 		}
 	}
 
-	klog.Infof("New tree state: %d, %x", newSize, newRoot)
+	klog.Infof("New tree: %d, %x", newSize, newRoot)
 
 	return newSize, newRoot, nil
 }
@@ -591,7 +591,8 @@ func (a *appender) publishCheckpoint(minStaleness time.Duration) error {
 	if err := a.s.overwrite(layout.CheckpointPath, cpRaw); err != nil {
 		return fmt.Errorf("overwrite(%s): %v", layout.CheckpointPath, err)
 	}
-	klog.Infof("Published latest checkpoint")
+
+	klog.V(2).Infof("Published latest checkpoint: %d, %x", size, root)
 
 	return nil
 }


### PR DESCRIPTION
All storage backends will log when a new checkpoint is published.

Tiny change to standardize logging message for integration as well.