### PR TITLE
[AWS] Tune conformance binary for lower latency

### DIFF
--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -81,9 +81,9 @@ func main() {
 	appender, shutdown, _, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
 		WithCheckpointSigner(s, a...).
 		WithCheckpointInterval(*publishInterval).
-		WithBatching(1024, time.Second).
+		WithBatching(512, 300*time.Millisecond).
 		WithPushback(10*4096).
-		WithAntispam(256, nil))
+		WithAntispam(256<<10, nil))
 	if err != nil {
 		klog.Exit(err)
 	}


### PR DESCRIPTION
This PR tweaks some tunables to lower write-latency for the conformance/CI use-case.

Previously, we were waiting for a full second for a batch of 1024 entries which was never going to arrive.

