### PR TITLE
Fix missing wrapped `os.ErrNotExist` for `http.StatusNotFound` case in `HTTPFetcher`

### DIFF
--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -81,7 +81,7 @@ func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 		break
 	case http.StatusNotFound:
 		// Need to return ErrNotExist here, by contract.
-		return nil, fmt.Errorf("get(%q): %v", u.String(), os.ErrNotExist)
+		return nil, fmt.Errorf("get(%q): %w", u.String(), os.ErrNotExist)
 	default:
 		return nil, fmt.Errorf("get(%q): %v", u.String(), r.StatusCode)
 	}


### PR DESCRIPTION
Here is the Go Playground code to show how the existing non-wrapped error does not fit into the contract.
https://go.dev/play/p/WVZ2oLE5Zxm