### PR TITLE
Hold fd open for directory while making changes within

### DIFF
--- a/storage/posix/file_ops.go
+++ b/storage/posix/file_ops.go
@@ -32,31 +32,45 @@ const (
 	filePerm = 0o644
 )
 
-// syncDir calls fsync on the provided path.
+// syncDir opens the specified directory and calls op before syncing and closing the handle on the directory.
 //
-// This is intended to be used to sync directories in which we've just created new entries.
-func syncDir(d string) error {
-	fd, err := os.Open(d)
+// This dance ensures that the inode of the specified directory cannot be evicted from the kernel inode cache while
+// the operation is underway, and so any error which occurs while updating metadata about a file operation which happens
+// _within_ that directory is detected.
+//
+// This function is intended to be used by the other functions in this file.
+func syncDir(dir string, op func() error) (err error) {
+	fd, err := os.OpenFile(dir, os.O_RDONLY|syscall.O_DIRECTORY, 0)
 	if err != nil {
-		return fmt.Errorf("failed to open %q: %v", d, err)
+		return fmt.Errorf("failed to open %q: %w", dir, err)
+	}
+	defer func() {
+		e := fd.Close()
+		if err == nil {
+			err = e
+		}
+	}()
+
+	if err := op(); err != nil {
+		return err
 	}
 
 	if err := fd.Sync(); err != nil {
-		return fmt.Errorf("failed to sync %q: %v", d, err)
+		return fmt.Errorf("failed to sync %q: %w", dir, err)
 	}
-	return fd.Close()
+	return nil
 }
 
 // mkdirAll is a reimplementation of os.mkdirAll but where we fsync the parent directory/ies
 // we modify.
-func mkdirAll(name string, perm os.FileMode) (err error) {
+func mkdirAll(name string, perm os.FileMode) error {
 	name = strings.TrimSuffix(name, string(filepath.Separator))
 	if name == "" {
 		return nil
 	}
 
 	// Finally, check and create the dir if necessary.
-	dir, _ := filepath.Split(name)
+	dir := filepath.Dir(name)
 	di, err := os.Lstat(name)
 	switch {
 	case errors.Is(err, syscall.ENOENT):
@@ -72,13 +86,14 @@ func mkdirAll(name string, perm os.FileMode) (err error) {
 		// create the final entry in the requested path.
 		fallthrough
 	case errors.Is(err, os.ErrNotExist):
-		// We'll see ErrNotExist if the final entry in the requested path doesn't exist,
-		// so we simply attempt to create it in here.
-		if err := os.Mkdir(name, perm); err != nil {
-			return fmt.Errorf("%q: %v", name, err)
-		}
-		// And be sure to sync the parent directory.
-		return syncDir(dir)
+		return syncDir(dir, func() error {
+			// We'll see ErrNotExist if the final entry in the requested path doesn't exist,
+			// so we simply attempt to create it in here.
+			if err := os.Mkdir(name, perm); err != nil {
+				return fmt.Errorf("%q: %v", name, err)
+			}
+			return nil
+		})
 	case err != nil:
 		return fmt.Errorf("lstat %q: %v", name, err)
 	case !di.IsDir():
@@ -94,47 +109,52 @@ func mkdirAll(name string, perm os.FileMode) (err error) {
 // Returns an error if a file already exists at the specified location, or it's unable to fully write the
 // data & close the file.
 func createEx(name string, d []byte) error {
-	dir, _ := filepath.Split(name)
+	dir := filepath.Dir(name)
 	if err := mkdirAll(dir, dirPerm); err != nil {
-		return fmt.Errorf("failed to make entries directory structure: %w", err)
+		return fmt.Errorf("failed to make directory structure: %w", err)
 	}
-
-	tmpName, err := createTemp(name, d)
-	if err != nil {
-		return fmt.Errorf("failed to create temp file: %v", err)
-	}
-	defer func() {
-		if err := os.Remove(tmpName); err != nil {
-			klog.Warningf("Failed to remove temporary file %q: %v", tmpName, err)
+	return syncDir(dir, func() error {
+		tmpName, err := createTemp(name, d)
+		if err != nil {
+			return fmt.Errorf("failed to create temp file: %v", err)
 		}
-	}()
+		defer func() {
+			if err := os.Remove(tmpName); err != nil {
+				klog.Warningf("Failed to remove temporary file %q: %v", tmpName, err)
+			}
+		}()
 
-	if err := os.Link(tmpName, name); err != nil {
-		// Wrap the error here because we need to know if it's os.ErrExists at higher levels.
-		return fmt.Errorf("failed to link temporary file to target %q: %w", name, err)
-	}
-
-	return syncDir(dir)
+		if err := os.Link(tmpName, name); err != nil {
+			// Wrap the error here because we need to know if it's os.ErrExists at higher levels.
+			return fmt.Errorf("failed to link temporary file to target %q: %w", name, err)
+		}
+		return nil
+	})
 }
 
 // overwrite atomically creates/overwrites a file at the given path containing the provided data, and syncs
 // the directory containing the overwritten/created file.
 func overwrite(name string, d []byte) error {
-	dir, _ := filepath.Split(name)
+	dir := filepath.Dir(name)
 	if err := mkdirAll(dir, dirPerm); err != nil {
-		return fmt.Errorf("failed to make entries directory structure: %w", err)
+		return fmt.Errorf("failed to make directory structure: %w", err)
 	}
+	return syncDir(dir, func() error {
+		dir, _ := filepath.Split(name)
+		if err := mkdirAll(dir, dirPerm); err != nil {
+			return fmt.Errorf("failed to make entries directory structure: %w", err)
+		}
 
-	tmpName, err := createTemp(name, d)
-	if err != nil {
-		return fmt.Errorf("failed to create temp file: %v", err)
-	}
+		tmpName, err := createTemp(name, d)
+		if err != nil {
+			return fmt.Errorf("failed to create temp file: %v", err)
+		}
 
-	if err := os.Rename(tmpName, name); err != nil {
-		return fmt.Errorf("failed to rename temporary file to target %q: %w", name, err)
-	}
-
-	return syncDir(dir)
+		if err := os.Rename(tmpName, name); err != nil {
+			return fmt.Errorf("failed to rename temporary file to target %q: %w", name, err)
+		}
+		return nil
+	})
 }
 
 // createTemp creates a new temporary file in the directory dir, with a name based on the provided prefix,


### PR DESCRIPTION
This PR makes the low-level POSIX file operations more robust by avoiding a situation where, on Linux, an i/o error resulting from a write could potentially be lost.

It's unclear whether this corner-case affects ZFS.

See https://wiki.postgresql.org/wiki/Fsync_Errors#Open_source_kernels for more info.

Addresses #749 

Here's some trimmed down and commented output from `strace` showing the new behaviour via an invocation of the `posix-oneshow` tool:
```bash
$ strace -f -e 'trace=openat,renameat,linkat,fsync,close,read,write' ./posix-oneshot --private_key=tessera.sec --storage_dir=/tessera/test --entries go.*

# Lock tree for update
[pid 1376975] openat(AT_FDCWD, "/tessera/test/.state/treeState.lock", O_RDWR|O_CREAT|O_CLOEXEC, 0644) = 4
...

# Read current state (size == 1)
[pid 1376975] openat(AT_FDCWD, "/tessera/test/.state/treeState", O_RDONLY|O_CLOEXEC) = 7
[pid 1376975] read(7, "{\"size\":1,\"root\":\"W6Z5WsxUC1jA7L"..., 512) = 64
[pid 1376975] read(7, "", 448)          = 0
[pid 1376975] close(7)                  = 0
# Update bundles
## Read right-hand partial bundle
[pid 1376975] openat(AT_FDCWD, "/tessera/test/tile/entries/000.p/1", O_RDONLY|O_CLOEXEC) = 7
[pid 1376975] read(7, "\f\326# How to contribute\n\nWe'd love"..., 3289) = 3288
[pid 1376975] read(7, "", 1)            = 0
[pid 1376975] close(7)                  = 0
## Create new RH partial bundle (createEx)
### syncDir(...)
[pid 1376975] openat(AT_FDCWD, "/tessera/test/tile/entries/000.p", O_RDONLY|O_CLOEXEC|O_DIRECTORY) = 7
###   + createTemp()
[pid 1376975] openat(AT_FDCWD, "/tessera/test/tile/entries/000.p/21191081446", O_WRONLY|O_CREAT|O_EXCL|O_SYNC|O_CLOEXEC, 0644) = 8
[pid 1376975] write(8, "\f\326# How to contribute\n\nWe'd love"..., 9308) = 9308
[pid 1376975] close(8)                  = 0
###   + rename()
[pid 1376975] renameat(AT_FDCWD, "/tessera/test/tile/entries/000.p/21191081446", AT_FDCWD, "/tessera/test/tile/entries/000.p/2") = 0
### syncDir postamble
[pid 1376975] fsync(7)                  = 0
[pid 1376975] close(7)                  = 0

# Update tiles
[pid 1376975] openat(AT_FDCWD, "/tessera/test/tile/0/000.p/1", O_RDONLY|O_CLOEXEC) = 7
## Read RH partial tile
[pid 1376975] read(7, "[\246yZ\314T\vX\300\354\274\24\2\334\333\253\231\341\n\266\337\3109YB\357\227\307~\211\336\357", 512) = 32
[pid 1376975] read(7, "", 480)          = 0
[pid 1376975] close(7)                  = 0
## Create new RH partial tile (createEx)
### syncDir(...) 
[pid 1376975] openat(AT_FDCWD, "/tessera/test/tile/0/000.p", O_RDONLY|O_CLOEXEC|O_DIRECTORY) = 7
###   + createTemp()
[pid 1376975] openat(AT_FDCWD, "/tessera/test/tile/0/000.p/21446951856", O_WRONLY|O_CREAT|O_EXCL|O_SYNC|O_CLOEXEC, 0644) = 8
[pid 1376975] write(8, "[\246yZ\314T\vX\300\354\274\24\2\334\333\253\231\341\n\266\337\3109YB\357\227\307~\211\336\357"..., 64) = 64
[pid 1376975] close(8)                  = 0
###   + rename()
[pid 1376977] renameat(AT_FDCWD, "/tessera/test/tile/0/000.p/21446951856", AT_FDCWD, "/tessera/test/tile/0/000.p/2") = 0
### syncDir postamble
[pid 1376977] fsync(7)                  = 0
[pid 1376977] close(7)                  = 0

# Update tree state to reflect newly integrated entries
## syncDir()
[pid 1376977] openat(AT_FDCWD, "/tessera/test/.state", O_RDONLY|O_CLOEXEC|O_DIRECTORY) = 7
##   + createTemp()
[pid 1376977] openat(AT_FDCWD, "/tessera/test/.state/treeState1376844182", O_WRONLY|O_CREAT|O_EXCL|O_SYNC|O_CLOEXEC, 0644) = 8
[pid 1376977] write(8, "{\"size\":2,\"root\":\"DGLuhM8Bmgt4b4"..., 64) = 64
[pid 1376977] close(8)                  = 0
##   + rename()
[pid 1376977] renameat(AT_FDCWD, "/tessera/test/.state/treeState1376844182", AT_FDCWD, "/tessera/test/.state/treeState") = 0
## syncDir postamble
[pid 1376977] fsync(7 <unfinished ...>
[pid 1376977] <... fsync resumed>)      = 0
[pid 1376977] close(7)                  = 0

# Release lock on tree
[pid 1376977] close(4)                  = 0
```