### PR TITLE
Factor-out EntryStreamReader

### DIFF
--- a/storage/aws/antispam/aws.go
+++ b/storage/aws/antispam/aws.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	tessera "github.com/transparency-dev/trillian-tessera"
-	"github.com/transparency-dev/trillian-tessera/api/layout"
+	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
 	"k8s.io/klog/v2"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -239,58 +239,6 @@ func (d *AntispamStorage) Follower(b func([]byte) ([][]byte, error)) tessera.Fol
 	}
 }
 
-// entryStreamReader converts a stream of {RangeInfo, EntryBundle} into a stream of individually processed entries.
-//
-// TODO(al): Factor this out for re-use elsewhere when it's ready.
-type entryStreamReader[T any] struct {
-	bundleFn func([]byte) ([]T, error)
-	next     func() (layout.RangeInfo, []byte, error)
-
-	curData []T
-	curRI   layout.RangeInfo
-	i       uint64
-}
-
-// newEntryStreamReader creates a new stream reader which uses the provided bundleFn to process bundles into processed entries of type T
-//
-// Different bundleFn implementations can be provided to return raw entry bytes, parsed entry structs, or derivations of entries (e.g. hashes) as needed.
-func newEntryStreamReader[T any](next func() (layout.RangeInfo, []byte, error), bundleFn func([]byte) ([]T, error)) *entryStreamReader[T] {
-	return &entryStreamReader[T]{
-		bundleFn: bundleFn,
-		next:     next,
-		i:        0,
-	}
-}
-
-// Next processes and returns the next available entry in the stream along with its index in the log.
-func (e *entryStreamReader[T]) Next() (uint64, T, error) {
-	var t T
-	if len(e.curData) == 0 {
-		var err error
-		var b []byte
-		e.curRI, b, err = e.next()
-		if err != nil {
-			return 0, t, fmt.Errorf("next: %v", err)
-		}
-		e.curData, err = e.bundleFn(b)
-		if err != nil {
-			return 0, t, fmt.Errorf("bundleFn(bundleEntry @%d): %v", e.curRI.Index, err)
-
-		}
-		if e.curRI.First > 0 {
-			e.curData = e.curData[e.curRI.First:]
-		}
-		if len(e.curData) > int(e.curRI.N) {
-			e.curData = e.curData[:e.curRI.N]
-		}
-		e.i = 0
-	}
-	t, e.curData = e.curData[0], e.curData[1:]
-	rIdx := e.curRI.Index*layout.EntryBundleWidth + uint64(e.curRI.First) + e.i
-	e.i++
-	return rIdx, t, nil
-}
-
 // follower is a struct which knows how to populate the antispam storage with identity hashes
 // for entries in a log.
 type follower struct {
@@ -308,7 +256,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 
 	t := time.NewTicker(time.Second)
 	var (
-		entryReader *entryStreamReader[[]byte]
+		entryReader *storage.EntryStreamReader[[]byte]
 		stop        func()
 
 		curEntries [][]byte
@@ -367,7 +315,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 				if entryReader == nil {
 					next, st := lr.StreamEntries(ctx, followFrom)
 					stop = st
-					entryReader = newEntryStreamReader(next, f.bundleHasher)
+					entryReader = storage.NewEntryStreamReader(next, f.bundleHasher)
 				}
 
 				bs := uint64(f.as.opts.MaxBatchSize)

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -31,7 +31,7 @@ import (
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
 
 	tessera "github.com/transparency-dev/trillian-tessera"
-	"github.com/transparency-dev/trillian-tessera/api/layout"
+	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
 	"google.golang.org/grpc/codes"
 	"k8s.io/klog/v2"
 )
@@ -193,58 +193,6 @@ func (d *AntispamStorage) Follower(b func([]byte) ([][]byte, error)) tessera.Fol
 	return f
 }
 
-// entryStreamReader converts a stream of {RangeInfo, EntryBundle} into a stream of individually processed entries.
-//
-// TODO(al): Factor this out for re-use elsewhere when it's ready.
-type entryStreamReader[T any] struct {
-	bundleFn func([]byte) ([]T, error)
-	next     func() (layout.RangeInfo, []byte, error)
-
-	curData []T
-	curRI   layout.RangeInfo
-	i       uint64
-}
-
-// newEntryStreamReader creates a new stream reader which uses the provided bundleFn to process bundles into processed entries of type T
-//
-// Different bundleFn implementations can be provided to return raw entry bytes, parsed entry structs, or derivations of entries (e.g. hashes) as needed.
-func newEntryStreamReader[T any](next func() (layout.RangeInfo, []byte, error), bundleFn func([]byte) ([]T, error)) *entryStreamReader[T] {
-	return &entryStreamReader[T]{
-		bundleFn: bundleFn,
-		next:     next,
-		i:        0,
-	}
-}
-
-// Next processes and returns the next available entry in the stream along with its index in the log.
-func (e *entryStreamReader[T]) Next() (uint64, T, error) {
-	var t T
-	if len(e.curData) == 0 {
-		var err error
-		var b []byte
-		e.curRI, b, err = e.next()
-		if err != nil {
-			return 0, t, fmt.Errorf("next: %v", err)
-		}
-		e.curData, err = e.bundleFn(b)
-		if err != nil {
-			return 0, t, fmt.Errorf("bundleFn(bundleEntry @%d): %v", e.curRI.Index, err)
-
-		}
-		if e.curRI.First > 0 {
-			e.curData = e.curData[e.curRI.First:]
-		}
-		if len(e.curData) > int(e.curRI.N) {
-			e.curData = e.curData[:e.curRI.N]
-		}
-		e.i = 0
-	}
-	t, e.curData = e.curData[0], e.curData[1:]
-	rIdx := e.curRI.Index*layout.EntryBundleWidth + uint64(e.curRI.First) + e.i
-	e.i++
-	return rIdx, t, nil
-}
-
 // follower is a struct which knows how to populate the antispam storage with identity hashes
 // for entries in a log.
 type follower struct {
@@ -273,7 +221,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 
 	t := time.NewTicker(time.Second)
 	var (
-		entryReader *entryStreamReader[[]byte]
+		entryReader *storage.EntryStreamReader[[]byte]
 		stop        func()
 
 		curEntries [][]byte
@@ -326,7 +274,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 					span.AddEvent("Start streaming entries")
 					next, st := lr.StreamEntries(ctx, followFrom)
 					stop = st
-					entryReader = newEntryStreamReader(next, f.bundleHasher)
+					entryReader = storage.NewEntryStreamReader(next, f.bundleHasher)
 				}
 
 				if curIndex == followFrom && curEntries != nil {


### PR DESCRIPTION
This PR factors out the common implementation of `entryReader` next to `StreamAdaptor`.

In general, we're not at the point where we want to start factoring things out of storage implementations, but this one (which is specific to antispam, as opposed to log storage) is slightly different - the implementation of `entryStreamReader` is intricate, and is intended for use with the output of the `StreamAdaptor` implementation in the same package.

There's further work which could be done here, but that's for later.