### PR TITLE
[AWS Antispam] End-to-end antispam for conformance

### DIFF
--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -91,7 +91,7 @@ func main() {
 		}
 		antispam, err = aws_as.NewAntispam(ctx, antispamMysqlConfig().FormatDSN(), asOpts)
 		if err != nil {
-			klog.Exitf("Failed to create new GCP antispam storage: %v", err)
+			klog.Exitf("Failed to create new AWS antispam storage: %v", err)
 		}
 	}
 	appender, shutdown, _, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().

--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/storage/aws"
+	aws_as "github.com/transparency-dev/trillian-tessera/storage/aws/antispam"
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -38,7 +39,7 @@ import (
 
 var (
 	bucket            = flag.String("bucket", "", "Bucket to use for storing log")
-	dbName            = flag.String("db_name", "", "AuroraDB name")
+	dbName            = flag.String("db_name", "", "AuroraDB name for the log DB")
 	dbHost            = flag.String("db_host", "", "AuroraDB host")
 	dbPort            = flag.Int("db_port", 3306, "AuroraDB port")
 	dbUser            = flag.String("db_user", "", "AuroraDB user")
@@ -54,6 +55,9 @@ var (
 	publishInterval   = flag.Duration("publish_interval", 3*time.Second, "How frequently to publish updated checkpoints")
 	traceFraction     = flag.Float64("trace_fraction", 0, "Fraction of open-telemetry span traces to sample")
 	additionalSigners = []string{}
+
+	antispamEnable = flag.Bool("antispam", false, "EXPERIMENTAL: Set to true to enable persistent antispam storage")
+	antispamDb     = flag.String("antispam_db_name", "", "AuroraDB name for the antispam DB")
 )
 
 func init() {
@@ -78,12 +82,24 @@ func main() {
 	if err != nil {
 		klog.Exitf("Failed to create new AWS storage: %v", err)
 	}
+	var antispam tessera.Antispam
+	// Persistent antispam is currently experimental, so there's no documentation yet!
+	if *antispamEnable {
+		asOpts := aws_as.AntispamOpts{
+			MaxBatchSize:      64,
+			PushbackThreshold: 1024,
+		}
+		antispam, err = aws_as.NewAntispam(ctx, antispamMysqlConfig().FormatDSN(), asOpts)
+		if err != nil {
+			klog.Exitf("Failed to create new GCP antispam storage: %v", err)
+		}
+	}
 	appender, shutdown, _, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
 		WithCheckpointSigner(s, a...).
 		WithCheckpointInterval(*publishInterval).
 		WithBatching(512, 300*time.Millisecond).
 		WithPushback(10*4096).
-		WithAntispam(256<<10, nil))
+		WithAntispam(256<<10, antispam))
 	if err != nil {
 		klog.Exit(err)
 	}
@@ -184,6 +200,35 @@ func storageConfigFromFlags() aws.Config {
 		DSN:          c.FormatDSN(),
 		MaxOpenConns: *dbMaxConns,
 		MaxIdleConns: *dbMaxIdle,
+	}
+}
+
+func antispamMysqlConfig() *mysql.Config {
+	if *antispamDb == "" {
+		klog.Exit("--antispam_db_name must be set")
+	}
+	if *dbHost == "" {
+		klog.Exit("--db_host must be set")
+	}
+	if *dbPort == 0 {
+		klog.Exit("--db_port must be set")
+	}
+	if *dbUser == "" {
+		klog.Exit("--db_user must be set")
+	}
+	// Empty passord isn't an option with AuroraDB MySQL.
+	if *dbPassword == "" {
+		klog.Exit("--db_password must be set")
+	}
+
+	return &mysql.Config{
+		User:                    *dbUser,
+		Passwd:                  *dbPassword,
+		Net:                     "tcp",
+		Addr:                    fmt.Sprintf("%s:%d", *dbHost, *dbPort),
+		DBName:                  *antispamDb,
+		AllowCleartextPasswords: true,
+		AllowNativePasswords:    true,
 	}
 }
 

--- a/deployment/live/aws/codelab/README.md
+++ b/deployment/live/aws/codelab/README.md
@@ -143,8 +143,8 @@ endpoint.
       --db_password=password \
       --db_name=tessera \
       --db_host=$LOG_RDS_DB \
-      --signer=$(cat /home/ec2-user/tessera-keys/$LOG_NAME.sec)
-      -v=3
+      --signer=$(cat /home/ec2-user/tessera-keys/$LOG_NAME.sec) \
+      --v=3
     ```
 
  1. 🎉 **Congratulations** 🎉
@@ -169,3 +169,29 @@ endpoint.
 > the S3 bucket or DynamoDB instance Terraform created to store its state for
 > instance). If `terragrunt destroy` shows no output, run
 > `terragrunt destroy --terragrunt-log-level debug --terragrunt-debug`.
+
+## Trying with Antispam
+
+The instructions above deploy the conformance binary without antispam enabled.
+This means that it will take any number of duplicate entries.
+
+For logs that are publicly writable, it may be beneficial to deploy Antispam, which is a weak form of deduplication.
+The instructions to do this for the codelab are largely the same, except:
+
+ 1. When applying the terraform, instruct it to create an additional DB for the antispam tables:
+    ```
+    terragrunt apply --working-dir=deployment/live/aws/codelab/ -var="create_antispam=true"
+    ```
+ 1. When running the conformance binary, pass in two additional flags to configure antispam:
+    ```
+    go run ./cmd/conformance/aws \
+      --bucket=$LOG_BUCKET \
+      --db_user=root \
+      --db_password=password \
+      --db_name=tessera \
+      --db_host=$LOG_RDS_DB \
+      --signer=$(cat /home/ec2-user/tessera-keys/$LOG_NAME.sec) \
+      --v=3 \
+      --antispam=true \
+      --antispam_db_name=antispam_db
+    ```

--- a/deployment/live/aws/codelab/README.md
+++ b/deployment/live/aws/codelab/README.md
@@ -172,10 +172,10 @@ endpoint.
 
 ## Trying with Antispam
 
-The instructions above deploy the conformance binary without antispam enabled.
-This means that it will take any number of duplicate entries.
+The instructions above deploy the conformance binary without antispam.
+This means that duplicate entries can be written to the log.
 
-For logs that are publicly writable, it may be beneficial to deploy Antispam, which is a weak form of deduplication.
+For logs that are publicly writable, it may be beneficial to deploy antispam, which is a weak form of deduplication.
 The instructions to do this for the codelab are largely the same, except:
 
  1. When applying the terraform, instruct it to create an additional DB for the antispam tables:

--- a/deployment/live/aws/conformance/terragrunt.hcl
+++ b/deployment/live/aws/conformance/terragrunt.hcl
@@ -16,6 +16,7 @@ locals {
   # Roles are defined externally
   ecs_execution_role        = "arn:aws:iam::864981736166:role/ecsTaskExecutionRole"
   ecs_conformance_task_role = "arn:aws:iam::864981736166:role/ConformanceECSTaskRolePolicy"
+  antispam                  = true
   ephemeral                 = true
 }
 

--- a/deployment/modules/aws/codelab/main.tf
+++ b/deployment/modules/aws/codelab/main.tf
@@ -3,7 +3,7 @@ terraform {
   backend "s3" {}
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "5.76.0"
     }
   }
@@ -21,10 +21,11 @@ provider "aws" {
 module "storage" {
   source = "../storage"
 
-  prefix_name = var.prefix_name
-  base_name   = var.base_name
-  region      = var.region
-  ephemeral   = true
+  prefix_name     = var.prefix_name
+  base_name       = var.base_name
+  region          = var.region
+  create_antispam = var.create_antispam
+  ephemeral       = var.ephemeral
 }
 
 # Resources ####################################################################
@@ -32,7 +33,7 @@ module "storage" {
 # This will be used for the containers to communicate between themselves, and
 # the S3 bucket.
 resource "aws_default_vpc" "default" {
-   tags = {
+  tags = {
     Name = "Default VPC"
   }
 }
@@ -70,9 +71,9 @@ data "aws_iam_policy_document" "allow_access_from_vpce" {
     ]
 
     condition {
-     test = "StringEquals"
-     variable = "aws:sourceVpce" 
-     values = [aws_vpc_endpoint.s3.id]
+      test     = "StringEquals"
+      variable = "aws:sourceVpce"
+      values   = [aws_vpc_endpoint.s3.id]
     }
   }
   depends_on = [aws_vpc_endpoint.s3]

--- a/deployment/modules/aws/codelab/outputs.tf
+++ b/deployment/modules/aws/codelab/outputs.tf
@@ -3,6 +3,11 @@ output "log_bucket_id" {
   value       = module.storage.log_bucket.id
 }
 
+output "log_bucket_http" {
+  description = "Log S3 bucket http access"
+  value       = "https://${module.storage.log_bucket.bucket_regional_domain_name}"
+}
+
 output "log_rds_db" {
   description = "Log RDS database endpoint"
   value       = module.storage.log_rds_db.endpoint

--- a/deployment/modules/aws/codelab/variables.tf
+++ b/deployment/modules/aws/codelab/variables.tf
@@ -13,7 +13,14 @@ variable "region" {
   type        = string
 }
 
+variable "create_antispam" {
+  description = "Set to true to create another database to be used by the antispam implementation."
+  type        = bool
+  default     = false
+}
+
 variable "ephemeral" {
   description = "Set to true if this is a throwaway/temporary log instance. Will set attributes on created resources to allow them to be disabled/deleted more easily."
-  type = bool
+  type        = bool
+  default     = true
 }

--- a/deployment/modules/aws/conformance/main.tf
+++ b/deployment/modules/aws/conformance/main.tf
@@ -21,10 +21,11 @@ provider "aws" {
 module "storage" {
   source = "../storage"
 
-  prefix_name = var.prefix_name
-  base_name   = var.base_name
-  region      = var.region
-  ephemeral   = true
+  prefix_name     = var.prefix_name
+  base_name       = var.base_name
+  region          = var.region
+  ephemeral       = true
+  create_antispam = var.antispam
 }
 
 # Resources ####################################################################
@@ -158,6 +159,8 @@ resource "aws_ecs_task_definition" "conformance" {
       "--db_password=password",
       "--db_name=tessera",
       "--db_host=${module.storage.log_rds_db.endpoint}",
+      "--antispam=${var.antispam}",
+      "--antispam_db_name=antispam_db",
       "-v=2"
     ],
     "logConfiguration" : {
@@ -171,26 +174,26 @@ resource "aws_ecs_task_definition" "conformance" {
         "awslogs-stream-prefix" : "ecs"
       },
     },
-  }, {
-    "name": "aws-otel-collector-${local.name}",
-    "image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.43.1",
-    "command":["--config=/etc/ecs/ecs-cloudwatch-xray.yaml"],
-    "essential": true,
-    "logConfiguration": {
-      "logDriver": "awslogs",
-      "options": {
+    }, {
+    "name" : "aws-otel-collector-${local.name}",
+    "image" : "public.ecr.aws/aws-observability/aws-otel-collector:v0.43.1",
+    "command" : ["--config=/etc/ecs/ecs-cloudwatch-xray.yaml"],
+    "essential" : true,
+    "logConfiguration" : {
+      "logDriver" : "awslogs",
+      "options" : {
         "awslogs-group" : "/ecs/${local.name}",
-        "awslogs-region": "us-east-1",
-        "awslogs-stream-prefix": "ecs",
-        "awslogs-create-group": "true"
+        "awslogs-region" : "us-east-1",
+        "awslogs-stream-prefix" : "ecs",
+        "awslogs-create-group" : "true"
       }
     },
-    "healthCheck": {
-      "command": [ "/healthcheck" ],
-      "interval": 5,
-      "timeout": 6,
-      "retries": 5,
-      "startPeriod": 1
+    "healthCheck" : {
+      "command" : ["/healthcheck"],
+      "interval" : 5,
+      "timeout" : 6,
+      "retries" : 5,
+      "startPeriod" : 1
     },
     "portMappings" : [],
   }])

--- a/deployment/modules/aws/conformance/variables.tf
+++ b/deployment/modules/aws/conformance/variables.tf
@@ -15,7 +15,7 @@ variable "region" {
 
 variable "ephemeral" {
   description = "Set to true if this is a throwaway/temporary log instance. Will set attributes on created resources to allow them to be disabled/deleted more easily."
-  type = bool
+  type        = bool
 }
 
 variable "ecr_registry" {
@@ -51,4 +51,10 @@ variable "ecs_execution_role" {
 variable "ecs_conformance_task_role" {
   description = "Role assumed by conformance containers when they run."
   type        = string
+}
+
+variable "antispam" {
+  description = "Set to true to enable antispam for this conformance log."
+  type        = bool
+  default     = false
 }

--- a/deployment/modules/aws/storage/main.tf
+++ b/deployment/modules/aws/storage/main.tf
@@ -2,6 +2,15 @@ locals {
   name = "${var.prefix_name}-${var.base_name}"
 }
 
+terraform {
+  required_providers {
+    mysql = {
+      source  = "petoju/mysql"
+      version = "3.0.71"
+    }
+  }
+}
+
 # Configure the AWS Provider
 provider "aws" {
   region = var.region
@@ -11,19 +20,19 @@ provider "aws" {
 
 ## S3 Bucket
 resource "aws_s3_bucket" "log_bucket" {
-  bucket = "${local.name}-bucket"
+  bucket        = "${local.name}-bucket"
   force_destroy = var.ephemeral
 }
 
 ## Aurora MySQL RDS database
 resource "aws_rds_cluster" "log_rds" {
-  apply_immediately       = true
-  cluster_identifier      = "${local.name}-cluster"
-  engine                  = "aurora-mysql"
+  apply_immediately  = true
+  cluster_identifier = "${local.name}-cluster"
+  engine             = "aurora-mysql"
   # TODO(phboneff): make sure that we want to pin this
-  engine_version          = "8.0.mysql_aurora.3.05.2"
-  database_name           = "tessera"
-  master_username         = "root"
+  engine_version  = "8.0.mysql_aurora.3.05.2"
+  database_name   = "tessera"
+  master_username = "root"
   # TODO(phboneff): move to either random strings / Secret Manager / IAM
   master_password         = "password"
   skip_final_snapshot     = true
@@ -39,4 +48,18 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   instance_class     = "db.r5.large"
   engine             = aws_rds_cluster.log_rds.engine
   engine_version     = aws_rds_cluster.log_rds.engine_version
+}
+
+# Configure the MySQL provider based on the outcome of
+# creating the aws_db_instance.
+provider "mysql" {
+  endpoint = aws_rds_cluster_instance.cluster_instances[0].endpoint
+  username = aws_rds_cluster.log_rds.master_username
+  password = aws_rds_cluster.log_rds.master_password
+}
+
+# Create a second database for antispam.
+resource "mysql_database" "antispam_db" {
+  name  = "antispam_db"
+  count = var.create_antispam ? 1 : 0
 }

--- a/deployment/modules/aws/storage/variables.tf
+++ b/deployment/modules/aws/storage/variables.tf
@@ -13,7 +13,13 @@ variable "region" {
   type        = string
 }
 
+variable "create_antispam" {
+  description = "Set to true to create another database to be used by the antispam implementation."
+  type        = bool
+  default     = false
+}
+
 variable "ephemeral" {
   description = "Set to true if this is a throwaway/temporary log instance. Will set attributes on created resources to allow them to be disabled/deleted more easily."
-  type = bool
+  type        = bool
 }


### PR DESCRIPTION
Antispam DB can now be created via the Terraform, and the conformance
command takes flags that allow antispam to be enabled and configured
with this DB.

Docs have been added to the end of the codelab instructions to document
how to deploy this.

Some performance testing was performed and results look good: with 1200
write workers doing 1200 writes per second, with 30% dupe chance, the
log was keeping up, growing by around 800 leaves per second.

```
Read (8 workers): Current max: 20/s. Oversupply in last second: 0
Write (1200 workers): Current max: 1200/s. Oversupply in last second: 0
TreeSize: 199416 (Δ 745qps over 30s)
Time-in-queue: 6ms/411ms/1056ms (min/avg/max)
Observed-time-to-integrate: 43ms/1291ms/4346ms (min/avg/max)
```

There are a couple of fixes in here for state/transaction management to
be more resilient when following the DB. Previously TXs were sometimes
not closed, which would lock the table until TX expiry.

Towards #526.