### PR TITLE
Enable S3 lockfiles

### DIFF
--- a/deployment/live/aws/conformance/terragrunt.hcl
+++ b/deployment/live/aws/conformance/terragrunt.hcl
@@ -30,5 +30,6 @@ remote_state {
     s3_bucket_tags = {
       name = "terraform_state_storage"
     }
+    use_lockfile = true
   }
 }


### PR DESCRIPTION
Towards #740 

Following https://opentofu.org/docs/language/settings/backends/s3/#s3-state-locking. I've already run:

```
terragrunt init -reconfigure --terragrunt-working-dir=deployment/live/aws/conformance/ci
```