### PR TITLE
Bump to Go 1.24

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/cmd/conformance/aws/Dockerfile
+++ b/cmd/conformance/aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.19@sha256:fe8f9c7d418d3ac91787f11c31071c4814b6da5f9aae55bc581a7aacc264c395 AS builder
+FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
 
 ARG GOFLAGS="-trimpath -buildvcs=false -buildmode=exe"
 ENV GOFLAGS=$GOFLAGS

--- a/cmd/conformance/gcp/Dockerfile
+++ b/cmd/conformance/gcp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.19@sha256:fe8f9c7d418d3ac91787f11c31071c4814b6da5f9aae55bc581a7aacc264c395 AS builder
+FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
 
 ARG GOFLAGS="-trimpath -buildvcs=false -buildmode=exe"
 ENV GOFLAGS=$GOFLAGS

--- a/cmd/conformance/mysql/docker/Dockerfile
+++ b/cmd/conformance/mysql/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.4-bookworm@sha256:2e838582004fab0931693a3a84743ceccfbfeeafa8187e87291a1afea457ff7a AS build
+FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
 
 WORKDIR /build
 
@@ -11,6 +11,6 @@ RUN CGO_ENABLED=0 go build -v -o ./conformance-mysql ./cmd/conformance/mysql
 
 FROM alpine:3.20@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
 
-COPY --from=build /build/conformance-mysql /build/cmd/conformance/mysql/docker/testdata/key /build/cmd/conformance/mysql/docker/testdata/key.pub /build/storage/mysql/schema.sql /
+COPY --from=builder /build/conformance-mysql /build/cmd/conformance/mysql/docker/testdata/key /build/cmd/conformance/mysql/docker/testdata/key.pub /build/storage/mysql/schema.sql /
 
 ENTRYPOINT ["/conformance-mysql"]

--- a/cmd/conformance/posix/docker/Dockerfile
+++ b/cmd/conformance/posix/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.0-alpine3.19@sha256:fe8f9c7d418d3ac91787f11c31071c4814b6da5f9aae55bc581a7aacc264c395 AS build
+FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
 
 WORKDIR /build
 
@@ -11,6 +11,6 @@ RUN CGO_ENABLED=0 go build -v -o ./conformance-posix ./cmd/conformance/posix
 
 FROM alpine:3.20@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
 
-COPY --from=build /build/conformance-posix /
+COPY --from=builder /build/conformance-posix /
 
 ENTRYPOINT ["/conformance-posix"]

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/transparency-dev/trillian-tessera
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.4
+toolchain go1.24.1
 
 require (
 	cloud.google.com/go/spanner v1.77.0

--- a/internal/hammer/Dockerfile
+++ b/internal/hammer/Dockerfile
@@ -1,5 +1,4 @@
-
-FROM golang:1.23.0-alpine3.19@sha256:fe8f9c7d418d3ac91787f11c31071c4814b6da5f9aae55bc581a7aacc264c395 AS builder
+FROM golang:1.24.1-alpine3.21@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS builder
 
 ARG GOFLAGS="-trimpath -buildvcs=false -buildmode=exe"
 ENV GOFLAGS=$GOFLAGS


### PR DESCRIPTION
This PR bumps the `go.mod` file to `1.24`, along with actions/dockerfiles etc.

TesseraCT is already at `1.24`, and this gives us nice things like `t.Context()` for tests etc.