### PR TITLE
Add opinionated timeouts for periodic storage operations

### DIFF
--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -86,6 +86,13 @@ const (
 	// NOTE: if changing this version, you need to consider whether end-users are going to update their schema instances to be
 	// compatible with the new format, and provide a means to do it if so.
 	SchemaCompatibilityVersion = 1
+
+	// defaultIntegrationTimeout is the default context timeout applied when undertaking an integration task.
+	defaultIntegrationTimeout = 10 * time.Second
+	// defaultPublicationTimeout is the default context timeout applied when undertaking a checkpoint publication task.
+	defaultPublicationTimeout = 5 * time.Second
+	// defaultGCTimeout is the default context timeout applied when undertaking a garbage collection task.
+	defaultGCTimeout = 30 * time.Second
 )
 
 // Storage is an AWS based storage implementation for Tessera.
@@ -277,11 +284,10 @@ func (a *Appender) integrateEntriesJob(ctx context.Context) {
 		}
 
 		if err := otel.TraceErr(ctx, "tessera.storage.aws.integrateEntriesJob", tracer, func(ctx context.Context, span trace.Span) error {
-			// Don't quickloop for now, it causes issues updating checkpoint too frequently.
-			cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-			defer cancel()
+			ctx, cancel := context.WithTimeout(ctx, defaultIntegrationTimeout)
+			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
 
-			if _, err := a.sequencer.consumeEntries(cctx, DefaultIntegrationSizeLimit, a.integrateEntries, false); err != nil {
+			if _, err := a.sequencer.consumeEntries(ctx, DefaultIntegrationSizeLimit, a.integrateEntries, false); err != nil {
 				return err
 			}
 			select {
@@ -309,8 +315,16 @@ func (a *Appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 		case <-a.treeUpdated:
 		case <-t.C:
 		}
-		if err := a.sequencer.publishCheckpoint(ctx, pubInterval, republishInterval, a.updateCheckpoint); err != nil {
-			klog.Warningf("publishCheckpoint: %v", err)
+		if err := otel.TraceErr(ctx, "tessera.storage.aws.publishCheckpointJob", tracer, func(ctx context.Context, span trace.Span) error {
+			ctx, cancel := context.WithTimeout(ctx, defaultPublicationTimeout)
+			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
+
+			if err := a.sequencer.publishCheckpoint(ctx, pubInterval, republishInterval, a.updateCheckpoint); err != nil {
+				return fmt.Errorf("publishCheckpoint failed: %v", err)
+			}
+			return nil
+		}); err != nil {
+			klog.Error(err)
 		}
 	}
 }
@@ -332,6 +346,9 @@ func (a *Appender) garbageCollectorJob(ctx context.Context, i time.Duration) {
 		case <-t.C:
 		}
 		if err := otel.TraceErr(ctx, "tessera.storage.aws.garbageCollectJob", tracer, func(ctx context.Context, span trace.Span) error {
+			ctx, cancel := context.WithTimeout(ctx, defaultGCTimeout)
+			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
+
 			// Figure out the size of the latest published checkpoint - we can't be removing partial tiles implied by
 			// that checkpoint just because we've done an integration and know about a larger (but as yet unpublished)
 			// checkpoint!
@@ -368,9 +385,9 @@ func (a *Appender) init(ctx context.Context) error {
 			// No checkpoint exists, do a forced (possibly empty) integration to create one in a safe
 			// way (calling updateCP directly here would not be safe as it's outside the transactional
 			// framework which prevents the tree from rolling backwards or otherwise forking).
-			cctx, c := context.WithTimeout(ctx, 10*time.Second)
+			ctx, c := context.WithTimeout(ctx, 10*time.Second)
 			defer c()
-			if _, err := a.sequencer.consumeEntries(cctx, DefaultIntegrationSizeLimit, a.integrateEntries, true); err != nil {
+			if _, err := a.sequencer.consumeEntries(ctx, DefaultIntegrationSizeLimit, a.integrateEntries, true); err != nil {
 				return fmt.Errorf("forced integrate: %v", err)
 			}
 			select {

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -95,6 +95,13 @@ const (
 	// NOTE: if changing this version, you need to consider whether end-users are going to update their schema instances to be
 	// compatible with the new format, and provide a means to do it if so.
 	SchemaCompatibilityVersion = 1
+
+	// defaultIntegrationTimeout is the default context timeout applied when undertaking an integration task.
+	defaultIntegrationTimeout = 10 * time.Second
+	// defaultPublicationTimeout is the default context timeout applied when undertaking a checkpoint publication task.
+	defaultPublicationTimeout = 5 * time.Second
+	// defaultGCTimeout is the default context timeout applied when undertaking a garbage collection task.
+	defaultGCTimeout = 30 * time.Second
 )
 
 // Storage is a GCP based storage implementation for Tessera.
@@ -326,11 +333,10 @@ func (a *Appender) integrateEntriesJob(ctx context.Context) {
 		}
 
 		if err := otel.TraceErr(ctx, "tessera.storage.gcp.integrateEntriesJob", tracer, func(ctx context.Context, span trace.Span) error {
-			// Don't quickloop for now, it causes issues updating checkpoint too frequently.
-			cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-			defer cancel()
+			ctx, cancel := context.WithTimeout(ctx, defaultIntegrationTimeout)
+			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
 
-			if _, err := a.sequencer.consumeEntries(cctx, DefaultIntegrationSizeLimit, a.integrateEntries, false); err != nil {
+			if _, err := a.sequencer.consumeEntries(ctx, DefaultIntegrationSizeLimit, a.integrateEntries, false); err != nil {
 				return fmt.Errorf("integrateEntriesJob: %v", err)
 			}
 			select {
@@ -358,8 +364,16 @@ func (a *Appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 		case <-a.cpUpdated:
 		case <-t.C:
 		}
-		if err := a.sequencer.publishCheckpoint(ctx, pubInterval, republishInterval, a.updateCheckpoint); err != nil {
-			klog.Warningf("publishCheckpoint failed: %v", err)
+		if err := otel.TraceErr(ctx, "tessera.storage.gcp.publishCheckpointJob", tracer, func(ctx context.Context, span trace.Span) error {
+			ctx, cancel := context.WithTimeout(ctx, defaultPublicationTimeout)
+			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
+
+			if err := a.sequencer.publishCheckpoint(ctx, pubInterval, republishInterval, a.updateCheckpoint); err != nil {
+				return fmt.Errorf("publishCheckpoint failed: %v", err)
+			}
+			return nil
+		}); err != nil {
+			klog.Error(err)
 		}
 	}
 }
@@ -380,7 +394,10 @@ func (a *Appender) garbageCollectorJob(ctx context.Context, i time.Duration) {
 			return
 		case <-t.C:
 		}
-		if err := otel.TraceErr(ctx, "tessera.storage.gcp.garbageCollectTask", tracer, func(ctx context.Context, span trace.Span) error {
+		if err := otel.TraceErr(ctx, "tessera.storage.gcp.garbageCollectJob", tracer, func(ctx context.Context, span trace.Span) error {
+			ctx, cancel := context.WithTimeout(ctx, defaultGCTimeout)
+			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
+
 			// Figure out the size of the latest published checkpoint - we can't be removing partial tiles implied by
 			// that checkpoint just because we've done an integration and know about a larger (but as yet unpublished)
 			// checkpoint!
@@ -411,9 +428,9 @@ func (a *Appender) init(ctx context.Context) error {
 			// No checkpoint exists, do a forced (possibly empty) integration to create one in a safe
 			// way (setting the checkpoint directly here would not be safe as it's outside the transactional
 			// framework which prevents the tree from rolling backwards or otherwise forking).
-			cctx, c := context.WithTimeout(ctx, 10*time.Second)
+			ctx, c := context.WithTimeout(ctx, defaultIntegrationTimeout)
 			defer c()
-			if _, err := a.sequencer.consumeEntries(cctx, DefaultIntegrationSizeLimit, a.integrateEntries, true); err != nil {
+			if _, err := a.sequencer.consumeEntries(ctx, DefaultIntegrationSizeLimit, a.integrateEntries, true); err != nil {
 				return fmt.Errorf("forced integrate: %v", err)
 			}
 			select {

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -63,6 +63,13 @@ const (
 	treeStateLock = treeStateFile + ".lock"
 
 	minCheckpointInterval = 100 * time.Millisecond
+
+	// defaultIntegrationTimeout is the default context timeout applied when undertaking an integration task.
+	defaultIntegrationTimeout = 10 * time.Second
+	// defaultPublicationTimeout is the default context timeout applied when undertaking a checkpoint publication task.
+	defaultPublicationTimeout = 5 * time.Second
+	// defaultGCTimeout is the default context timeout applied when undertaking a garbage collection task.
+	defaultGCTimeout = 30 * time.Second
 )
 
 // Storage implements storage functions for a POSIX filesystem.
@@ -143,26 +150,37 @@ func (s *Storage) newAppender(ctx context.Context, o *logResourceStorage, opts *
 	if err := a.initialise(ctx); err != nil {
 		return nil, nil, err
 	}
-	a.queue = storage.NewQueue(ctx, opts.BatchMaxAge(), opts.BatchMaxSize(), a.sequenceBatch)
+	a.queue = storage.NewQueue(ctx, opts.BatchMaxAge(), opts.BatchMaxSize(), func(ctx context.Context, entries []*tessera.Entry) error {
+		ctx, cancel := context.WithTimeout(ctx, defaultIntegrationTimeout)
+		defer cancel()
+		return a.sequenceBatch(ctx, entries)
+	})
 
-	go func(ctx context.Context, i time.Duration) {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-a.cpUpdated:
-			case <-time.After(i):
-			}
-			if err := a.publishCheckpoint(ctx, i, opts.CheckpointRepublishInterval()); err != nil {
-				klog.Warningf("publishCheckpoint: %v", err)
-			}
-		}
-	}(ctx, opts.CheckpointInterval())
+	go a.publishCheckpointJob(ctx, opts.CheckpointInterval(), opts.CheckpointRepublishInterval())
 	if i := opts.GarbageCollectionInterval(); i > 0 {
 		go a.garbageCollectorJob(ctx, i)
 	}
 
 	return a, a.logStorage, nil
+}
+
+func (a *appender) publishCheckpointJob(ctx context.Context, pubInterval, republishInterval time.Duration) {
+	t := time.NewTicker(pubInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-a.cpUpdated:
+		case <-t.C:
+		}
+		func() {
+			ctx, cancel := context.WithTimeout(ctx, defaultPublicationTimeout)
+			defer cancel()
+			if err := a.publishCheckpoint(ctx, pubInterval, republishInterval); err != nil {
+				klog.Warningf("publishCheckpoint failed: %v", err)
+			}
+		}()
+	}
 }
 
 // lockFile creates/opens a lock file at the specified path, and flocks it.
@@ -712,19 +730,24 @@ func (a *appender) garbageCollectorJob(ctx context.Context, i time.Duration) {
 		case <-t.C:
 		}
 
-		// Figure out the size of the latest published checkpoint - we can't be removing partial tiles implied by
-		// that checkpoint just because we've done an integration and know about a larger (but as yet unpublished)
-		// checkpoint!
-		pubSize, err := a.publishedSize(ctx)
-		if err != nil {
-			klog.Warningf("GarbageCollect: %v", err)
-			continue
-		}
+		func() {
+			ctx, cancel := context.WithTimeout(ctx, defaultGCTimeout)
+			defer cancel()
 
-		if err := a.s.garbageCollect(ctx, pubSize, maxBundlesPerRun, a.logStorage.entriesPath); err != nil {
-			klog.Warningf("GarbageCollect failed: %v", err)
-			continue
-		}
+			// Figure out the size of the latest published checkpoint - we can't be removing partial tiles implied by
+			// that checkpoint just because we've done an integration and know about a larger (but as yet unpublished)
+			// checkpoint!
+			pubSize, err := a.publishedSize(ctx)
+			if err != nil {
+				klog.Warningf("GarbageCollect: %v", err)
+				return
+			}
+
+			if err := a.s.garbageCollect(ctx, pubSize, maxBundlesPerRun, a.logStorage.entriesPath); err != nil {
+				klog.Warningf("GarbageCollect failed: %v", err)
+				return
+			}
+		}()
 	}
 }
 


### PR DESCRIPTION
This PR adds timeouts for periodic operations in the storage implementations.

This should help applications recover if some transient weirdness happens at the storage infra layer.

Currently, these timeouts are set to opinionated values, but we can consider opening these up to being overridden by users later on.