### PR TITLE
Update linter for slog

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,4 +24,4 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.10.1
-          args: --timeout=8m --enable=sloglint
+          args: --timeout=8m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+version: "2"
+
+linters:
+  enable:
+    - depguard
+    - sloglint
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: "k8s.io/klog/v2"
+              desc: "klog is forbidden, use log/slog instead"
+            - pkg: "k8s.io/klog"
+              desc: "klog is forbidden, use log/slog instead"
+    sloglint:
+      attr-only: true
+      context: all

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -380,7 +380,7 @@ func (a *Appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 			}
 			return nil
 		}); err != nil {
-			slog.ErrorContext(ctx, "publishCheckpoint failed", "error", err)
+			slog.ErrorContext(ctx, "publishCheckpoint failed", slog.Any("error", err))
 		}
 	}
 }


### PR DESCRIPTION
This enforces that we always use attributes and context. This turned up a callsite that wasn't using attributes, which is now fixed.

This sets up the linter settings in a proper file, instead of relying on flag-passing. This should give more consistency and configuration options.
