### PR TITLE
[Docs] Improve docs for common lifecycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ By far the most common way to operate logs is in an append-only manner, and the 
 this mode.
 For lifecycle states other than Appender mode, take a look at [Lifecycles](#lifecycles) below.
 
-As an example of creating an `Appender` for the POSIX driver:
+Here's an example of creating an `Appender` for the POSIX driver:
 ```go file=README_test.go region=construct_example
 	driver, _ := posix.New(ctx, "/tmp/mylog")
 	signer := createSigner()
@@ -214,7 +214,7 @@ Take a look at the methods named `With*` on the `AppendOptions` struct in the ro
 
 Writing to the log follows this flow:
  1. Call `Add` with a new entry created with the data to be added as a leaf in the log.
-    - This method returns a _future_ of the form `func() (idx uint64, err error)`.
+    - This method returns a _future_ of the form `func() (Index, error)`.
  2. Call this future function, which will block until the data passed into `Add` has been sequenced
     - On success, an index number is _durably_ assigned and returned
     - On failure, the error is returned

--- a/README_test.go
+++ b/README_test.go
@@ -33,8 +33,8 @@ import (
 
 	// #region common_imports
 	tessera "github.com/transparency-dev/trillian-tessera"
-	// Choose one!
 
+	// Choose one!
 	"github.com/transparency-dev/trillian-tessera/storage/posix"
 	// "github.com/transparency-dev/trillian-tessera/storage/aws"
 	// "github.com/transparency-dev/trillian-tessera/storage/gcp"
@@ -48,11 +48,11 @@ func constructStorage() {
 	ctx := context.Background()
 
 	// #region construct_example
-	// Choose one!
 	driver, _ := posix.New(ctx, "/tmp/mylog")
 	signer := createSigner()
 
-	appender, shutdown, reader, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().WithCheckpointSigner(signer))
+	appender, shutdown, reader, err := tessera.NewAppender(
+		ctx, driver, tessera.NewAppendOptions().WithCheckpointSigner(signer))
 	// #endregion
 
 	// use the vars so the compiler/linter doesn't complain.
@@ -71,7 +71,8 @@ func constructAndUseAppender() {
 	signer := createSigner()
 
 	// #region use_appender_example
-	appender, shutdown, reader, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().WithCheckpointSigner(signer))
+	appender, shutdown, reader, err := tessera.NewAppender(
+		ctx, driver, tessera.NewAppendOptions().WithCheckpointSigner(signer))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Improved docs primarily for appender and migrate lifecycle modes.

Towards #574.
