### PR TITLE
Add follower metrics

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -236,9 +236,9 @@ func followerStats(ctx context.Context, f Follower, size func(context.Context) (
 		case <-t.C:
 		}
 
-		idx, err := f.Position(ctx)
+		idx, err := f.EntriesProcessed(ctx)
 		if err != nil {
-			klog.Errorf("followerStats: follower %q Position(): %v", name, err)
+			klog.Errorf("followerStats: follower %q EntriesProcessed(): %v", name, err)
 			continue
 		}
 		s, err := size(ctx)
@@ -246,7 +246,7 @@ func followerStats(ctx context.Context, f Follower, size func(context.Context) (
 			klog.Errorf("followerStats: follower %q size(): %v", name, err)
 		}
 		attrs := metric.WithAttributes(followerNameKey.String(name))
-		followerPosition.Record(ctx, otel.Clamp64(idx), attrs)
+		followerEntriesProcessed.Record(ctx, otel.Clamp64(idx), attrs)
 		followerLag.Record(ctx, otel.Clamp64(s-idx), attrs)
 	}
 }

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -236,7 +236,7 @@ func followerStats(ctx context.Context, f Follower, size func(context.Context) (
 		case <-t.C:
 		}
 
-		idx, err := f.EntriesProcessed(ctx)
+		n, err := f.EntriesProcessed(ctx)
 		if err != nil {
 			klog.Errorf("followerStats: follower %q EntriesProcessed(): %v", name, err)
 			continue
@@ -246,8 +246,8 @@ func followerStats(ctx context.Context, f Follower, size func(context.Context) (
 			klog.Errorf("followerStats: follower %q size(): %v", name, err)
 		}
 		attrs := metric.WithAttributes(followerNameKey.String(name))
-		followerEntriesProcessed.Record(ctx, otel.Clamp64(idx), attrs)
-		followerLag.Record(ctx, otel.Clamp64(s-idx), attrs)
+		followerEntriesProcessed.Record(ctx, otel.Clamp64(n), attrs)
+		followerLag.Record(ctx, otel.Clamp64(s-n), attrs)
 	}
 }
 

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -56,8 +56,8 @@ var (
 	appenderSignedSize       metric.Int64Gauge
 	appenderWitnessedSize    metric.Int64Gauge
 
-	followerPosition metric.Int64Gauge
-	followerLag      metric.Int64Gauge
+	followerEntriesProcessed metric.Int64Gauge
+	followerLag              metric.Int64Gauge
 
 	// Custom histogram buckets as we're still interested in details in the 1-2s area.
 	histogramBuckets = []float64{0, 10, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000, 2500, 3000, 4000, 5000, 6000, 8000, 10000}
@@ -123,16 +123,16 @@ func init() {
 		klog.Exitf("Failed to create appenderWitnessedSize metric: %v", err)
 	}
 
-	followerPosition, err = meter.Int64Gauge(
-		"tessera.follower.index",
-		metric.WithDescription("Current follower position"),
+	followerEntriesProcessed, err = meter.Int64Gauge(
+		"tessera.follower.processed",
+		metric.WithDescription("Number of entries processed"),
 		metric.WithUnit("{entry}"))
 	if err != nil {
-		klog.Exitf("Failed to create followerPosition metric: %v", err)
+		klog.Exitf("Failed to create followerEntriesProcessed metric: %v", err)
 	}
 	followerLag, err = meter.Int64Gauge(
 		"tessera.follower.lag",
-		metric.WithDescription("Number of entries between the follower position and the current integrated size"),
+		metric.WithDescription("Number of unprocessed entries in the current integrated tree"),
 		metric.WithUnit("{entry}"))
 	if err != nil {
 		klog.Exitf("Failed to create followerLag metric: %v", err)

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -93,9 +93,9 @@ type Follower interface {
 	// if e.g. the binary is restarted.
 	Follow(context.Context, LogReader)
 
-	// Position reports the progress of the follower, and should return the largest index which has been
+	// EntriesProcessed reports the progress of the follower, returning the total number of log entries
 	// successfully seen/processed.
-	Position(context.Context) (uint64, error)
+	EntriesProcessed(context.Context) (uint64, error)
 }
 
 // Antispam describes the contract that an antispam implementation must meet in order to be used via the

--- a/migrate_lifecycle.go
+++ b/migrate_lifecycle.go
@@ -161,9 +161,9 @@ func (mt *MigrationTarget) Migrate(ctx context.Context, numWorkers uint, sourceS
 			info = append(info, progress("copy", bn, bundlesToCopy))
 			info = append(info, progress("integration", s, sourceSize))
 			for _, f := range mt.followers {
-				p, err := f.Position(ctx)
+				p, err := f.EntriesProcessed(ctx)
 				if err != nil {
-					klog.Infof("%s Position(): %v", f.Name(), err)
+					klog.Infof("%s EntriesProcessed(): %v", f.Name(), err)
 					continue
 				}
 				info = append(info, progress(f.Name(), p, sourceSize))
@@ -218,9 +218,9 @@ func awaitFollower(ctx context.Context, f Follower, i uint64) func() error {
 			case <-time.After(time.Second):
 			}
 
-			pos, err := f.Position(ctx)
+			pos, err := f.EntriesProcessed(ctx)
 			if err != nil {
-				klog.Infof("%s Position(): %v", f.Name(), err)
+				klog.Infof("%s EntriesProcessed(): %v", f.Name(), err)
 				continue
 			}
 			if pos >= i {

--- a/otel.go
+++ b/otel.go
@@ -16,6 +16,7 @@ package tessera
 
 import (
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const name = "github.com/transparency-dev/trillian-tessera"
@@ -23,4 +24,8 @@ const name = "github.com/transparency-dev/trillian-tessera"
 var (
 	tracer = otel.Tracer(name)
 	meter  = otel.Meter(name)
+)
+
+var (
+	followerNameKey = attribute.Key("tessera.follower.name")
 )

--- a/storage/aws/antispam/aws.go
+++ b/storage/aws/antispam/aws.go
@@ -421,8 +421,8 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 	}
 }
 
-// Position returns the index of the entry furthest from the start of the log which has been processed.
-func (f *follower) Position(ctx context.Context) (uint64, error) {
+// EntriesProcessed returns the total number of log entries processed.
+func (f *follower) EntriesProcessed(ctx context.Context) (uint64, error) {
 	row := f.as.dbPool.QueryRowContext(ctx, "SELECT nextIdx FROM AntispamFollowCoord WHERE id = 0")
 
 	var idx uint64

--- a/storage/aws/antispam/aws_test.go
+++ b/storage/aws/antispam/aws_test.go
@@ -63,7 +63,7 @@ func TestAntispam(t *testing.T) {
 	follower := antispam.Follower(testBundleHasher)
 	go follower.Follow(ctx, fl.LogReader)
 
-	pos, err := follower.Position(ctx)
+	pos, err := follower.EntriesProcessed(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestAntispam(t *testing.T) {
 		t.Fatal(err)
 	}
 	for {
-		if idx, err := follower.Position(ctx); err != nil {
+		if idx, err := follower.EntriesProcessed(ctx); err != nil {
 			t.Fatal(err)
 		} else if idx == 2 {
 			break

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -426,8 +426,8 @@ func (f *follower) batchUpdateIndex(ctx context.Context, _ *spanner.ReadWriteTra
 	})
 }
 
-// Position returns the index of the entry furthest from the start of the log which has been processed.
-func (f *follower) Position(ctx context.Context) (uint64, error) {
+// EntriesProcessed returns the total number of log entries processed.
+func (f *follower) EntriesProcessed(ctx context.Context) (uint64, error) {
 	row, err := f.as.dbPool.Single().ReadRow(ctx, "FollowCoord", spanner.Key{0}, []string{"nextIdx"})
 	if err != nil {
 		return 0, err

--- a/storage/gcp/antispam/gcp_test.go
+++ b/storage/gcp/antispam/gcp_test.go
@@ -96,9 +96,9 @@ func TestAntispamStorage(t *testing.T) {
 
 			for {
 				time.Sleep(time.Second)
-				pos, err := f.Position(ctx)
+				pos, err := f.EntriesProcessed(ctx)
 				if err != nil {
-					t.Logf("Position: %v", err)
+					t.Logf("EntriesProcessed: %v", err)
 					continue
 				}
 				sz, err := fl.LogReader.IntegratedSize(t.Context())


### PR DESCRIPTION
This PR adds a couple of `Follower`-related metrics:
* Position (by follower name): which exposes the highest index each follower has consumed.
* Lag (by follower name): how many entries behind the currently integrated tree each follower each follower is.

Towards #570 