### PR TITLE
aws: Initialize default HTTP client when one isn't provided

### DIFF
--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -175,6 +175,9 @@ func New(ctx context.Context, cfg Config) (tessera.Driver, error) {
 	} else {
 		printDragonsWarning()
 	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = http.DefaultClient
+	}
 
 	return &Storage{
 		cfg: cfg,


### PR DESCRIPTION
The comment mentioned that when unset, Tessera uses the default client, but I noticed this wasn't being set while testing. This mirrors the behavior of the GCP and POSIX storage backends as well.