### PR TITLE
Adjust antispam defaults, and use them in conformance bins

### DIFF
--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -85,10 +85,7 @@ func main() {
 	var antispam tessera.Antispam
 	// Persistent antispam is currently experimental, so there's no documentation yet!
 	if *antispamEnable {
-		asOpts := aws_as.AntispamOpts{
-			MaxBatchSize:      64,
-			PushbackThreshold: 1024,
-		}
+		asOpts := aws_as.AntispamOpts{} // Use defaults
 		antispam, err = aws_as.NewAntispam(ctx, antispamMysqlConfig().FormatDSN(), asOpts)
 		if err != nil {
 			klog.Exitf("Failed to create new AWS antispam storage: %v", err)

--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -70,10 +70,7 @@ func main() {
 	var antispam tessera.Antispam
 	// Persistent antispam is currently experimental, so there's no terraform or documentation yet!
 	if *persistentAntispam {
-		asOpts := gcp_as.AntispamOpts{
-			MaxBatchSize:      1024,
-			PushbackThreshold: 1024,
-		}
+		asOpts := gcp_as.AntispamOpts{} // Use defaults
 		antispam, err = gcp_as.NewAntispam(ctx, fmt.Sprintf("%s-antispam", *spanner), asOpts)
 		if err != nil {
 			klog.Exitf("Failed to create new GCP antispam storage: %v", err)

--- a/storage/aws/antispam/aws.go
+++ b/storage/aws/antispam/aws.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	DefaultMaxBatchSize      = 64
-	DefaultPushbackThreshold = 1024
+	DefaultPushbackThreshold = 2048
 
 	// SchemaCompatibilityVersion represents the expected version (e.g. layout & serialisation) of stored data.
 	//

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -37,8 +37,8 @@ import (
 )
 
 const (
-	DefaultMaxBatchSize      = 64
-	DefaultPushbackThreshold = 1024
+	DefaultMaxBatchSize      = 1500
+	DefaultPushbackThreshold = 2048
 )
 
 // AntispamOpts allows configuration of some tunable options.


### PR DESCRIPTION
This PR adjusts defaults for the antispam implementations.

The new numbers come from running the GCP implementation at scale for a while. AWS has been _optimistically_ bumped to match as implementation is similar, but should be revisited once more experience is gained with it.