### PR TITLE
Make posix-oneshot more snappy.

### DIFF
--- a/cmd/examples/posix-oneshot/main.go
+++ b/cmd/examples/posix-oneshot/main.go
@@ -45,7 +45,7 @@ const (
 	// Since this is a short-lived command-line tool, we set this to a relatively low value so that
 	// the tool can publish the new checkpoint and exit relatively quickly after integrating the entries
 	// into the tree.
-	checkpointInterval = time.Second
+	checkpointInterval = 100 * time.Millisecond
 )
 
 // entryInfo binds the actual bytes to be added as a leaf with a
@@ -96,7 +96,7 @@ func main() {
 
 	// We don't want to exit until our entries have been integrated into the tree, so we'll use Tessera's
 	// PublicationAwaiter to help with that.
-	await := tessera.NewPublicationAwaiter(ctx, r.ReadCheckpoint, time.Second)
+	await := tessera.NewPublicationAwaiter(ctx, r.ReadCheckpoint, 100*time.Millisecond)
 
 	// Add each of the leaves in order, and store the futures in a slice
 	// that we will check once all leaves are sent to storage.

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -62,7 +62,7 @@ const (
 	// treeStateLock must be held when integrating entries into the tree or writing to the treeState file.
 	treeStateLock = treeStateFile + ".lock"
 
-	minCheckpointInterval = time.Second
+	minCheckpointInterval = 100 * time.Millisecond
 )
 
 // Storage implements storage functions for a POSIX filesystem.


### PR DESCRIPTION
Reduces the minimum permissible checkpoint interval in the POSIX storage backend. There's no infra-imposed limit for why this should be set to 1s as there is in GCP.