### PR TITLE
Fix bug in `EntriesPathForLogIndex`

### DIFF
--- a/api/layout/paths.go
+++ b/api/layout/paths.go
@@ -38,7 +38,8 @@ const (
 // The logSize is required so that a partial qualifier can be appended to tiles that
 // would contain fewer than 256 entries.
 func EntriesPathForLogIndex(seq, logSize uint64) string {
-	return EntriesPath(seq/EntryBundleWidth, PartialTileSize(0, seq, logSize))
+	tileIndex := seq / EntryBundleWidth
+	return EntriesPath(tileIndex, PartialTileSize(0, tileIndex, logSize))
 }
 
 // Range returns an iterator over a list of RangeInfo structs which describe the bundles/tiles

--- a/api/layout/paths_test.go
+++ b/api/layout/paths_test.go
@@ -44,6 +44,10 @@ func TestEntriesPathForLogIndex(t *testing.T) {
 			logSize:  512,
 			wantPath: "tile/entries/001",
 		}, {
+			seq:      3,
+			logSize:  257,
+			wantPath: "tile/entries/000",
+		}, {
 			seq:      256,
 			logSize:  257,
 			wantPath: "tile/entries/001.p/1",

--- a/api/layout/tile.go
+++ b/api/layout/tile.go
@@ -25,8 +25,8 @@ const (
 	EntryBundleWidth = TileWidth
 )
 
-// PartialTileSize returns the expected number of leaves in a tile at the given location within
-// a tree of the specified logSize, or 0 if the tile is expected to be fully populated.
+// PartialTileSize returns the expected number of leaves in a tile at the given tile level and index
+// within a tree of the specified logSize, or 0 if the tile is expected to be fully populated.
 func PartialTileSize(level, index, logSize uint64) uint8 {
 	sizeAtLevel := logSize >> (level * TileHeight)
 	fullTiles := sizeAtLevel / TileWidth


### PR DESCRIPTION
I couldn't see any use of this function in `trillian-tessera` nor `static-ct`, so it's unlikely someone has run into it. The hammer doesn't use this function, because it uses `EntriesPath` directly.