### PR TITLE
Add a simple tlog-files fsck tool

### DIFF
--- a/cmd/experimental/fsck/README.md
+++ b/cmd/experimental/fsck/README.md
@@ -1,0 +1,32 @@
+# fsck
+
+`fsck` is a simple tool for verifying the integrity of a [`tlog-tiles`][] log.
+
+It is so-named as a nod towards the 'nix tools which perform a similar job for filesystems.
+Note, however, that this tool is generally applicable for all tlog-tile instances accessible
+via a HTTP, not just those which _happen_ to be backed by a POSIX filesystem.
+
+## Usage
+
+The tool is provided the URL of the log to check, and will attempt to re-derive 
+the claimed root hash from the log's `checkpoint`, as well as the contents of all
+tiles implied by the tree size it contains.
+
+It can be run with the following command:
+
+```bash
+$ go run github.com/transparency-dev/trillian-tessera/cmd/experimental/fsck --storage_url=http://localhost:2024/ 
+I0515 11:53:10.652868  241971 fsck.go:54] Fsck: checkpoint:
+TestTessera
+193446
+3dFT/ML7vbDp84UT+SVR+Y9csuztBzvu5yuZXoV4E+k=
+
+— TestTessera V9zVSATPw3zQN8jQ5hVhDTqQv0IMov4Ax+2xYE0yUNyySVHfX5xxuka0/HiwjaWqI96ux4/5kZsEqLjUFCMnzX/z2AA=
+I0515 11:53:10.652964  241971 fsck.go:60] Fsck: checking log of size 193446
+I0515 11:53:10.653001  241971 stream.go:90] StreamAdaptor: streaming from 0 to 193446
+I0515 11:53:11.297305  241971 fsck.go:118] Successfully fsck'd log with size 193446 and root ddd153fcc2fbbdb0e9f38513f92551f98f5cb2eced073beee72b995e857813e9
+```
+
+Optional flags may be used to control the amount of parallelism used during the process, run the tool with `--help`
+for more details.
+

--- a/cmd/experimental/fsck/README.md
+++ b/cmd/experimental/fsck/README.md
@@ -15,7 +15,7 @@ tiles implied by the tree size it contains.
 It can be run with the following command:
 
 ```bash
-$ go run github.com/transparency-dev/trillian-tessera/cmd/experimental/fsck --storage_url=http://localhost:2024/ 
+$ go run github.com/transparency-dev/trillian-tessera/cmd/experimental/fsck --storage_url=http://localhost:2024/ --public_key=tessera.pub
 I0515 11:53:10.652868  241971 fsck.go:54] Fsck: checkpoint:
 TestTessera
 193446

--- a/cmd/experimental/fsck/main.go
+++ b/cmd/experimental/fsck/main.go
@@ -1,0 +1,64 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// fsck is a command-line tool for checking the integrity of a tlog-tiles based log.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+
+	"github.com/transparency-dev/merkle/rfc6962"
+	"github.com/transparency-dev/trillian-tessera/api"
+	"github.com/transparency-dev/trillian-tessera/client"
+	"github.com/transparency-dev/trillian-tessera/internal/fsck"
+	"k8s.io/klog/v2"
+)
+
+var (
+	storageURL = flag.String("storage_url", "", "Base tlog-tiles URL")
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+	ctx := context.Background()
+	logURL, err := url.Parse(*storageURL)
+	if err != nil {
+		klog.Exitf("Invalid --storage_url %q: %v", *storageURL, err)
+	}
+	src, err := client.NewHTTPFetcher(logURL, nil)
+	if err != nil {
+		klog.Exitf("Failed to create HTTP fetcher: %v", err)
+	}
+	if err := fsck.Check(ctx, src, defaultMerkleLeafHasher); err != nil {
+		klog.Exitf("fsck failed: %v", err)
+	}
+}
+
+// defaultMerkleLeafHasher parses a C2SP tlog-tile bundle and returns the Merkle leaf hashes of each entry it contains.
+func defaultMerkleLeafHasher(bundle []byte) ([][]byte, error) {
+	eb := &api.EntryBundle{}
+	if err := eb.UnmarshalText(bundle); err != nil {
+		return nil, fmt.Errorf("unmarshal: %v", err)
+	}
+	r := make([][]byte, 0, len(eb.Entries))
+	for _, e := range eb.Entries {
+		h := rfc6962.DefaultHasher.HashLeaf(e)
+		r = append(r, h[:])
+	}
+	return r, nil
+}

--- a/cmd/experimental/fsck/main.go
+++ b/cmd/experimental/fsck/main.go
@@ -30,6 +30,7 @@ import (
 
 var (
 	storageURL = flag.String("storage_url", "", "Base tlog-tiles URL")
+	N          = flag.Uint("N", 1, "The number of workers to use when fetching/comparing resources")
 )
 
 func main() {
@@ -44,7 +45,7 @@ func main() {
 	if err != nil {
 		klog.Exitf("Failed to create HTTP fetcher: %v", err)
 	}
-	if err := fsck.Check(ctx, src, defaultMerkleLeafHasher); err != nil {
+	if err := fsck.Check(ctx, src, *N, defaultMerkleLeafHasher); err != nil {
 		klog.Exitf("fsck failed: %v", err)
 	}
 }

--- a/internal/fsck/fsck.go
+++ b/internal/fsck/fsck.go
@@ -1,0 +1,196 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsck
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/transparency-dev/merkle/compact"
+	"github.com/transparency-dev/merkle/rfc6962"
+	"github.com/transparency-dev/trillian-tessera/api"
+	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/internal/parse"
+	"github.com/transparency-dev/trillian-tessera/internal/stream"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/klog/v2"
+)
+
+type Fetcher interface {
+	ReadCheckpoint(ctx context.Context) ([]byte, error)
+	ReadTile(ctx context.Context, l, i uint64, p uint8) ([]byte, error)
+	ReadEntryBundle(ctx context.Context, i uint64, p uint8) ([]byte, error)
+}
+
+func Check(ctx context.Context, f Fetcher, bundleHasher func([]byte) ([][]byte, error)) error {
+	cp, err := f.ReadCheckpoint(ctx)
+	if err != nil {
+		klog.Exitf("fetch initial source checkpoint: %v", err)
+	}
+	klog.V(1).Infof("Fsck: checkpoint:\n%s", cp)
+	// TODO(al): Should really open this with the pubK to verify the checkpoint is well formed.
+	_, logSize, logRoot, err := parse.CheckpointUnsafe(cp)
+	if err != nil {
+		klog.Exitf("Failed to parse checkpoint: %v", err)
+	}
+	klog.Infof("Fsck: checking log of size %d", logSize)
+
+	N := uint(1)
+
+	fTree := fsckTree{
+		fetcher:           f,
+		bundleHasher:      bundleHasher,
+		tree:              (&compact.RangeFactory{Hash: rfc6962.DefaultHasher.HashChildren}).NewEmptyRange(0),
+		sourceSize:        logSize,
+		pendingTiles:      make(map[compact.NodeID]*api.HashTile),
+		expectedResources: make(chan resource, N),
+	}
+
+	getSize := func(_ context.Context) (uint64, error) { return logSize, nil }
+	next, cancel := stream.StreamAdaptor(ctx, N, getSize, f.ReadEntryBundle, 0)
+	defer cancel()
+
+	eg := errgroup.Group{}
+	eg.Go(fTree.compareResources(ctx))
+
+	for {
+		ri, b, err := next()
+		if err != nil {
+			klog.Warningf("next: %v", err)
+			break
+		}
+		if err := fTree.AppendBundle(ri, b); err != nil {
+			klog.Warningf("AppendBundle(%v): %v", ri, err)
+			break
+		}
+		if fTree.tree.End() == logSize {
+			break
+		}
+	}
+	fTree.flushPartialTiles()
+	close(fTree.expectedResources)
+
+	if err := eg.Wait(); err != nil {
+		klog.Exitf("Failed: %v", err)
+	}
+
+	gotRoot, err := fTree.tree.GetRootHash(nil)
+	switch {
+	case err != nil:
+		klog.Exitf("Failed to calculate root: %v", err)
+	case !bytes.Equal(gotRoot, logRoot):
+		klog.Exitf("Calculated root %x, but checkpoint claims %x", gotRoot, logRoot)
+	default:
+		klog.Infof("Successfully fsck'd log with size %d and root %x", logSize, gotRoot)
+	}
+
+	return nil
+}
+
+type resource struct {
+	level, index uint64
+	partial      uint8
+	content      []byte
+}
+
+type fsckTree struct {
+	fetcher      Fetcher
+	bundleHasher func([]byte) ([][]byte, error)
+	tree         *compact.Range
+	sourceSize   uint64
+
+	pendingTiles map[compact.NodeID]*api.HashTile
+
+	expectedResources chan resource
+}
+
+func (f *fsckTree) AppendBundle(ri layout.RangeInfo, data []byte) error {
+	hs, err := f.bundleHasher(data)
+	if err != nil {
+		return err
+	}
+	for i := ri.First; i < ri.First+ri.N; i++ {
+		if err := f.tree.Append(hs[i], f.visit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fsckTree) visit(id compact.NodeID, h []byte) {
+	// We're only storing the lowest level of hash in the tiles, so early-out in other cases.
+	if id.Level%layout.TileHeight != 0 {
+		return
+	}
+	tLevel, tIdx, hIdx := id.Level/layout.TileHeight, id.Index/layout.EntryBundleWidth, id.Index%layout.EntryBundleWidth
+	k := compact.NodeID{Level: tLevel, Index: tIdx}
+	t, ok := f.pendingTiles[k]
+	if !ok {
+		t = &api.HashTile{}
+		f.pendingTiles[k] = t
+	}
+	if hIdx != uint64(len(t.Nodes)) {
+		klog.Exitf("LOGIC ERROR: got tile (l: %d, idx: %d) node index %d, for tile with %d nodes", tLevel, tIdx, hIdx, len(t.Nodes))
+	}
+	t.Nodes = append(t.Nodes, h)
+	// TODO: make this better
+	if len(t.Nodes) == layout.EntryBundleWidth {
+		c, err := t.MarshalText()
+		if err != nil {
+			klog.Exitf("Failed to marshal tile: %v", err)
+		}
+		f.expectedResources <- resource{
+			level:   uint64(tLevel),
+			index:   tIdx,
+			partial: uint8(len(t.Nodes)),
+			content: c,
+		}
+		delete(f.pendingTiles, k)
+	}
+}
+
+func (f *fsckTree) flushPartialTiles() {
+	for k, t := range f.pendingTiles {
+		c, err := t.MarshalText()
+		if err != nil {
+			klog.Exitf("Failed to marshal tile: %v", err)
+		}
+		f.expectedResources <- resource{
+			level:   uint64(k.Level),
+			index:   k.Index,
+			partial: uint8(len(t.Nodes)),
+			content: c,
+		}
+		delete(f.pendingTiles, k)
+	}
+}
+
+func (f *fsckTree) compareResources(ctx context.Context) func() error {
+	return func() error {
+		for r := range f.expectedResources {
+			data, err := f.fetcher.ReadTile(ctx, r.level, r.index, r.partial)
+			if err != nil {
+				return err
+			}
+			p := layout.TilePath(r.level, r.index, r.partial)
+			if !bytes.Equal(data, r.content) {
+				return fmt.Errorf("%s: log has %x expected %x", p, data, r.content)
+			}
+			klog.V(2).Infof("%s ok", p)
+		}
+		return nil
+	}
+}

--- a/internal/stream/otel.go
+++ b/internal/stream/otel.go
@@ -1,0 +1,25 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stream
+
+import (
+	"go.opentelemetry.io/otel"
+)
+
+const name = "github.com/transparency-dev/trillian-tessera/internal/stream"
+
+var (
+	tracer = otel.Tracer(name)
+)

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+// Package stream provides support for streaming contiguous entries from logs.
+package stream
 
 import (
 	"context"

--- a/storage/aws/antispam/aws.go
+++ b/storage/aws/antispam/aws.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	tessera "github.com/transparency-dev/trillian-tessera"
-	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
+	"github.com/transparency-dev/trillian-tessera/internal/stream"
 	"k8s.io/klog/v2"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -256,7 +256,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 
 	t := time.NewTicker(time.Second)
 	var (
-		entryReader *storage.EntryStreamReader[[]byte]
+		entryReader *stream.EntryStreamReader[[]byte]
 		stop        func()
 
 		curEntries [][]byte
@@ -315,7 +315,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 				if entryReader == nil {
 					next, st := lr.StreamEntries(ctx, followFrom)
 					stop = st
-					entryReader = storage.NewEntryStreamReader(next, f.bundleHasher)
+					entryReader = stream.NewEntryStreamReader(next, f.bundleHasher)
 				}
 
 				bs := uint64(f.as.opts.MaxBatchSize)

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -55,6 +55,7 @@ import (
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/internal/stream"
 	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/klog/v2"
@@ -651,7 +652,7 @@ func (lr *logResourceStore) StreamEntries(ctx context.Context, fromEntry uint64)
 	// Reads to S3 should be able to go highly concurrent without issue, but some performance testing should probably be undertaken.
 	// 10 works well for GCP, so start with that as a default.
 	numWorkers := uint(10)
-	return storage.StreamAdaptor(ctx, numWorkers, lr.IntegratedSize, lr.ReadEntryBundle, fromEntry)
+	return stream.StreamAdaptor(ctx, numWorkers, lr.IntegratedSize, lr.ReadEntryBundle, fromEntry)
 }
 
 // get returns the requested object.

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -31,7 +31,7 @@ import (
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
 
 	tessera "github.com/transparency-dev/trillian-tessera"
-	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
+	"github.com/transparency-dev/trillian-tessera/internal/stream"
 	"google.golang.org/grpc/codes"
 	"k8s.io/klog/v2"
 )
@@ -221,7 +221,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 
 	t := time.NewTicker(time.Second)
 	var (
-		entryReader *storage.EntryStreamReader[[]byte]
+		entryReader *stream.EntryStreamReader[[]byte]
 		stop        func()
 
 		curEntries [][]byte
@@ -274,7 +274,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 					span.AddEvent("Start streaming entries")
 					next, st := lr.StreamEntries(ctx, followFrom)
 					stop = st
-					entryReader = storage.NewEntryStreamReader(next, f.bundleHasher)
+					entryReader = stream.NewEntryStreamReader(next, f.bundleHasher)
 				}
 
 				if curIndex == followFrom && curEntries != nil {

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -53,6 +53,7 @@ import (
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
 	"github.com/transparency-dev/trillian-tessera/internal/otel"
+	"github.com/transparency-dev/trillian-tessera/internal/stream"
 	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/googleapi"
@@ -188,7 +189,7 @@ func (lr *LogReader) StreamEntries(ctx context.Context, fromEntry uint64) (next 
 	// TODO(al): Consider making this configurable.
 	// Requests to GCS can go super parallel without too much issue, but even just 10 concurrent requests seems to provide pretty good throughput.
 	numWorkers := uint(10)
-	return storage.StreamAdaptor(ctx, numWorkers, lr.integratedSize, lr.lrs.getEntryBundle, fromEntry)
+	return stream.StreamAdaptor(ctx, numWorkers, lr.integratedSize, lr.lrs.getEntryBundle, fromEntry)
 }
 
 func (s *Storage) Appender(ctx context.Context, opts *tessera.AppendOptions) (*tessera.Appender, tessera.LogReader, error) {

--- a/storage/posix/antispam/badger.go
+++ b/storage/posix/antispam/badger.go
@@ -28,7 +28,7 @@ import (
 	"github.com/dgraph-io/badger/v4"
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/internal/otel"
-	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
+	"github.com/transparency-dev/trillian-tessera/internal/stream"
 	"k8s.io/klog/v2"
 )
 
@@ -213,7 +213,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 
 	t := time.NewTicker(time.Second)
 	var (
-		entryReader *storage.EntryStreamReader[[]byte]
+		entryReader *stream.EntryStreamReader[[]byte]
 		stop        func()
 
 		curEntries [][]byte
@@ -273,7 +273,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 					span.AddEvent("Start streaming entries")
 					next, st := lr.StreamEntries(ctx, followFrom)
 					stop = st
-					entryReader = storage.NewEntryStreamReader(next, f.bundleHasher)
+					entryReader = stream.NewEntryStreamReader(next, f.bundleHasher)
 				}
 
 				if curIndex == followFrom && curEntries != nil {

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -33,6 +33,7 @@ import (
 	tessera "github.com/transparency-dev/trillian-tessera"
 	"github.com/transparency-dev/trillian-tessera/api"
 	"github.com/transparency-dev/trillian-tessera/api/layout"
+	"github.com/transparency-dev/trillian-tessera/internal/stream"
 	storage "github.com/transparency-dev/trillian-tessera/storage/internal"
 	"k8s.io/klog/v2"
 )
@@ -208,7 +209,7 @@ func (l *logResourceStorage) StreamEntries(ctx context.Context, fromEntry uint64
 	// e.g. NVME will likely respond well to some concurrency, HDD less so.
 	// For now, we'll just stick to a safe default.
 	numWorkers := uint(1)
-	return storage.StreamAdaptor(ctx, numWorkers, l.IntegratedSize, l.ReadEntryBundle, fromEntry)
+	return stream.StreamAdaptor(ctx, numWorkers, l.IntegratedSize, l.ReadEntryBundle, fromEntry)
 }
 
 // sequenceBatch writes the entries from the provided batch into the entry bundle files of the log.


### PR DESCRIPTION
This PR adds a simple `fsck` tool for `tlog-tile` compatible logs.

It recalculates the root hash in a `checkpoint` by reading all entry bundles implied by the checkpoint, verifies that all tiles implied by the checkpoint are present and contain the hashes the should, and that the checkpoint's root hash matches the calculated value.