### PR TITLE
Move witnessing fully into lifecycle layer

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -102,6 +102,9 @@ func NewAppender(ctx context.Context, d Driver, opts *AppendOptions) (*Appender,
 	if !ok {
 		return nil, nil, nil, fmt.Errorf("driver %T does not implement Appender lifecycle", d)
 	}
+	if err := opts.valid(); err != nil {
+		return nil, nil, nil, err
+	}
 	a, r, err := lc.Appender(ctx, opts)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to init appender lifecycle: %v", err)
@@ -243,6 +246,14 @@ type AppendOptions struct {
 
 	addDecorators []func(AddFn) AddFn
 	followers     []Follower
+}
+
+// valid returns an error if an invalid combination of options has been set, or nil otherwise.
+func (o AppendOptions) valid() error {
+	if o.newCP == nil {
+		return errors.New("invalid AppendOptions: WithCheckpointSigner must be set")
+	}
+	return nil
 }
 
 // CheckpointPublisher returns a function which should be used to create, sign, and potentially witness a new checkpoint.

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -258,12 +258,12 @@ func (o AppendOptions) valid() error {
 
 // CheckpointPublisher returns a function which should be used to create, sign, and potentially witness a new checkpoint.
 func (o AppendOptions) CheckpointPublisher(lr LogReader, httpClient *http.Client) func(context.Context, uint64, []byte) ([]byte, error) {
+	wg := witness.NewWitnessGateway(o.Witnesses(), httpClient, lr.ReadTile)
 	return func(ctx context.Context, size uint64, root []byte) ([]byte, error) {
 		cp, err := o.newCP(ctx, size, root)
 		if err != nil {
 			return nil, fmt.Errorf("newCP: %v", err)
 		}
-		wg := witness.NewWitnessGateway(o.Witnesses(), httpClient, lr.ReadTile)
 		return wg.Witness(ctx, cp)
 	}
 }

--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -36,8 +36,24 @@ import (
 
 var ErrPolicyNotSatisfied = errors.New("witness policy was not satisfied")
 
+// WitnessGroup defines a group of witnesses, and a threshold of
+// signatures that must be met for this group to be satisfied.
+// Witnesses within a group should be fungible, e.g. all of the Armored
+// Witness devices form a logical group, and N should be picked to
+// represent a threshold of the quorum. For some users this will be a
+// simple majority, but other strategies are available.
+// N must be <= len(WitnessKeys).
 type WitnessGroup interface {
+	// Satisfied returns true if the checkpoint provided is signed by this witness.
+	// This will return false if there is no signature, and also if the
+	// checkpoint cannot be read as a valid note. It is up to the caller to ensure
+	// that the input value represents a valid note.
 	Satisfied(cp []byte) bool
+
+	// Endpoints returns the details required for updating a witness and checking the
+	// response. The returned result is a map from the URL that should be used to update
+	// the witness with a new checkpoint, to the value which is the verifier to check
+	// the response is well formed.
 	Endpoints() map[string]note.Verifier
 }
 

--- a/storage/aws/aws_test.go
+++ b/storage/aws/aws_test.go
@@ -409,7 +409,9 @@ func TestPublishCheckpoint(t *testing.T) {
 					entriesPath: layout.EntriesPath,
 				},
 				sequencer: s,
-				newCP:     func(size uint64, hash []byte) ([]byte, error) { return []byte(fmt.Sprintf("%d/%x,", size, hash)), nil },
+				newCP: func(_ context.Context, size uint64, hash []byte) ([]byte, error) {
+					return []byte(fmt.Sprintf("%d/%x,", size, hash)), nil
+				},
 			}
 			// Call init so we've got a zero-sized checkpoint to work with.
 			if err := storage.init(ctx); err != nil {

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -456,7 +456,9 @@ func TestPublishCheckpoint(t *testing.T) {
 					entriesPath: layout.EntriesPath,
 				},
 				sequencer: s,
-				newCP:     func(size uint64, hash []byte) ([]byte, error) { return []byte(fmt.Sprintf("%d/%x,", size, hash)), nil },
+				newCP: func(_ context.Context, size uint64, hash []byte) ([]byte, error) {
+					return []byte(fmt.Sprintf("%d/%x,", size, hash)), nil
+				},
 			}
 			// Call init so we've got a zero-sized checkpoint to work with.
 			if err := storage.init(ctx); err != nil {


### PR DESCRIPTION
This PR consolidates responsibility for dealing with getting checkpoints witnessed in the lifecycle layer, removing the need for storage implementations to be aware of it.

This is a continuation of the approach taken for creating checkpoints and signing them.

Down the line we may want to add an (optional) mechanism to thread custom `http.Clients` in, currently applications could achieve something similar by configuring `http.DefaultClient`.

Fixes #516 