### PR TITLE
Improve hammer performance

### DIFF
--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -131,6 +131,9 @@ func main() {
 		Addr:    *listen,
 		Handler: h2c.NewHandler(http.DefaultServeMux, h2s),
 	}
+	if err := http2.ConfigureServer(h1s, h2s); err != nil {
+		klog.Exitf("http2.ConfigureServer: %v", err)
+	}
 
 	if err := h1s.ListenAndServe(); err != nil {
 		if err := shutdown(ctx); err != nil {

--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -119,6 +119,9 @@ func main() {
 		Addr:    *listen,
 		Handler: h2c.NewHandler(http.DefaultServeMux, h2s),
 	}
+	if err := http2.ConfigureServer(h1s, h2s); err != nil {
+		klog.Exitf("http2.ConfigureServer: %v", err)
+	}
 
 	if err := h1s.ListenAndServe(); err != nil {
 		if err := shutdown(ctx); err != nil {


### PR DESCRIPTION
This PR addresses the connection-reuse issue in the hammer described in #689, and also fixes the `H2C` support in both the hammer and conformance binaries.

The hammer now performs with a much higher throughput, while using ~20 times less CPU.

### Previously
**Throughput:**
```
│TreeSize: 2990087 (Δ 1093qps over 30s)                                                                                                                                                                                                                                                              
```
**CPU usage:**
```
22793 hammer           /home/al...   80 al  207M ⣶⣴⣷⣿⣿ 99.4%
```
**TIME_WAIT:**
```
$ netstat -an | grep TIME_WAIT | wc -l                                                                                                                                                                                                     
53663
```

### Now
**Throughput:**
```
│TreeSize: 2525636 (Δ 2163qps over 30s)                                                                                                                                                                                                                                       
```
**CPU usage:**
```
22284 hammer           /home/al...   16 al  173M ⣀⣀⣀⣀⣀  4.3%
```

**TIME_WAIT:**
```
$ netstat -an | grep TIME_WAIT | wc -l                                                                                                                                                                                                     
0
```

Fixes #689.


