### PR TITLE
Add NextIndex metric

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -53,6 +53,7 @@ var (
 	appenderHighestIndex     metric.Int64Gauge
 	appenderIntegratedSize   metric.Int64Gauge
 	appenderIntegrateLatency metric.Int64Histogram
+	appenderPendingCount     metric.Int64Gauge
 	appenderSignedSize       metric.Int64Gauge
 	appenderWitnessedSize    metric.Int64Gauge
 
@@ -105,6 +106,14 @@ func init() {
 		metric.WithExplicitBucketBoundaries(histogramBuckets...))
 	if err != nil {
 		klog.Exitf("Failed to create appenderIntegrateLatency metric: %v", err)
+	}
+
+	appenderPendingCount, err = meter.Int64Gauge(
+		"tessera.appender.pending.count",
+		metric.WithDescription("Number of sequenced but not yet integrated entries"),
+		metric.WithUnit("{entry}"))
+	if err != nil {
+		klog.Exitf("Failed to create appenderPendingCount metric: %v", err)
 	}
 
 	appenderSignedSize, err = meter.Int64Gauge(
@@ -320,6 +329,11 @@ func (i *integrationStats) updateStats(ctx context.Context, r LogReader) {
 		if d, ok := i.latency(s); ok {
 			appenderIntegrateLatency.Record(ctx, d.Milliseconds())
 		}
+		p, err := r.PendingCount(ctx)
+		if err != nil {
+			klog.Errorf("PendingCount: %v", err)
+		}
+		appenderPendingCount.Record(ctx, otel.Clamp64(p))
 	}
 }
 

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -64,11 +64,12 @@ type LogReader interface {
 	// log should be used. If in doubt, use ReadCheckpoint instead.
 	IntegratedSize(ctx context.Context) (uint64, error)
 
-	// PendingCount returns the number of sequenced but not-yet-integrated entries.
+	// NextIndex returns the first as-yet unassigned index.
 	//
-	// This is primarily intended for use in metrics, and for shifts in lifecycle mode where
-	// it's important to know when the log is fully drained.
-	PendingCount(ctx context.Context) (uint64, error)
+	// In a quiescent log, this will be the same as the checkpoint size. In a log with entries actively
+	// being added, this number will be higher since it will take sequenced but not-yet-integrated
+	// entries into account.
+	NextIndex(ctx context.Context) (uint64, error)
 
 	// StreamEntries() returns functions `next` and `stop` which act like a pull iterator for
 	// consecutive entry bundles, starting with the entry bundle which contains the requested entry

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -67,7 +67,7 @@ type LogReader interface {
 	// NextIndex returns the first as-yet unassigned index.
 	//
 	// In a quiescent log, this will be the same as the checkpoint size. In a log with entries actively
-	// being added, this number will be higher since it will take sequenced but not-yet-integrated
+	// being added, this number will be higher since it will take sequenced but not-yet-integrated/not-yet-published
 	// entries into account.
 	NextIndex(ctx context.Context) (uint64, error)
 

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -64,6 +64,12 @@ type LogReader interface {
 	// log should be used. If in doubt, use ReadCheckpoint instead.
 	IntegratedSize(ctx context.Context) (uint64, error)
 
+	// PendingCount returns the number of sequenced but not-yet-integrated entries.
+	//
+	// This is primarily intended for use in metrics, and for shifts in lifecycle mode where
+	// it's important to know when the log is fully drained.
+	PendingCount(ctx context.Context) (uint64, error)
+
 	// StreamEntries() returns functions `next` and `stop` which act like a pull iterator for
 	// consecutive entry bundles, starting with the entry bundle which contains the requested entry
 	// index.

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -104,6 +104,8 @@ type sequencer interface {
 	consumeEntries(ctx context.Context, limit uint64, f consumeFunc, forceUpdate bool) (bool, error)
 	// currentTree returns the tree state of the currently integrated tree according to the IntCoord table.
 	currentTree(ctx context.Context) (uint64, []byte, error)
+	// pendingCount returns the number of sequenced but not-yet-integrated entries.
+	pendingCount(ctx context.Context) (uint64, error)
 }
 
 // consumeFunc is the signature of a function which can consume entries from the sequencer and integrate
@@ -129,6 +131,7 @@ func New(ctx context.Context, cfg Config) (tessera.Driver, error) {
 type LogReader struct {
 	lrs            logResourceStore
 	integratedSize func(context.Context) (uint64, error)
+	pendingCount   func(context.Context) (uint64, error)
 }
 
 func (lr *LogReader) ReadCheckpoint(ctx context.Context) ([]byte, error) {
@@ -163,6 +166,13 @@ func (lr *LogReader) IntegratedSize(ctx context.Context) (uint64, error) {
 	defer span.End()
 
 	return lr.integratedSize(ctx)
+}
+
+func (lr *LogReader) PendingCount(ctx context.Context) (uint64, error) {
+	ctx, span := tracer.Start(ctx, "tessera.storage.gcp.PendingCount")
+	defer span.End()
+
+	return lr.pendingCount(ctx)
 }
 
 func (lr *LogReader) StreamEntries(ctx context.Context, fromEntry uint64) (next func() (ri layout.RangeInfo, bundle []byte, err error), cancel func()) {
@@ -211,6 +221,9 @@ func (s *Storage) Appender(ctx context.Context, opts *tessera.AppendOptions) (*t
 		integratedSize: func(context.Context) (uint64, error) {
 			s, _, err := a.sequencer.currentTree(ctx)
 			return s, err
+		},
+		pendingCount: func(context.Context) (uint64, error) {
+			return a.sequencer.pendingCount(ctx)
 		},
 	}
 	a.newCP = opts.CheckpointPublisher(reader, http.DefaultClient)
@@ -880,6 +893,34 @@ func (s *spannerCoordinator) currentTree(ctx context.Context) (uint64, []byte, e
 	return uint64(fromSeq), rootHash, nil
 }
 
+// pendingCount returns the number of sequenced but not-yet-integrated entries.
+func (s *spannerCoordinator) pendingCount(ctx context.Context) (uint64, error) {
+	txn := s.dbPool.ReadOnlyTransaction()
+	defer txn.Close()
+
+	var treeSize int64 // Spanner doesn't support uint64
+	row, err := txn.ReadRow(ctx, "IntCoord", spanner.Key{0}, []string{"seq"})
+	if err != nil {
+		return 0, fmt.Errorf("failed to read integration coordination row: %v", err)
+	}
+	if err := row.Columns(&treeSize); err != nil {
+		return 0, fmt.Errorf("failed to read integration coordination info: %v", err)
+	}
+
+	var nextSeq int64 // Spanner doesn't support uint64
+	row, err = txn.ReadRow(ctx, "SeqCoord", spanner.Key{0}, []string{"next"})
+	if err != nil {
+		return 0, fmt.Errorf("failed to read sequence coordination row: %v", err)
+	}
+	if err := row.Columns(&nextSeq); err != nil {
+		return 0, fmt.Errorf("failed to read sequence coordination info: %v", err)
+	}
+
+	pendingCount := nextSeq - treeSize
+
+	return uint64(pendingCount), nil
+}
+
 // gcsStorage knows how to store and retrieve objects from GCS.
 type gcsStorage struct {
 	bucket    string
@@ -998,6 +1039,9 @@ func (s *Storage) MigrationWriter(ctx context.Context, opts *tessera.MigrationOp
 		integratedSize: func(context.Context) (uint64, error) {
 			s, _, err := m.sequencer.currentTree(ctx)
 			return s, err
+		},
+		pendingCount: func(context.Context) (uint64, error) {
+			return 0, nil
 		},
 	}
 	return m, r, nil

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -331,6 +331,15 @@ func (s *Storage) IntegratedSize(ctx context.Context) (uint64, error) {
 	return ts.size, nil
 }
 
+// PendingCount returns the number of sequenced but not-yet-integrated entries.
+//
+// Currently, this is always zero because integration is synchronous with queue flush.
+//
+// This is part of the tessera LogReader contract.
+func (s *Storage) PendingCount(ctx context.Context) (uint64, error) {
+	return 0, nil
+}
+
 // StreamEntries() returns functions `next` and `cancel` which act like a pull iterator for
 // consecutive entry bundles, starting with the entry bundle which contains the requested entry
 // index.

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -331,13 +331,12 @@ func (s *Storage) IntegratedSize(ctx context.Context) (uint64, error) {
 	return ts.size, nil
 }
 
-// PendingCount returns the number of sequenced but not-yet-integrated entries.
+// NextIndex returns the next available leaf index.
 //
-// Currently, this is always zero because integration is synchronous with queue flush.
-//
+// Currently, this is the same as the integrated size since new leaves are integrated synchronously.
 // This is part of the tessera LogReader contract.
-func (s *Storage) PendingCount(ctx context.Context) (uint64, error) {
-	return 0, nil
+func (s *Storage) NextIndex(ctx context.Context) (uint64, error) {
+	return s.IntegratedSize(ctx)
 }
 
 // StreamEntries() returns functions `next` and `cancel` which act like a pull iterator for

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -200,8 +200,8 @@ func (l *logResourceStorage) IntegratedSize(_ context.Context) (uint64, error) {
 	return size, err
 }
 
-func (l *logResourceStorage) PendingCount(_ context.Context) (uint64, error) {
-	return l.s.pendingCount()
+func (l *logResourceStorage) NextIndex(ctx context.Context) (uint64, error) {
+	return l.IntegratedSize(ctx)
 }
 
 func (l *logResourceStorage) StreamEntries(ctx context.Context, fromEntry uint64) (next func() (ri layout.RangeInfo, bundle []byte, err error), cancel func()) {
@@ -301,7 +301,7 @@ func (a *appender) sequenceBatch(ctx context.Context, entries []*tessera.Entry) 
 	}
 
 	// For simplicity, in-line the integration of these new entries into the Merkle structure too.
-	// If this is broken out into an async process, we'll need to update the implementation of pendingCount below, too.
+	// If this is broken out into an async process, we'll need to update the implementation of NextIndex, too.
 	newSize, newRoot, err := doIntegrate(ctx, seq, leafHashes, a.logStorage)
 	if err != nil {
 		klog.Errorf("Integrate failed: %v", err)
@@ -545,13 +545,6 @@ func (s *Storage) readTreeState() (uint64, []byte, error) {
 		return 0, nil, fmt.Errorf("error in Unmarshal: %v", err)
 	}
 	return ts.Size, ts.Root, nil
-}
-
-// pendingCount returns the number of sequenced but not-yet-integrated entries.
-//
-// Currently, integration is done inline with queue flushes, so this is always zero.
-func (s *Storage) pendingCount() (uint64, error) {
-	return 0, nil
 }
 
 // publishCheckpoint checks whether the currently published checkpoint (if any) is more than


### PR DESCRIPTION
This PR adds a metric which exposes the next index which will be used for sequencing.

Such a metric helps determine whether a log is fully drained, critical information when switching lifecycle modes. 

Towards #588  