### PR TITLE
Don't fail PR check for benchmarking

### DIFF
--- a/.github/workflows/benchmark-go-pr.yml
+++ b/.github/workflows/benchmark-go-pr.yml
@@ -38,6 +38,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: false
           alert-threshold: "150%"
-          fail-on-alert: true
+          fail-on-alert: false # Don't make red crosses on the PR, it's almost certainly a false positive currently
           comment-on-alert: true # notify on PR if alert triggers
           summary-always: true # always comment on PRs to leave job summary


### PR DESCRIPTION
This PR stops the benchmark action from recording a check fail on PRs if the performance delta is over the threshold.

While it's useful to track benchmark history, the "fails" we've seen are almost all false positives due to the environment in which the benchmark is running. So, for now at least, this PR will remove the likely undeserved red X from PR checks, which should remove a bit of cognitive load from reviewers ("ah, _that_ failure is ok, but not _this_ one", etc.)