### PR TITLE
Add GCP antispam test

### DIFF
--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -338,7 +338,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 
 				// Now update the index.
 				{
-					ms := make([]*spanner.Mutation, 0)
+					ms := make([]*spanner.Mutation, 0, len(curEntries))
 					for i, e := range curEntries {
 						ms = append(ms, spanner.Insert("IDSeq", []string{"h", "idx"}, []interface{}{e, int64(curIndex + uint64(i))}))
 					}

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -170,10 +170,16 @@ func (d *AntispamStorage) Decorator() func(f tessera.AddFn) tessera.AddFn {
 //
 // This implements tessera.Antispam.
 func (d *AntispamStorage) Follower(b func([]byte) ([][]byte, error)) tessera.Follower {
-	return &follower{
+	f := &follower{
 		as:           d,
 		bundleHasher: b,
 	}
+	// Use the "normal" BatchWrite mechanism to update the antispam index.
+	// This will be overriden by the test to use an "inline" mechanism since spannertest
+	// does not support BatchWrite :(
+	f.updateIndex = f.batchUpdateIndex
+
+	return f
 }
 
 // entryStreamReader converts a stream of {RangeInfo, EntryBundle} into a stream of individually processed entries.
@@ -231,7 +237,18 @@ func (e *entryStreamReader[T]) Next() (uint64, T, error) {
 // follower is a struct which knows how to populate the antispam storage with identity hashes
 // for entries in a log.
 type follower struct {
-	as           *AntispamStorage
+	as *AntispamStorage
+
+	// updateIndex knows how to apply the provided slice of mutations to the underlying Spanner DB.
+	//
+	// In normal operation this simply points to the batchUpdateIndex func below, but spannertest
+	// does not support either:
+	//   - BatchWrite operations, or
+	//   - nested transactions
+	// so we use this member as a hook to fallback to
+	// a regular transaction for tests.
+	updateIndex func(context.Context, *spanner.ReadWriteTransaction, []*spanner.Mutation) error
+
 	bundleHasher func([]byte) ([][]byte, error)
 }
 
@@ -319,40 +336,13 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 					curIndex = followFrom
 				}
 
-				// Store antispam entries.
-				//
-				// Note that we're writing the antispam entries outside of the transaction here. The reason is because we absolutely do not want
-				// the transaction to fail if there's already an entry for the same hash in the IDSeq table.
-				//
-				// It looks unusual, but is ok because:
-				//  - individual antispam entries fails because there's already an entry for that hash is perfectly ok
-				//  - we'll only continue on to update FollowCoord if no errors (other than AlreadyExists) occur while inserting entries
-				//  - similarly, if we manage to insert antispam entries here, but then fail to update FollowCoord, we'll end up
-				//    retrying over the same set of log entries, and then ignoring the AlreadyExists which will occur.
-				//
-				// Alternative approaches are:
-				//  - Use InsertOrUpdate, but that will keep updating the index associated with the ID hash, and we'd rather keep serving
-				//    the earliest index known for that entry.
-				//  - Perform reads for each of the hashes we're about to write, and use that to filter writes.
-				//    This would work, but would also incur an extra round-trip of data which isn't really necessary but would
-				//    slow the process down considerably and add extra load to Spanner for no benefit.
+				// Now update the index.
 				{
-					m := make([]*spanner.MutationGroup, 0, len(curEntries))
+					ms := make([]*spanner.Mutation, 0)
 					for i, e := range curEntries {
-						m = append(m, &spanner.MutationGroup{
-							Mutations: []*spanner.Mutation{spanner.Insert("IDSeq", []string{"h", "idx"}, []interface{}{e, int64(curIndex + uint64(i))})},
-						})
+						ms = append(ms, spanner.Insert("IDSeq", []string{"h", "idx"}, []interface{}{e, int64(curIndex + uint64(i))}))
 					}
-
-					i := f.as.dbPool.BatchWrite(ctx, m)
-					err := i.Do(func(r *spannerpb.BatchWriteResponse) error {
-						s := r.GetStatus()
-						if c := codes.Code(s.Code); c != codes.OK && c != codes.AlreadyExists {
-							return fmt.Errorf("failed to write antispam record: %v (%v)", s.GetMessage(), c)
-						}
-						return nil
-					})
-					if err != nil {
+					if err := f.updateIndex(ctx, txn, ms); err != nil {
 						return err
 					}
 				}
@@ -377,6 +367,43 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 			curEntries = nil
 		}
 	}
+}
+
+// batchUpdateIndex applies the provided mutations using Spanner's BatchWrite support.
+//
+// Note that we _do not_ use the passed in txn here -  we're writing the antispam entries outside of the transaction.
+// The reason is because we absolutely do not want the larger transaction to fail if there's already an entry for the
+// same hash in the IDSeq table - this would cause us to get stuck retrying forever, so we use BatchWrite and ignore
+// any AlreadyExists errors we encounter.
+//
+// It looks unusual, but is ok because:
+//   - individual antispam entries failing to insert because there's already an entry for that hash is perfectly ok,
+//   - we'll only continue on to update FollowCoord if no errors (other than AlreadyExists) occur while inserting entries,
+//   - similarly, if we manage to insert antispam entries here, but then fail to update FollowCoord, we'll end up
+//     retrying over the same set of log entries, and then ignoring the AlreadyExists which will occur.
+//
+// Alternative approaches are:
+//   - Use InsertOrUpdate, but that will keep updating the index associated with the ID hash, and we'd rather keep serving
+//     the earliest index known for that entry.
+//   - Perform reads for each of the hashes we're about to write, and use that to filter writes.
+//     This would work, but would also incur an extra round-trip of data which isn't really necessary but would
+//     slow the process down considerably and add extra load to Spanner for no benefit.
+func (f *follower) batchUpdateIndex(ctx context.Context, _ *spanner.ReadWriteTransaction, ms []*spanner.Mutation) error {
+	mgs := make([]*spanner.MutationGroup, 0, len(ms))
+	for _, m := range ms {
+		mgs = append(mgs, &spanner.MutationGroup{
+			Mutations: []*spanner.Mutation{m},
+		})
+	}
+
+	i := f.as.dbPool.BatchWrite(ctx, mgs)
+	return i.Do(func(r *spannerpb.BatchWriteResponse) error {
+		s := r.GetStatus()
+		if c := codes.Code(s.Code); c != codes.OK && c != codes.AlreadyExists {
+			return fmt.Errorf("failed to write antispam record: %v (%v)", s.GetMessage(), c)
+		}
+		return nil
+	})
 }
 
 // Position returns the index of the entry furthest from the start of the log which has been processed.

--- a/storage/gcp/antispam/gcp_test.go
+++ b/storage/gcp/antispam/gcp_test.go
@@ -1,0 +1,203 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner/spannertest"
+	tessera "github.com/transparency-dev/trillian-tessera"
+	"github.com/transparency-dev/trillian-tessera/api"
+	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"k8s.io/klog/v2"
+)
+
+type testLookup struct {
+	entryHash    []byte
+	wantIndex    uint64
+	wantNotFound bool
+}
+
+func TestAntispamStorage(t *testing.T) {
+	closeDB := newSpannerDB(t)
+	defer closeDB()
+
+	for _, test := range []struct {
+		name          string
+		opts          AntispamOpts
+		logEntries    [][]byte
+		lookupEntries []testLookup
+	}{
+		{
+			name: "roundtrip",
+			logEntries: [][]byte{
+				[]byte("one"),
+				[]byte("two"),
+				[]byte("three"),
+			},
+			lookupEntries: []testLookup{
+				{
+					entryHash: testIDHash([]byte("one")),
+					wantIndex: 0,
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			as, err := NewAntispam(t.Context(), "projects/p/instances/i/databases/d", test.opts)
+			if err != nil {
+				t.Fatalf("NewAntispam: %v", err)
+			}
+
+			fr := newFakeLogReader(test.logEntries)
+
+			f := as.Follower(testBundleHasher)
+			go f.Follow(t.Context(), fr)
+
+			for {
+				time.Sleep(time.Second)
+				pos, err := f.Position(t.Context())
+				if err != nil {
+					t.Logf("Position: %v", err)
+					continue
+				}
+				klog.Infof("Wait for follower (%d) to catch up with tree (%d)", pos, fr.size)
+				if pos >= fr.size {
+					break
+				}
+			}
+
+			for _, e := range test.lookupEntries {
+				gotIndex, err := as.index(t.Context(), e.entryHash)
+				if err != nil {
+					t.Errorf("error looking up hash %x: %v", e.entryHash, err)
+				}
+				if gotIndex == nil {
+					t.Errorf("no index for hash %x", e.entryHash)
+					continue
+				}
+				if *gotIndex != e.wantIndex {
+					t.Errorf("got index %d, want %d from looking up hash %x", gotIndex, e.wantIndex, e.entryHash)
+				}
+			}
+		})
+	}
+}
+
+func newSpannerDB(t *testing.T) func() {
+	t.Helper()
+	srv, err := spannertest.NewServer("localhost:0")
+	if err != nil {
+		t.Fatalf("Failed to set up test spanner: %v", err)
+	}
+	if err := os.Setenv("SPANNER_EMULATOR_HOST", srv.Addr); err != nil {
+		t.Fatalf("Setenv: %v", err)
+	}
+	return srv.Close
+}
+
+func testIDHash(d []byte) []byte {
+	r := sha256.Sum256(d)
+	return r[:]
+}
+
+func testBundleHasher(b []byte) ([][]byte, error) {
+	bun := &api.EntryBundle{}
+	err := bun.UnmarshalText(b)
+	return bun.Entries, err
+}
+
+type fakeLogReader struct {
+	bundles [][]byte
+	size    uint64
+}
+
+func newFakeLogReader(data [][]byte) *fakeLogReader {
+	r := &fakeLogReader{}
+	c := [][]byte{}
+	for _, d := range data {
+		c = append(c, d)
+		if len(c) == layout.EntryBundleWidth {
+			b := []byte{}
+			for i := range c {
+				e := tessera.NewEntry(c[i])
+				b = append(b, e.MarshalBundleData(r.size)...)
+				r.size++
+			}
+			r.bundles = append(r.bundles, b)
+			c = [][]byte{}
+		}
+	}
+	if len(c) > 0 {
+		b := []byte{}
+		for i := range c {
+			e := tessera.NewEntry(c[i])
+			b = append(b, e.MarshalBundleData(r.size)...)
+			r.size++
+		}
+		r.bundles = append(r.bundles, b)
+	}
+	return r
+}
+
+func (f fakeLogReader) ReadCheckpoint(_ context.Context) ([]byte, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (f fakeLogReader) ReadTile(_ context.Context, _, _ uint64, _ uint8) ([]byte, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (f fakeLogReader) ReadEntryBundle(_ context.Context, index uint64, _ uint8) ([]byte, error) {
+	if index >= uint64(len(f.bundles)) {
+		return nil, fmt.Errorf("no bundle at index %d: %v", index, os.ErrNotExist)
+	}
+	return f.bundles[index], nil
+}
+
+func (f fakeLogReader) IntegratedSize(_ context.Context) (uint64, error) {
+	return f.size, nil
+}
+
+func (f fakeLogReader) StreamEntries(_ context.Context, fromEntry uint64) (func() (layout.RangeInfo, []byte, error), func()) {
+	next := func() (layout.RangeInfo, []byte, error) {
+		if fromEntry >= f.size {
+			return layout.RangeInfo{}, nil, os.ErrNotExist
+		}
+
+		bi, offset := fromEntry/layout.EntryBundleWidth, fromEntry%layout.EntryBundleWidth
+		n := layout.EntryBundleWidth - offset
+		if fromEntry+n > f.size {
+			n = f.size - fromEntry
+		}
+
+		ri := layout.RangeInfo{
+			Index: bi,
+			First: uint(offset),
+			N:     uint(n),
+		}
+		fromEntry += n
+		klog.Infof("YIELD: %v, %v", ri, f.bundles[bi])
+		return ri, f.bundles[bi], nil
+	}
+	cancel := func() {}
+	return next, cancel
+}

--- a/storage/gcp/antispam/gcp_test.go
+++ b/storage/gcp/antispam/gcp_test.go
@@ -38,6 +38,7 @@ type testLookup struct {
 }
 
 func TestAntispamStorage(t *testing.T) {
+	ctx := context.Background()
 	closeDB := newSpannerDB(t)
 	defer closeDB()
 
@@ -72,7 +73,7 @@ func TestAntispamStorage(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			as, err := NewAntispam(t.Context(), "projects/p/instances/i/databases/d", test.opts)
+			as, err := NewAntispam(ctx, "projects/p/instances/i/databases/d", test.opts)
 			if err != nil {
 				t.Fatalf("NewAntispam: %v", err)
 			}
@@ -83,11 +84,11 @@ func TestAntispamStorage(t *testing.T) {
 			// Hack in a workaround for spannertest not supporting BatchWrites
 			f.(*follower).updateIndex = updateIndexTx
 
-			go f.Follow(t.Context(), fr)
+			go f.Follow(ctx, fr)
 
 			for {
 				time.Sleep(time.Second)
-				pos, err := f.Position(t.Context())
+				pos, err := f.Position(ctx)
 				if err != nil {
 					t.Logf("Position: %v", err)
 					continue
@@ -99,7 +100,7 @@ func TestAntispamStorage(t *testing.T) {
 			}
 
 			for _, e := range test.lookupEntries {
-				gotIndex, err := as.index(t.Context(), e.entryHash)
+				gotIndex, err := as.index(ctx, e.entryHash)
 				if err != nil {
 					t.Errorf("error looking up hash %x: %v", e.entryHash, err)
 				}


### PR DESCRIPTION
This PR adds a simple test for the GCP antispam implementation.

Unfortunately, due to `spannertest` not supporting `BatchWrite`, I've had to add a somewhat unpleasant hook to make this possible, but at least by doing so we can exercise a fair amount of the implementation.