### PR TITLE
[POSIX] Migrate allows writing checkpoint

### DIFF
--- a/cmd/experimental/migrate/posix/main.go
+++ b/cmd/experimental/migrate/posix/main.go
@@ -22,21 +22,24 @@ import (
 	"flag"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
 	"log/slog"
 
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/api/layout"
 	"github.com/transparency-dev/tessera/client"
 	"github.com/transparency-dev/tessera/storage/posix"
 )
 
 var (
-	storageDir = flag.String("storage_dir", "", "Root directory to store log data.")
-	sourceURL  = flag.String("source_url", "", "Base URL for the source log.")
-	numWorkers = flag.Uint("num_workers", 30, "Number of migration worker goroutines.")
-	slogLevel  = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
+	storageDir     = flag.String("storage_dir", "", "Root directory to store log data.")
+	sourceURL      = flag.String("source_url", "", "Base URL for the source log.")
+	numWorkers     = flag.Uint("num_workers", 30, "Number of migration worker goroutines.")
+	slogLevel      = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
+	saveCheckpoint = flag.Bool("save_checkpoint", false, "Set to true to write the checkpoint used during migration. Useful for mirrors.")
 )
 
 func main() {
@@ -86,5 +89,12 @@ func main() {
 	if err := m.Migrate(context.Background(), *numWorkers, sourceSize, sourceRoot, src.ReadEntryBundle); err != nil {
 		slog.ErrorContext(ctx, "Migrate failed", slog.Any("error", err))
 		os.Exit(1)
+	}
+
+	if *saveCheckpoint {
+		if err := os.WriteFile(filepath.Join(*storageDir, layout.CheckpointPath), sourceCP, 0o644); err != nil {
+			slog.ErrorContext(ctx, "Failed to write checkpoint", slog.Any("error", err))
+			os.Exit(1)
+		}
 	}
 }


### PR DESCRIPTION
This is a pragmatic way to support setting up mirrors (#576) from POSIX logs.
Confirmed this works by cloning SumDB to a POSIX TLogTiles log:

```shell
# Run the proxy
go run github.com/transparency-dev/incubator/tree/main/sumdb/cmd@main \
  --listen=":8089" &

# Migrate the data
go run ./cmd/experimental/migrate/posix \
  --storage_dir ~/log-clones/sumdb \
  --source_url http://localhost:8089/ \
  --save_checkpoint

# Verify it mirrored properly
echo sum.golang.org+033de0ae+Ac4zctda0e5eza+HJyk9SxEdh+s3Ux18htTTAD8OuAn8 > ~/.go.sum.vkey
go run github.com/transparency-dev/tessera/cmd/fsck@main \
  --storage_url file:///${HOME}/log-clones/sumdb/ \
  --public_key ~/.go.sum.vkey \
  --origin "go.sum database tree"
```
