### PR TITLE
Fixed go.mod file to remove exclude

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/transparency-dev/trillian-tessera
 
 go 1.24.0
+
 require (
 	cloud.google.com/go/spanner v1.78.0
 	cloud.google.com/go/storage v1.51.0
@@ -101,5 +102,3 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 )
-
-exclude google.golang.org/grpc/stats/opentelemetry v0.0.0-20240907200651-3ffb98b2c93a


### PR DESCRIPTION
Exclude directives break running commands in the repository in the
normal go run way:

```shell
go run github.com/transparency-dev/trillian-tessera/cmd/examples/posix-oneshot@main --storage_dir=/tmp/mylog --initialise

The go.mod file for the module providing named packages contains one or
more exclude directives. It must not contain directives that would cause
it to be interpreted differently than if it were the main module.
```

I've run `go mod tidy` after this and it seems OK. We'll need to keep an
eye for dependabot making a mess.
