### PR TITLE
Add experimental mirror tool

### DIFF
--- a/cmd/experimental/mirror/internal/mirror.go
+++ b/cmd/experimental/mirror/internal/mirror.go
@@ -1,0 +1,145 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mirror provides support for the infrastructure-specific mirror tools.
+package mirror
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"golang.org/x/sync/errgroup"
+)
+
+// StoreFn is the signature of a function which knows how to store a static resource
+// at the given path.
+type StoreFn func(ctx context.Context, path string, data []byte) error
+
+// Fetcher describes a type which can fetch static resources from a source log, like
+// the .*Fetcher implementations in the client package.
+type Fetcher interface {
+	ReadCheckpoint(ctx context.Context) ([]byte, error)
+	ReadTile(ctx context.Context, l, i uint64, p uint8) ([]byte, error)
+	ReadEntryBundle(_ context.Context, i uint64, p uint8) ([]byte, error)
+}
+
+// Mirror uses the provided Fetcher to pull static tlog-tile resources and checkpoint from
+// a source log, and stores them using the provided StoreFn.
+//
+// The checkpoint will only be stored once all static resources have been successfully mirrored.
+// Errors fetching or storing operations will cause the operation to be retried.
+//
+// Note that this function _only copies the data_; no self-consistency or correctness checking of
+// the copied tiles/entries/checkpoint is undertaken.
+func Mirror(ctx context.Context, src Fetcher, numWorkers uint, store StoreFn) error {
+	sourceCP, err := src.ReadCheckpoint(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch initial source checkpoint: %v", err)
+	}
+	bits := strings.Split(string(sourceCP), "\n")
+	srcSize, err := strconv.ParseUint(bits[1], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid CP size %q: %v", bits[1], err)
+	}
+	log.Printf("Source log size: %d", srcSize)
+
+	totalResources := (srcSize/layout.TileWidth)*2 - 1
+	resourcesFetched := atomic.Uint64{}
+
+	work := make(chan job, numWorkers)
+
+	go func() {
+		defer close(work)
+
+		stride := srcSize / uint64(numWorkers)
+		if r := stride % layout.TileWidth; r != 0 {
+			stride += (layout.TileWidth - r)
+		}
+		log.Printf("Stride: %d", stride)
+
+		for ext, l := srcSize-1, uint64(0); ext > 0; ext, l = uint64(ext>>layout.TileHeight), l+1 {
+			for from := uint64(0); from < ext; {
+				N := min(stride, ext-from)
+				select {
+				case <-ctx.Done():
+					return
+				case work <- job{level: l, from: from, N: N}:
+					log.Printf("Level %d, [%d, %d) ", l, from, from+N)
+				}
+				from = from + N
+			}
+		}
+		log.Println("no more work")
+	}()
+
+	go func() {
+		t := time.NewTicker(time.Second)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				p := float64(resourcesFetched.Load()*100) / float64(totalResources)
+				log.Printf("Progress %d of %d resources (%0.2f)", resourcesFetched.Load(), totalResources, p)
+			}
+		}
+	}()
+
+	g := errgroup.Group{}
+	for i := range numWorkers {
+		g.Go(func() error {
+			for j := range work {
+				log.Printf("Worker %d: working on %s", i, j)
+				for ri := range layout.Range(j.from, j.N, srcSize>>(j.level*layout.TileHeight)) {
+					if err := retry.Do(func() error {
+						d, err := src.ReadTile(ctx, j.level, ri.Index, ri.Partial)
+						if err != nil {
+							log.Println(err.Error())
+							return err
+						}
+						if err := store(ctx, layout.TilePath(j.level, ri.Index, ri.Partial), d); err != nil {
+							return err
+						}
+						resourcesFetched.Add(1)
+						return nil
+					}); err != nil {
+						log.Println(err.Error())
+						return err
+					}
+				}
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("failed to migrate static resources: %v", err)
+	}
+	return store(ctx, layout.CheckpointPath, sourceCP)
+}
+
+type job struct {
+	level   uint64
+	from, N uint64
+}
+
+func (j job) String() string {
+	return fmt.Sprintf("Level: %d, Range: [%d, %d)", j.level, j.from, j.from+j.N)
+}

--- a/cmd/experimental/mirror/posix/main.go
+++ b/cmd/experimental/mirror/posix/main.go
@@ -1,0 +1,80 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mirror/posix is a command-line tool for mirroring a tlog-tiles compliant log
+// into a POSIX filesystem.
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/transparency-dev/trillian-tessera/client"
+	mirror "github.com/transparency-dev/trillian-tessera/cmd/experimental/mirror/internal"
+	"k8s.io/klog/v2"
+)
+
+var (
+	storageDir = flag.String("storage_dir", "", "Root directory to store log data.")
+	sourceURL  = flag.String("source_url", "", "Base URL for the source log.")
+	numWorkers = flag.Uint("num_workers", 30, "Number of migration worker goroutines.")
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+	ctx := context.Background()
+
+	srcURL, err := url.Parse(*sourceURL)
+	if err != nil {
+		klog.Exitf("Invalid --source_url %q: %v", *sourceURL, err)
+	}
+	src, err := client.NewHTTPFetcher(srcURL, nil)
+	if err != nil {
+		klog.Exitf("Failed to create HTTP fetcher: %v", err)
+	}
+
+	if err := mirror.Mirror(ctx, src, *numWorkers, storeFunc(*storageDir)); err != nil {
+		klog.Exitf("Failed to mirror log: %v", err)
+	}
+
+	klog.Exitf("Log mirrored successfully.")
+}
+
+func storeFunc(root string) mirror.StoreFn {
+	return func(ctx context.Context, p string, d []byte) (err error) {
+		fp := filepath.Join(root, p)
+		if err := os.MkdirAll(filepath.Dir(fp), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(fp, d, 0o644); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				if e, err := os.ReadFile(fp); err != nil {
+					return fmt.Errorf("%q already exists, but couldn't read it: %v", fp, err)
+				} else if !bytes.Equal(d, e) {
+					return fmt.Errorf("%q already exists, but contains different data", fp)
+				}
+				return nil
+			}
+			return err
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
This PR adds an experimental `mirror` library and `posix` tool for mirroring `tlog-tiles` compliant logs.

In contrast to the `migration` tooling, this tool makes no attempt to verify the correctness of the source log as it's copied over.

Currently there's no support for resuming a failed mirror operation, nor mirroring any further growth in the source log since the last time it was successfully mirrored.