### PR TITLE
Add max entry size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,9 @@ configured using the [`tessera.NewAppendOptions`](https://pkg.go.dev/github.com/
 
 This is described above in [Constructing the Appender](#constructing-the-appender).
 
+Note that entries are limited to 64KB in size by the [tlog-tiles][] spec, with the exception that when Tessera is configured for use
+with Static CT via the `WithCTLayout` option, entries are then limited to 256KB.
+
 See more details in the [Lifecycle Design: Appender](https://github.com/transparency-dev/tessera/blob/main/docs/design/lifecycle.md#appender).
 
 ### Migration Target

--- a/ct_only.go
+++ b/ct_only.go
@@ -25,6 +25,10 @@ import (
 	"golang.org/x/crypto/cryptobyte"
 )
 
+// ctEntrySizeLimit is the maximum permitted serialized entry size when Tessera is configured for static-ct logs.
+// Note that storage implementations MAY impose a lower limit due to infrastructure limitations.
+const ctEntrySizeLimit = 256 << 10
+
 // NewCertificateTransparencyAppender returns a function which knows how to add a CT-specific entry type to the log.
 //
 // This entry point MUST ONLY be used for CT logs participating in the CT ecosystem.
@@ -60,6 +64,7 @@ func convertCTEntry(e *ctonly.Entry) *Entry {
 func (o *AppendOptions) WithCTLayout() *AppendOptions {
 	o.entriesPath = ctEntriesPath
 	o.bundleIDHasher = ctBundleIDHasher
+	o.maxEntrySize = ctEntrySizeLimit
 	return o
 }
 


### PR DESCRIPTION
This PR adds a check to the Appender lifecycle ensuring that added entries are of an acceptable size.

By default, this is the `tlog-tiles` mandated 64KB, but this limit is raised to 256KB for logs configured with the `WithCTLayout` option.