### PR TITLE
Slight API pruning and modernization

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Once an index has been returned, the new data is sequenced, but not necessarily 
 
 As discussed above in [Integration](#integration), sequenced entries will be _asynchronously_ integrated into the log and be made available via the read API.
 Some personalities may need to block until this has been performed, e.g. because they will provide the requester with an inclusion proof, which requires integration.
-Such personalities are recommended to use [Synchronous Integration](#synchronous-integration) to perform this blocking.
+Such personalities are recommended to use [Synchronous Integration](#synchronous-publication) to perform this blocking.
 
 #### Reading from the Log
 
@@ -307,10 +307,10 @@ If this method is not called then no witnessing will be configured.
 > If the policy cannot be satisfied then no checkpoint will be published.
 > It is up to the log operator to ensure that a satisfiable policy is configured, and that the requested publishing rate is acceptable to the configured witnesses.
 
-### Synchronous Integration
+### Synchronous Publication
 
-Synchronous Integration is provided by [`tessera.IntegrationAwaiter`](https://pkg.go.dev/github.com/transparency-dev/trillian-tessera#IntegrationAwaiter).
-This allows applications built with Tessera to block until one or more leaves passed via calls to `Add()` are fully integrated into the tree.
+Synchronous Publication is provided by [`tessera.PublicationAwaiter`](https://pkg.go.dev/github.com/transparency-dev/trillian-tessera#PublicationAwaiter).
+This allows applications built with Tessera to block until leaves passed via calls to `Add()` are committed to via a public checkpoint.
 
 > [!Tip]
 > This is useful if e.g. your application needs to return an inclusion proof in response to a request to add an entry to the log.

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -154,7 +154,7 @@ func BenchmarkLeafBundle_UnmarshalText(b *testing.B) {
 		_, _ = bs.Write(tessera.NewEntry([]byte(leafStr)).MarshalBundleData(uint64(i)))
 	}
 	rawBundle := bs.Bytes()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		tile := api.EntryBundle{}
 		if err := tile.UnmarshalText(rawBundle); err != nil {
 			b.Fatal(err)

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -159,7 +159,7 @@ func init() {
 // Once a leaf is sequenced, it will be integrated into the tree soon (generally single digit
 // seconds). Until it is integrated and published, clients of the log will not be able to
 // verifiably access this value. Personalities that require blocking until the leaf is integrated
-// can use the IntegrationAwaiter to wrap the call to this method.
+// can use the PublicationAwaiter to wrap the call to this method.
 type AddFn func(ctx context.Context, entry *Entry) IndexFuture
 
 // IndexFuture is the signature of a function which can return an assigned index or error.

--- a/await_test.go
+++ b/await_test.go
@@ -136,7 +136,7 @@ func TestAwait(t *testing.T) {
 				<-time.After(tC.cpDelay)
 				return tC.cpBody, tC.cpErr
 			}
-			awaiter := tessera.NewIntegrationAwaiter(ctx, readCheckpoint, 10*time.Millisecond)
+			awaiter := tessera.NewPublicationAwaiter(ctx, readCheckpoint, 10*time.Millisecond)
 
 			future := func() (tessera.Index, error) {
 				<-time.After(tC.fDelay)
@@ -195,7 +195,7 @@ func TestAwait_multiClient(t *testing.T) {
 		}
 		return n, nil
 	}
-	awaiter := tessera.NewIntegrationAwaiter(ctx, readCheckpoint, 10*time.Millisecond)
+	awaiter := tessera.NewPublicationAwaiter(ctx, readCheckpoint, 10*time.Millisecond)
 
 	wg := sync.WaitGroup{}
 	for i := range 300 {

--- a/await_test.go
+++ b/await_test.go
@@ -183,7 +183,7 @@ func TestAwait_multiClient(t *testing.T) {
 		// Grow the tree every time this is called
 		size += 10
 		// This isn't generating a real log but can be changed if needed
-		hash := sha256.Sum256([]byte(fmt.Sprint(size)))
+		hash := sha256.Sum256(fmt.Append(nil, size))
 		cpRaw := log.Checkpoint{
 			Origin: "example.com/log/testdata",
 			Size:   size,

--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -112,7 +113,7 @@ func main() {
 
 		idx, err := appender.Add(r.Context(), tessera.NewEntry(b))()
 		if err != nil {
-			if tessera.IsPushback(err) {
+			if errors.Is(err, tessera.ErrPushback) {
 				w.Header().Add("Retry-After", "1")
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return

--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -99,7 +100,7 @@ func main() {
 		f := appender.Add(r.Context(), tessera.NewEntry(b))
 		idx, err := f()
 		if err != nil {
-			if tessera.IsPushback(err) {
+			if errors.Is(err, tessera.ErrPushback) {
 				w.Header().Add("Retry-After", "1")
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return

--- a/cmd/examples/posix-oneshot/main.go
+++ b/cmd/examples/posix-oneshot/main.go
@@ -93,8 +93,8 @@ func main() {
 	}
 
 	// We don't want to exit until our entries have been integrated into the tree, so we'll use Tessera's
-	// IntegrationAwaiter to help with that.
-	await := tessera.NewIntegrationAwaiter(ctx, r.ReadCheckpoint, time.Second)
+	// PublicationAwaiter to help with that.
+	await := tessera.NewPublicationAwaiter(ctx, r.ReadCheckpoint, time.Second)
 
 	// Add each of the leaves in order, and store the futures in a slice
 	// that we will check once all leaves are sent to storage.

--- a/dedupe_test.go
+++ b/dedupe_test.go
@@ -85,7 +85,7 @@ func TestDedupe(t *testing.T) {
 func BenchmarkDedupe(b *testing.B) {
 	ctx := context.Background()
 	// Outer loop is for benchmark calibration, inside here is each individual run of the benchmark
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		idx := uint64(1)
 		delegate := func(ctx context.Context, e *Entry) IndexFuture {
 			thisIdx := idx
@@ -100,7 +100,7 @@ func BenchmarkDedupe(b *testing.B) {
 		for leafIndex := range 1024 {
 			wg.Add(1)
 			go func(index int) {
-				_, err := dedupeAdd(ctx, NewEntry([]byte(fmt.Sprintf("leaf with value %d", index%sha256.Size))))()
+				_, err := dedupeAdd(ctx, NewEntry(fmt.Appendf(nil, "leaf with value %d", index%sha256.Size)))()
 				if err != nil {
 					b.Error(err)
 				}

--- a/entry_test.go
+++ b/entry_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestEntryMarshalBundleDelegates(t *testing.T) {
 	const wantIdx = uint64(143)
-	wantBundle := []byte(fmt.Sprintf("Yes %d", wantIdx))
+	wantBundle := fmt.Appendf(nil, "Yes %d", wantIdx)
 
 	e := NewEntry([]byte("this is data"))
 	e.marshalForBundle = func(gotIdx uint64) []byte {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -130,7 +130,7 @@ func TestLiveLogIntegration(t *testing.T) {
 	errG := errgroup.Group{}
 	for i := range *testEntrySize {
 		errG.Go(func() error {
-			index, err := entryWriter.add(ctx, []byte(fmt.Sprintf("%d", i)))
+			index, err := entryWriter.add(ctx, fmt.Appendf(nil, "%d", i))
 			if err != nil {
 				return fmt.Errorf("entryWriter.add(%d): %v", i, err)
 			}
@@ -171,7 +171,7 @@ func TestLiveLogIntegration(t *testing.T) {
 			t.Fatalf("client.GetEntryBundle: %v", err)
 		}
 
-		got, want := entryBundle.Entries[index%layout.EntryBundleWidth], []byte(fmt.Sprintf("%d", data))
+		got, want := entryBundle.Entries[index%layout.EntryBundleWidth], fmt.Appendf(nil, "%d", data)
 		if !bytes.Equal(got, want) {
 			t.Errorf("Entry bundle (index: %d) got %v want %v", index, got, want)
 		}
@@ -185,7 +185,7 @@ func TestLiveLogIntegration(t *testing.T) {
 		if err != nil {
 			t.Errorf("pb.InclusionProof: %v", err)
 		}
-		leafHash := rfc6962.DefaultHasher.HashLeaf([]byte(fmt.Sprint(data)))
+		leafHash := rfc6962.DefaultHasher.HashLeaf(fmt.Append(nil, data))
 		if err := proof.VerifyInclusion(rfc6962.DefaultHasher, index, lst.Latest().Size, leafHash, ip, lst.Latest().Hash); err != nil {
 			t.Errorf("proof.VerifyInclusion: %v", err)
 		}

--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -201,7 +201,7 @@ func newLeafGenerator(startSize uint64, minLeafSize int, dupChance float64) func
 			// coder is to fill in multiple bytes at a time.
 			filler[i] = byte(source.Int())
 		}
-		return []byte(fmt.Sprintf("%x %d", filler, n))
+		return fmt.Appendf(nil, "%x %d", filler, n)
 	}
 
 	sizeLocked := startSize

--- a/internal/hammer/loadtest/analysis_test.go
+++ b/internal/hammer/loadtest/analysis_test.go
@@ -15,15 +15,13 @@
 package loadtest
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
 )
 
 func TestHammerAnalyser_Stats(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var treeSize treeSizeState
 	ha := NewHammerAnalyser(treeSize.getSize)

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -93,7 +93,7 @@ func mustDecodeB64(t *testing.T, encoded string) []byte {
 
 func BenchmarkCheckpointUnsafe(b *testing.B) {
 	cpRaw := []byte("go.sum database tree\n31700353\nqINS1GRFhWHwdkUeqLEoP4yEMkTBBzxBkGwGQlVlVcs=\n\n— sum.golang.org Az3grnmrIUEDFqHzAElIQCPNoRFRAAdFo47fooyWKMHb89k11GJh5zHIfNCOBmwn/C3YI8oW9/C8DJ87F61QqspBYwM=")
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _, _, err := parse.CheckpointUnsafe(cpRaw)
 		if err != nil {
 			b.Error(err)

--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -258,7 +258,7 @@ func (w *witness) update(ctx context.Context, cp []byte, size uint64, fetchProof
 			return nil, fmt.Errorf("witness %q at %q replied with invalid signature: %q\nconstructed note: %q\nerror: %v", w.verifier.Name(), w.url, rb, string(signed), err)
 		} else {
 			w.size = uint64(size)
-			return []byte(fmt.Sprintf("— %s %s\n", n.Sigs[0].Name, n.Sigs[0].Base64)), nil
+			return fmt.Appendf(nil, "— %s %s\n", n.Sigs[0].Name, n.Sigs[0].Base64), nil
 		}
 	case http.StatusConflict:
 		// Two cases here: the first is a situation we can recover from, the second isn't.

--- a/log.go
+++ b/log.go
@@ -18,17 +18,16 @@ import (
 	"errors"
 )
 
-// ErrPushback is returned by underlying storage implementations when there are too many
-// entries with indices assigned but which have not yet been integrated into the tree.
+// ErrPushback is returned by underlying storage implementations when a new entry cannot be accepted
+// due to overload in the system. This could be because there are too many entries with indices assigned
+// but which have not yet been integrated into the tree, or it could be because the antispam mechanism
+// is not able to keep up with recently added entries.
 //
 // Personalities encountering this error should apply back-pressure to the source of new entries
 // in an appropriate manner (e.g. for HTTP services, return a 503 with a Retry-After header).
+//
+// Personalities should check for this error using `errors.Is(e, ErrPushback)`.
 var ErrPushback = errors.New("pushback")
 
-// IsPushback returns true if the provided error is (or wraps) ErrPushback.
-func IsPushback(e error) bool {
-	return errors.Is(e, ErrPushback)
-}
-
 // Driver is the implementation-specific parts of Tessera. No methods are on here as this is not for public use.
-type Driver interface{}
+type Driver any

--- a/storage/aws/aws_test.go
+++ b/storage/aws/aws_test.go
@@ -192,7 +192,7 @@ func TestMySQLSequencerPushback(t *testing.T) {
 			// Now perform the test with a single additional entry to check for pushback
 			entries = []*tessera.Entry{tessera.NewEntry([]byte("additional"))}
 			err = seq.assignEntries(ctx, entries)
-			if gotPushback := tessera.IsPushback(err); gotPushback != test.wantPushback {
+			if gotPushback := errors.Is(err, tessera.ErrPushback); gotPushback != test.wantPushback {
 				t.Fatalf("assignEntries: got pushback %t (%v), want pushback: %t", gotPushback, err, test.wantPushback)
 			} else if !gotPushback && err != nil {
 				t.Fatalf("assignEntries: %v", err)

--- a/storage/aws/aws_test.go
+++ b/storage/aws/aws_test.go
@@ -127,7 +127,7 @@ func TestMySQLSequencerAssignEntries(t *testing.T) {
 	for chunks := range 10 {
 		entries := []*tessera.Entry{}
 		for i := range 10 + chunks {
-			entries = append(entries, tessera.NewEntry([]byte(fmt.Sprintf("item %d/%d", chunks, i))))
+			entries = append(entries, tessera.NewEntry(fmt.Appendf(nil, "item %d/%d", chunks, i)))
 		}
 		if err := seq.assignEntries(ctx, entries); err != nil {
 			t.Fatalf("assignEntries: %v", err)
@@ -183,7 +183,7 @@ func TestMySQLSequencerPushback(t *testing.T) {
 			// Set up the test scenario with the configured number of initial outstanding entries
 			entries := []*tessera.Entry{}
 			for i := range test.initialEntries {
-				entries = append(entries, tessera.NewEntry([]byte(fmt.Sprintf("initial item %d", i))))
+				entries = append(entries, tessera.NewEntry(fmt.Appendf(nil, "initial item %d", i)))
 			}
 			if err := seq.assignEntries(ctx, entries); err != nil {
 				t.Fatalf("initial assignEntries: %v", err)
@@ -220,7 +220,7 @@ func TestMySQLSequencerRoundTrip(t *testing.T) {
 	for chunks := range 10 {
 		entries := []*tessera.Entry{}
 		for range 10 + chunks {
-			e := tessera.NewEntry([]byte(fmt.Sprintf("item %d", seq)))
+			e := tessera.NewEntry(fmt.Appendf(nil, "item %d", seq))
 			entries = append(entries, e)
 			wantEntries = append(wantEntries, storage.SequencedEntry{
 				BundleData: e.MarshalBundleData(uint64(seq)),
@@ -261,7 +261,7 @@ func makeTile(t *testing.T, size uint64) *api.HashTile {
 	t.Helper()
 	r := &api.HashTile{Nodes: make([][]byte, size)}
 	for i := uint64(0); i < size; i++ {
-		h := sha256.Sum256([]byte(fmt.Sprintf("%d", i)))
+		h := sha256.Sum256(fmt.Appendf(nil, "%d", i))
 		r.Nodes[i] = h[:]
 	}
 	return r
@@ -317,7 +317,7 @@ func makeBundle(t *testing.T, idx uint64, size int) []byte {
 		size = layout.EntryBundleWidth
 	}
 	for i := range size {
-		e := tessera.NewEntry([]byte(fmt.Sprintf("%d:%d", idx, i)))
+		e := tessera.NewEntry(fmt.Appendf(nil, "%d:%d", idx, i))
 		if _, err := r.Write(e.MarshalBundleData(uint64(i))); err != nil {
 			t.Fatalf("MarshalBundleEntry: %v", err)
 		}
@@ -410,7 +410,7 @@ func TestPublishCheckpoint(t *testing.T) {
 				},
 				sequencer: s,
 				newCP: func(_ context.Context, size uint64, hash []byte) ([]byte, error) {
-					return []byte(fmt.Sprintf("%d/%x,", size, hash)), nil
+					return fmt.Appendf(nil, "%d/%x,", size, hash), nil
 				},
 			}
 			// Call init so we've got a zero-sized checkpoint to work with.

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -85,7 +85,7 @@ func NewAntispam(ctx context.Context, spannerDB string, opts AntispamOpts) (*Ant
 			"CREATE TABLE IF NOT EXISTS IDSeq (h BYTES(32) NOT NULL, idx INT64 NOT NULL) PRIMARY KEY (h)",
 		},
 		[][]*spanner.Mutation{
-			{spanner.Insert("FollowCoord", []string{"id", "nextIdx"}, []interface{}{0, 0})},
+			{spanner.Insert("FollowCoord", []string{"id", "nextIdx"}, []any{0, 0})},
 		},
 	); err != nil {
 		return nil, fmt.Errorf("failed to create tables: %v", err)
@@ -307,7 +307,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 				{
 					ms := make([]*spanner.Mutation, 0, len(curEntries))
 					for i, e := range curEntries {
-						ms = append(ms, spanner.Insert("IDSeq", []string{"h", "idx"}, []interface{}{e, int64(curIndex + uint64(i))}))
+						ms = append(ms, spanner.Insert("IDSeq", []string{"h", "idx"}, []any{e, int64(curIndex + uint64(i))}))
 					}
 					if err := f.updateIndex(ctx, txn, ms); err != nil {
 						return err
@@ -319,7 +319,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 
 				// Insertion of dupe entries was successful, so update our follow coordination row:
 				m := make([]*spanner.Mutation, 0)
-				m = append(m, spanner.Update("FollowCoord", []string{"id", "nextIdx"}, []interface{}{0, int64(followFrom + numAdded)}))
+				m = append(m, spanner.Update("FollowCoord", []string{"id", "nextIdx"}, []any{0, int64(followFrom + numAdded)}))
 
 				return txn.BufferWrite(m)
 			})

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -682,9 +682,9 @@ func (s *spannerCoordinator) initDB(ctx context.Context, spannerDB string) error
 			"CREATE TABLE IF NOT EXISTS IntCoord (id INT64 NOT NULL, seq INT64 NOT NULL, rootHash BYTES(32)) PRIMARY KEY (id)",
 		},
 		[][]*spanner.Mutation{
-			{spanner.Insert("Tessera", []string{"id", "compatibilityVersion"}, []interface{}{0, SchemaCompatibilityVersion})},
-			{spanner.Insert("SeqCoord", []string{"id", "next"}, []interface{}{0, 0})},
-			{spanner.Insert("IntCoord", []string{"id", "seq", "rootHash"}, []interface{}{0, 0, rfc6962.DefaultHasher.EmptyRoot()})},
+			{spanner.Insert("Tessera", []string{"id", "compatibilityVersion"}, []any{0, SchemaCompatibilityVersion})},
+			{spanner.Insert("SeqCoord", []string{"id", "next"}, []any{0, 0})},
+			{spanner.Insert("IntCoord", []string{"id", "seq", "rootHash"}, []any{0, 0, rfc6962.DefaultHasher.EmptyRoot()})},
 		},
 	)
 }
@@ -772,9 +772,9 @@ func (s *spannerCoordinator) assignEntries(ctx context.Context, entries []*tesse
 		// TODO(al): think about whether aligning bundles to tile boundaries would be a good idea or not.
 		m := []*spanner.Mutation{
 			// Insert our newly sequenced batch of entries into Seq,
-			spanner.Insert("Seq", []string{"id", "seq", "v"}, []interface{}{0, int64(next), data}),
+			spanner.Insert("Seq", []string{"id", "seq", "v"}, []any{0, int64(next), data}),
 			// and update the next-available sequence number row in SeqCoord.
-			spanner.Update("SeqCoord", []string{"id", "next"}, []interface{}{0, int64(next) + int64(num)}),
+			spanner.Update("SeqCoord", []string{"id", "next"}, []any{0, int64(next) + int64(num)}),
 		}
 		if err := txn.BufferWrite(m); err != nil {
 			return fmt.Errorf("failed to apply TX: %v", err)
@@ -863,7 +863,7 @@ func (s *spannerCoordinator) consumeEntries(ctx context.Context, limit uint64, f
 		// consumeFunc was successful, so we can update our coordination row, and delete the row(s) for
 		// the then consumed entries.
 		m := make([]*spanner.Mutation, 0)
-		m = append(m, spanner.Update("IntCoord", []string{"id", "seq", "rootHash"}, []interface{}{0, int64(orderCheck), newRoot}))
+		m = append(m, spanner.Update("IntCoord", []string{"id", "seq", "rootHash"}, []any{0, int64(orderCheck), newRoot}))
 		for _, c := range seqsConsumed {
 			m = append(m, spanner.Delete("Seq", spanner.Key{0, c}))
 		}
@@ -1186,7 +1186,7 @@ func (m *MigrationStorage) buildTree(ctx context.Context, sourceSize uint64) (ui
 
 		// integration was successful, so we can update our coordination row
 		m := make([]*spanner.Mutation, 0)
-		m = append(m, spanner.Update("IntCoord", []string{"id", "seq", "rootHash"}, []interface{}{0, int64(from + added), newRoot}))
+		m = append(m, spanner.Update("IntCoord", []string{"id", "seq", "rootHash"}, []any{0, int64(from + added), newRoot}))
 		return txn.BufferWrite(m)
 	})
 

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -124,7 +124,7 @@ func TestSpannerSequencerPushback(t *testing.T) {
 			// Now perform the test with a single additional entry to check for pushback
 			entries = []*tessera.Entry{tessera.NewEntry([]byte("additional"))}
 			err = seq.assignEntries(ctx, entries)
-			if gotPushback := tessera.IsPushback(err); gotPushback != test.wantPushback {
+			if gotPushback := errors.Is(err, tessera.ErrPushback); gotPushback != test.wantPushback {
 				t.Fatalf("assignEntries: got pushback %t (%v), want pushback: %t", gotPushback, err, test.wantPushback)
 			} else if !gotPushback && err != nil {
 				t.Fatalf("assignEntries: %v", err)

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -64,7 +64,7 @@ func TestSpannerSequencerAssignEntries(t *testing.T) {
 	for chunks := range 10 {
 		entries := []*tessera.Entry{}
 		for i := range 10 + chunks {
-			entries = append(entries, tessera.NewEntry([]byte(fmt.Sprintf("item %d/%d", chunks, i))))
+			entries = append(entries, tessera.NewEntry(fmt.Appendf(nil, "item %d/%d", chunks, i)))
 		}
 		if err := seq.assignEntries(ctx, entries); err != nil {
 			t.Fatalf("assignEntries: %v", err)
@@ -115,7 +115,7 @@ func TestSpannerSequencerPushback(t *testing.T) {
 			// Set up the test scenario with the configured number of initial outstanding entries
 			entries := []*tessera.Entry{}
 			for i := range test.initialEntries {
-				entries = append(entries, tessera.NewEntry([]byte(fmt.Sprintf("initial item %d", i))))
+				entries = append(entries, tessera.NewEntry(fmt.Appendf(nil, "initial item %d", i)))
 			}
 			if err := seq.assignEntries(ctx, entries); err != nil {
 				t.Fatalf("initial assignEntries: %v", err)
@@ -148,7 +148,7 @@ func TestSpannerSequencerRoundTrip(t *testing.T) {
 	for chunks := range 10 {
 		entries := []*tessera.Entry{}
 		for range 10 + chunks {
-			e := tessera.NewEntry([]byte(fmt.Sprintf("item %d", seq)))
+			e := tessera.NewEntry(fmt.Appendf(nil, "item %d", seq))
 			entries = append(entries, e)
 			wantEntries = append(wantEntries, storage.SequencedEntry{
 				BundleData: e.MarshalBundleData(uint64(seq)),
@@ -173,7 +173,7 @@ func TestSpannerSequencerRoundTrip(t *testing.T) {
 			}
 			seenIdx++
 		}
-		return []byte(fmt.Sprintf("root<%d>", seenIdx)), nil
+		return fmt.Appendf(nil, "root<%d>", seenIdx), nil
 	}
 
 	more, err := s.consumeEntries(ctx, 7, f, false)
@@ -216,7 +216,7 @@ func TestCheckDataCompatibility(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			if _, err := s.dbPool.Apply(ctx, []*spanner.Mutation{spanner.InsertOrUpdate("Tessera", []string{"id", "compatibilityVersion"}, []interface{}{0, test.dbV})}); err != nil {
+			if _, err := s.dbPool.Apply(ctx, []*spanner.Mutation{spanner.InsertOrUpdate("Tessera", []string{"id", "compatibilityVersion"}, []any{0, test.dbV})}); err != nil {
 				t.Fatalf("Failed for force schema version to %d: %v", test.dbV, err)
 			}
 
@@ -232,7 +232,7 @@ func makeTile(t *testing.T, size uint64) *api.HashTile {
 	t.Helper()
 	r := &api.HashTile{Nodes: make([][]byte, size)}
 	for i := uint64(0); i < size; i++ {
-		h := sha256.Sum256([]byte(fmt.Sprintf("%d", i)))
+		h := sha256.Sum256(fmt.Appendf(nil, "%d", i))
 		r.Nodes[i] = h[:]
 	}
 	return r
@@ -294,7 +294,7 @@ func makeBundle(t *testing.T, idx uint64, size int) []byte {
 		size = layout.EntryBundleWidth
 	}
 	for i := range size {
-		e := tessera.NewEntry([]byte(fmt.Sprintf("%d:%d", idx, i)))
+		e := tessera.NewEntry(fmt.Appendf(nil, "%d:%d", idx, i))
 		if _, err := r.Write(e.MarshalBundleData(uint64(i))); err != nil {
 			t.Fatalf("MarshalBundleEntry: %v", err)
 		}
@@ -457,7 +457,7 @@ func TestPublishCheckpoint(t *testing.T) {
 				},
 				sequencer: s,
 				newCP: func(_ context.Context, size uint64, hash []byte) ([]byte, error) {
-					return []byte(fmt.Sprintf("%d/%x,", size, hash)), nil
+					return fmt.Appendf(nil, "%d/%x,", size, hash), nil
 				},
 			}
 			// Call init so we've got a zero-sized checkpoint to work with.

--- a/storage/internal/integrate_test.go
+++ b/storage/internal/integrate_test.go
@@ -168,7 +168,7 @@ func BenchmarkIntegrate(b *testing.B) {
 
 	chunkSize := 200
 	seq := uint64(0)
-	for chunk := 0; chunk < b.N; chunk++ {
+	for chunk := 0; b.Loop(); chunk++ {
 		oldSeq := seq
 		c := make([][]byte, chunkSize)
 		for i := range c {

--- a/storage/internal/queue.go
+++ b/storage/internal/queue.go
@@ -64,7 +64,7 @@ func NewQueue(ctx context.Context, maxAge time.Duration, maxSize uint, f FlushFu
 	// a worker goroutine.
 	// This same worker thread will also handle the callbacks to f.
 	work := make(chan []*queueItem, 1)
-	toWork := func(items []interface{}) {
+	toWork := func(items []any) {
 		entries := make([]*queueItem, len(items))
 		for i, t := range items {
 			entries[i] = t.(*queueItem)

--- a/storage/internal/queue_test.go
+++ b/storage/internal/queue_test.go
@@ -77,7 +77,7 @@ func TestQueue(t *testing.T) {
 			adds := make([]tessera.IndexFuture, test.numItems)
 			wantEntries := make([]*tessera.Entry, test.numItems)
 			for i := uint64(0); i < test.numItems; i++ {
-				d := []byte(fmt.Sprintf("item %d", i))
+				d := fmt.Appendf(nil, "item %d", i)
 				wantEntries[i] = tessera.NewEntry(d)
 				adds[i] = q.Add(ctx, wantEntries[i])
 			}

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -178,7 +178,7 @@ func TestGetTile(t *testing.T) {
 	for i := range treeSize {
 		wg.Go(
 			func() error {
-				_, _, err := awaiter.Await(ctx, addFn(ctx, tessera.NewEntry([]byte(fmt.Sprintf("TestGetTile %d", i)))))
+				_, _, err := awaiter.Await(ctx, addFn(ctx, tessera.NewEntry(fmt.Appendf(nil, "TestGetTile %d", i))))
 				if err != nil {
 					return fmt.Errorf("failed to prep test with entry: %v", err)
 				}

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -170,7 +170,7 @@ func TestGetTile(t *testing.T) {
 	ctx := context.Background()
 	addFn, r, _ := newTestMySQLStorage(t, ctx)
 
-	awaiter := tessera.NewIntegrationAwaiter(ctx, r.ReadCheckpoint, 10*time.Millisecond)
+	awaiter := tessera.NewPublicationAwaiter(ctx, r.ReadCheckpoint, 10*time.Millisecond)
 
 	treeSize := 258
 

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -497,7 +497,7 @@ func (s *Storage) ensureVersion(version uint16) error {
 
 	if _, err := s.stat(versionFile); errors.Is(err, os.ErrNotExist) {
 		klog.V(1).Infof("No version file exists, creating")
-		data := []byte(fmt.Sprintf("%d", version))
+		data := fmt.Appendf(nil, "%d", version)
 		if err := s.createExclusive(versionFile, data); err != nil {
 			return fmt.Errorf("failed to create version file: %v", err)
 		}

--- a/witness_test.go
+++ b/witness_test.go
@@ -202,7 +202,7 @@ func BenchmarkWitnessGroupSatisfaction(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if !group.Satisfied(cp) {
 			b.Fatal("Group should have been satisfied!")
 		}


### PR DESCRIPTION
A few bits to clean up as we approach a beta release:
 - Pruned utility method from API
 - Renamed IntegrationAwaiter to PublicationAwaiter
 - Modernized some older go idioms
