### PR TITLE
[Antispam] Faster tests

### DIFF
--- a/storage/aws/antispam/aws_test.go
+++ b/storage/aws/antispam/aws_test.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"os"
 	"testing"
+	"time"
 
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api"
@@ -52,7 +53,7 @@ func TestAntispam(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fl, shutdown := testonly.NewTestLog(t, tessera.NewAppendOptions())
+	fl, shutdown := testonly.NewTestLog(t, tessera.NewAppendOptions().WithCheckpointInterval(time.Second))
 	defer func() {
 		if err := shutdown(t.Context()); err != nil {
 			t.Logf("shutdown: %v", err)

--- a/storage/gcp/antispam/gcp_test.go
+++ b/storage/gcp/antispam/gcp_test.go
@@ -72,7 +72,7 @@ func TestAntispamStorage(t *testing.T) {
 				t.Fatalf("NewAntispam: %v", err)
 			}
 
-			fl, shutdown := testonly.NewTestLog(t, tessera.NewAppendOptions())
+			fl, shutdown := testonly.NewTestLog(t, tessera.NewAppendOptions().WithCheckpointInterval(time.Second))
 			defer func() {
 				if err := shutdown(t.Context()); err != nil {
 					t.Logf("shutdown: %v", err)


### PR DESCRIPTION
These tests were waiting for 10s before finishing. Publishing the checkpoint faster allows this to exit in 1.5s each, instead of 10s each.
