### PR TITLE
Add metrics for latency of various POSIX operations

### DIFF
--- a/storage/posix/otel.go
+++ b/storage/posix/otel.go
@@ -32,8 +32,8 @@ var (
 var (
 	posixOpsHistogram metric.Int64Histogram
 
-	// Custom histogram buckets as we're still interested in details in the 1-2s area.
-	histogramBuckets = []float64{0, 10, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000, 2500, 3000, 4000, 5000, 6000, 8000, 10000}
+	// Custom histogram buckets as we're interested in low-millis upto low-seconds.
+	histogramBuckets = []float64{0, 1, 2, 5, 10, 20, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1200, 1400, 1600, 1800, 2000, 2500, 3000, 4000, 5000, 6000, 8000, 10000}
 )
 
 func init() {


### PR DESCRIPTION
This PR adds some lower-level metics related to POSIX operations & latency which will be useful when diagnosing performance issues.

These metrics can be used to build POSIX detail dashboards like this:
<img width="1437" height="1260" alt="image" src="https://github.com/user-attachments/assets/9ab1b096-ae34-4d1f-8e02-d4cbfb30e3c9" />

Towards transparency-dev/tesseract#479
