### PR TITLE
Improve one-shot commentary

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,11 @@ Now the fun part - writing to the log!
 The `AppendOptions` allow Tessera behaviour to be tuned.
 Take a look at the methods named `With*` on the `AppendOptions` struct in the root package, e.g. [`WithBatching`](https://pkg.go.dev/github.com/transparency-dev/tessera@main#AppendOptions.WithBatching) to see the available options are how they should be used.
 
+> [!Tip]
+> If you know ahead of time how many entries you want to add (e.g. if you're writing an "off-line" or batch tool,
+> which will process entries and then exit), you can pass that value as a performance hint to Tessera via the
+> _size_ parameter of `WithBatching`.
+ 
 Writing to the log follows this flow:
  1. Call `Add` with a new entry created with the data to be added as a leaf in the log.
     - This method returns a _future_ of the form `func() (Index, error)`.

--- a/cmd/examples/posix-oneshot/main.go
+++ b/cmd/examples/posix-oneshot/main.go
@@ -89,7 +89,12 @@ func main() {
 		WithCheckpointSigner(s).
 		// Hint to Tessera the number of entries we're about to add via the batchSize parameter below,
 		// this will cause the batch to flush as soon as we've called Add on the final entry.
-		WithBatching(batchSize, time.Second)
+		WithBatching(batchSize, 100*time.Millisecond).
+		// We're unlikely to ever wait this long to publish a checkpoint because of the batchSize hint
+		// passed in to the option above, but we set this interval low primarily such that if the user re-runs this
+		// tool to add further entries to the log, they don't have to wait for the previous checkpoint to
+		// become old enough to be overwritten.
+		WithCheckpointInterval(100 * time.Millisecond)
 
 	if *witnessPolicyFile != "" {
 		f, err := os.ReadFile(*witnessPolicyFile)


### PR DESCRIPTION
This PR improves the comments in the `one-shot` binary and adds a tip to the README about tuning for these types of usecase.

It also adds some `V(1)` logging to allow interested parties to see how long each phase of the process takes.