### PR TITLE
Disable antispam in AWS CI

### DIFF
--- a/deployment/live/aws/conformance/ci/terragrunt.hcl
+++ b/deployment/live/aws/conformance/ci/terragrunt.hcl
@@ -3,4 +3,16 @@ include "root" {
   expose = true
 }
 
-inputs = include.root.locals
+inputs = merge(
+  include.root.locals,
+  {
+    # This hack makes it so that the antispam tables are created in the main
+    # tessera DB. We strongly recommend that the antispam DB is separate, but
+    # creating a second DB from Terraform is too difficult without a large
+    # rewrite. For CI purposes, testing antispam, even if in the same DB, is
+    # preferred compared to not testing antispam at all.
+    antispam         = true
+    antispam_db_name = "tessera"
+    create_antispam  = false
+  }
+)

--- a/deployment/live/aws/conformance/terragrunt.hcl
+++ b/deployment/live/aws/conformance/terragrunt.hcl
@@ -16,7 +16,6 @@ locals {
   # Roles are defined externally
   ecs_execution_role        = "arn:aws:iam::864981736166:role/ecsTaskExecutionRole"
   ecs_conformance_task_role = "arn:aws:iam::864981736166:role/ConformanceECSTaskRolePolicy"
-  antispam                  = true
   ephemeral                 = true
 }
 

--- a/deployment/modules/aws/conformance/main.tf
+++ b/deployment/modules/aws/conformance/main.tf
@@ -25,7 +25,7 @@ module "storage" {
   base_name       = var.base_name
   region          = var.region
   ephemeral       = true
-  create_antispam = var.antispam
+  create_antispam = var.create_antispam
 }
 
 # Resources ####################################################################
@@ -160,7 +160,7 @@ resource "aws_ecs_task_definition" "conformance" {
       "--db_name=tessera",
       "--db_host=${module.storage.log_rds_db.endpoint}",
       "--antispam=${var.antispam}",
-      "--antispam_db_name=antispam_db",
+      "--antispam_db_name=${var.antispam_db_name}",
       "-v=2"
     ],
     "logConfiguration" : {

--- a/deployment/modules/aws/conformance/variables.tf
+++ b/deployment/modules/aws/conformance/variables.tf
@@ -54,7 +54,19 @@ variable "ecs_conformance_task_role" {
 }
 
 variable "antispam" {
-  description = "Set to true to enable antispam for this conformance log."
+  description = "Set to true to enable antispam for this conformance log. If enabled, antispam_db_name must also be provided."
   type        = bool
   default     = false
+}
+
+variable "create_antispam" {
+  description = "Set to true to create a separate DB for the antispam data. This will not work from github actions."
+  type        = bool
+  default     = false
+}
+
+variable "antispam_db_name" {
+  description = "The name of the antispam database."
+  type        = string
+  default     = ""
 }

--- a/deployment/modules/aws/storage/main.tf
+++ b/deployment/modules/aws/storage/main.tf
@@ -52,6 +52,9 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
 
 # Configure the MySQL provider based on the outcome of
 # creating the aws_db_instance.
+# This requires that the machine running terraform has access
+# to the DB instance created above. This is _NOT_ the case when
+# github actions are applying the terraform.
 provider "mysql" {
   endpoint = aws_rds_cluster_instance.cluster_instances[0].endpoint
   username = aws_rds_cluster.log_rds.master_username


### PR DESCRIPTION
This is failing at the moment since being enabled in #592. Some permissions need to be fixed, but disabling this to avoid other breakages in the meantime.
