### PR TITLE
[POSIX] Drop idempotent writes

### DIFF
--- a/storage/posix/README.md
+++ b/storage/posix/README.md
@@ -32,7 +32,7 @@ The final step in the dance above is atomic according to the POSIX spec, so in p
 of actions we can avoid corrupt or partially written files being part of the tree.
 
 1. Leaves are submitted by the binary built using Tessera via a call the storage's `Add` func.
-1. The storage library batches these entries up, and, after a configurable period of time has elapsed
+1. The storage library batches these entries up in memory, and, after a configurable period of time has elapsed
    or the batch reaches a configurable size threshold, the batch is sequenced and appended to the tree:
    1. An advisory lock is taken on `.state/treeState.lock` file.
       This helps prevent multiple frontends from stepping on each other, but isn't necesary for safety.
@@ -48,6 +48,12 @@ will be updated:
 
 ## Filesystems
 
-This implementation has been somewhat tested on both a local `ext4` filesystem and on a distributed
-[CephFS](https://docs.ceph.com/en/reef/cephfs/) instance on GCP, in both cases with multiple
+This implementation has been somewhat tested on local `ext4` and `ZFS` filesystems, and on a distributed
+[CephFS](https://docs.ceph.com/en/reef/cephfs/) instance on GCP, in all cases with multiple
 personality binaries attempting to add new entries concurrently.
+
+Other POSIX compliant filesystems such as `XFS` _should_ work, but filesystems which do not offer strong
+POSIX compliance (e.g. `s3fs` or `NFS`) are unlikely to result in long term happiness.
+
+If in doubt, tools like https://github.com/saidsay-so/pjdfstest may help in determining whether a given
+filesystem is suitable.


### PR DESCRIPTION
This PR removes support for idempotent writes from the POSIX storage driver implementation.

During normal operation, the only `tlog-tiles` resource which can ever be overwritten is `/checkpoint`; tiles and entry bundle resources are never appended to nor overwritten.

The POSIX driver does *synchronous integration* at the point of queue flush. If there were an error/the binary crashes during this flush/integration process, all flushed `Add` calls contributing to the integration batch will return an error (or, in the case of a crash, will never return), and no new `checkpoint` is created.

Since no knowledge of indices assigned is passed to the caller, nor is any commitment is made to any state updated, any "detritus" left by an errored integration run is both *ephemeral* and *not implied* by any existing `checkpoint`, and therefore can safely be discarded.

Additionally, given that the next flush/integration after an error:
   1. will attempt to re-assign any new leaves to indices immediately after the size of the currently integrated tree, and 
   2. is overwhelmingly unlikely to consist of identical leaves in the same order 
we do not need idempotent writes, but should instead overwrite resources which are not expected to exist given the currently integrated tree size.








