### PR TITLE
Reduce GCS memory footprint

### DIFF
--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -1153,6 +1153,8 @@ func (s *gcsStorage) setObject(ctx context.Context, objName string, data []byte,
 	}
 	w.ContentType = contType
 	w.CacheControl = cacheCtl
+	// Limit the amount of memory used for buffers, see https://pkg.go.dev/cloud.google.com/go/storage#Writer
+	w.ChunkSize = len(data) + 1024
 	if _, err := w.Write(data); err != nil {
 		return fmt.Errorf("failed to write object %q to bucket %q: %w", objName, s.bucket, err)
 	}


### PR DESCRIPTION
This PR significantly reduces the amount of memory used when running on GCP.

Previously, whenever a GCS resource was being created (which happens primarily during integration, with potentially multiple 10s of resources being updated concurrently in logs with high throughput) the GCS client library would allocate 16MB of buffer per object, resulting in a couple of hundred MB of wasted allocation.

With the change, the buffer is reduced to the size of the resource being written plus a small surplus as recommended by the docs.