### PR TITLE
Update observed integration delay more frequently

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -356,7 +356,7 @@ func (i *integrationStats) updateStats(ctx context.Context, r LogReader) {
 		klog.Warning("updateStates: nil logreader provided, not updating stats")
 		return
 	}
-	t := time.NewTicker(time.Second)
+	t := time.NewTicker(100 * time.Millisecond)
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
This PR reduces the interval between checking whether the sampled assigned index has been integrated yet.

Having this interval set too high artificially inflates the metric, which can be misleading for operators.

In the longer-term, it might be better to switch to some sort of event-based implementation for getting some of these metrics.
