### PR TITLE
Fix ability to sample on periodic tasks

### DIFF
--- a/await.go
+++ b/await.go
@@ -117,7 +117,6 @@ func (a *PublicationAwaiter) pollLoop(ctx context.Context, readCheckpoint func(c
 	)
 	for done := false; !done; {
 		done, _ = otel.Trace(ctx, "tessera.awaiter.pollLoopIteration", tracer, func(ctx context.Context, span trace.Span) (bool, error) {
-			span.SetAttributes(otel.PeriodicKey.Bool(true))
 
 			ctxDone := false
 
@@ -156,6 +155,6 @@ func (a *PublicationAwaiter) pollLoop(ctx context.Context, readCheckpoint func(c
 			a.c.L.Unlock()
 			span.AddEvent("Unlocked")
 			return ctxDone, nil
-		})
+		}, trace.WithAttributes(otel.PeriodicKey.Bool(true)))
 	}
 }

--- a/internal/otel/trace.go
+++ b/internal/otel/trace.go
@@ -22,8 +22,8 @@ import (
 )
 
 // TraceErr executes logic that returns only an error and traces it, recording any errors on the span.
-func TraceErr(ctx context.Context, name string, tracer trace.Tracer, fn func(context.Context, trace.Span) error) error {
-	ctx, span := tracer.Start(ctx, name)
+func TraceErr(ctx context.Context, name string, tracer trace.Tracer, fn func(context.Context, trace.Span) error, sOpts ...trace.SpanStartOption) error {
+	ctx, span := tracer.Start(ctx, name, sOpts...)
 	defer span.End()
 
 	err := fn(ctx, span)
@@ -35,8 +35,8 @@ func TraceErr(ctx context.Context, name string, tracer trace.Tracer, fn func(con
 }
 
 // Trace executes logic that returns (T, error) and traces it, recording any errors on the span.
-func Trace[T any](ctx context.Context, name string, tracer trace.Tracer, fn func(context.Context, trace.Span) (T, error)) (T, error) {
-	ctx, span := tracer.Start(ctx, name)
+func Trace[T any](ctx context.Context, name string, tracer trace.Tracer, fn func(context.Context, trace.Span) (T, error), sOpts ...trace.SpanStartOption) (T, error) {
+	ctx, span := tracer.Start(ctx, name, sOpts...)
 	defer span.End()
 
 	res, err := fn(ctx, span)
@@ -48,8 +48,8 @@ func Trace[T any](ctx context.Context, name string, tracer trace.Tracer, fn func
 }
 
 // Trace2 executes logic that returns (T1, T2, error) and traces it, recording any errors on the span.
-func Trace2[T1, T2 any](ctx context.Context, name string, tracer trace.Tracer, fn func(context.Context, trace.Span) (T1, T2, error)) (T1, T2, error) {
-	ctx, span := tracer.Start(ctx, name)
+func Trace2[T1, T2 any](ctx context.Context, name string, tracer trace.Tracer, fn func(context.Context, trace.Span) (T1, T2, error), sOpts ...trace.SpanStartOption) (T1, T2, error) {
+	ctx, span := tracer.Start(ctx, name, sOpts...)
 	defer span.End()
 
 	res1, res2, err := fn(ctx, span)
@@ -61,8 +61,8 @@ func Trace2[T1, T2 any](ctx context.Context, name string, tracer trace.Tracer, f
 }
 
 // Trace3 executes logic that returns (T1, T2, T3, error) and traces it, recording any errors on the span.
-func Trace3[T1, T2, T3 any](ctx context.Context, name string, tracer trace.Tracer, fn func(context.Context, trace.Span) (T1, T2, T3, error)) (T1, T2, T3, error) {
-	ctx, span := tracer.Start(ctx, name)
+func Trace3[T1, T2, T3 any](ctx context.Context, name string, tracer trace.Tracer, fn func(context.Context, trace.Span) (T1, T2, T3, error), sOpts ...trace.SpanStartOption) (T1, T2, T3, error) {
+	ctx, span := tracer.Start(ctx, name, sOpts...)
 	defer span.End()
 
 	res1, res2, res3, err := fn(ctx, span)
@@ -74,8 +74,8 @@ func Trace3[T1, T2, T3 any](ctx context.Context, name string, tracer trace.Trace
 }
 
 // Trace4 executes logic that returns (T1, T2, T3, T4, error) and traces it, recording any errors on the span.
-func Trace4[T1, T2, T3, T4 any](ctx context.Context, name string, tracer trace.Tracer, fn func(context.Context, trace.Span) (T1, T2, T3, T4, error)) (T1, T2, T3, T4, error) {
-	ctx, span := tracer.Start(ctx, name)
+func Trace4[T1, T2, T3, T4 any](ctx context.Context, name string, tracer trace.Tracer, fn func(context.Context, trace.Span) (T1, T2, T3, T4, error), sOpts ...trace.SpanStartOption) (T1, T2, T3, T4, error) {
+	ctx, span := tracer.Start(ctx, name, sOpts...)
 	defer span.End()
 
 	res1, res2, res3, res4, err := fn(ctx, span)

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -285,8 +285,6 @@ func (a *Appender) integrateEntriesJob(ctx context.Context) {
 		}
 
 		if err := otel.TraceErr(ctx, "tessera.storage.aws.integrateEntriesJob", tracer, func(ctx context.Context, span trace.Span) error {
-			span.SetAttributes(otel.PeriodicKey.Bool(true))
-
 			ctx, cancel := context.WithTimeout(ctx, defaultIntegrationTimeout)
 			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
 
@@ -298,7 +296,7 @@ func (a *Appender) integrateEntriesJob(ctx context.Context) {
 			default:
 			}
 			return nil
-		}); err != nil {
+		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
 			slog.ErrorContext(ctx, "integrateEntries", slog.Any("error", err))
 		}
 	}
@@ -319,8 +317,6 @@ func (a *Appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 		case <-t.C:
 		}
 		if err := otel.TraceErr(ctx, "tessera.storage.aws.publishCheckpointJob", tracer, func(ctx context.Context, span trace.Span) error {
-			span.SetAttributes(otel.PeriodicKey.Bool(true))
-
 			ctx, cancel := context.WithTimeout(ctx, defaultPublicationTimeout)
 			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
 
@@ -328,7 +324,7 @@ func (a *Appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 				return fmt.Errorf("publishCheckpoint failed: %v", err)
 			}
 			return nil
-		}); err != nil {
+		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
 			slog.ErrorContext(ctx, "Failed to execute checkpoint publisher job", slog.Any("error", err))
 		}
 	}
@@ -351,8 +347,6 @@ func (a *Appender) garbageCollectorJob(ctx context.Context, i time.Duration) {
 		case <-t.C:
 		}
 		if err := otel.TraceErr(ctx, "tessera.storage.aws.garbageCollectJob", tracer, func(ctx context.Context, span trace.Span) error {
-			span.SetAttributes(otel.PeriodicKey.Bool(true))
-
 			ctx, cancel := context.WithTimeout(ctx, defaultGCTimeout)
 			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
 
@@ -372,7 +366,7 @@ func (a *Appender) garbageCollectorJob(ctx context.Context, i time.Duration) {
 				return fmt.Errorf("garbageCollect failed: %v", err)
 			}
 			return nil
-		}); err != nil {
+		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
 			slog.WarnContext(ctx, "Failed to execute garbage Collector job", slog.Any("error", err))
 		}
 	}
@@ -1043,76 +1037,80 @@ func (s *mySQLSequencer) initDB(ctx context.Context) error {
 // This is achieved by storing the passed-in entries in the Seq table in MySQL, keyed by the
 // index assigned to the first entry in the batch.
 func (s *mySQLSequencer) assignEntries(ctx context.Context, entries []*tessera.Entry) error {
-	// First grab the treeSize in a non-locking read-only fashion (we don't want to block/collide with integration).
-	// We'll use this value to determine whether we need to apply back-pressure.
-	var treeSize uint64
-	row := s.dbPool.QueryRowContext(ctx, "SELECT seq FROM IntCoord WHERE id = ?", 0)
-	if err := row.Scan(&treeSize); err == sql.ErrNoRows {
-		return nil
-	} else if err != nil {
-		return fmt.Errorf("failed to read integration coordination info: %v", err)
-	}
+	return otel.TraceErr(ctx, "tessera.storage.gcp.assignEntries", tracer, func(ctx context.Context, span trace.Span) error {
+		span.SetAttributes(numEntriesKey.Int(len(entries)))
+		// First grab the treeSize in a non-locking read-only fashion (we don't want to block/collide with integration).
+		// We'll use this value to determine whether we need to apply back-pressure.
+		var treeSize uint64
+		row := s.dbPool.QueryRowContext(ctx, "SELECT seq FROM IntCoord WHERE id = ?", 0)
+		if err := row.Scan(&treeSize); err == sql.ErrNoRows {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("failed to read integration coordination info: %v", err)
+		}
 
-	// Now move on with sequencing in a single transaction
-	tx, err := s.dbPool.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin Tx: %v", err)
-	}
-	defer func() {
-		if tx != nil {
-			if err := tx.Rollback(); err != nil {
-				slog.ErrorContext(ctx, "failed to rollback Tx", slog.Any("error", err))
+		// Now move on with sequencing in a single transaction
+		tx, err := s.dbPool.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin Tx: %v", err)
+		}
+		defer func() {
+			if tx != nil {
+				if err := tx.Rollback(); err != nil {
+					slog.ErrorContext(ctx, "failed to rollback Tx", slog.Any("error", err))
+				}
+			}
+		}()
+
+		// First we need to grab the next available sequence number from the SeqCoord table.
+		var next, id uint64
+		r := tx.QueryRowContext(ctx, "SELECT id, next FROM SeqCoord WHERE id = ? FOR UPDATE", 0)
+		if err := r.Scan(&id, &next); err != nil {
+			return fmt.Errorf("failed to read seqcoord: %v", err)
+		}
+
+		// Check whether there are too many outstanding entries and we should apply
+		// back-pressure.
+		if outstanding := next - treeSize; outstanding > s.maxOutstanding {
+			return tessera.ErrPushbackIntegration
+		}
+
+		sequencedEntries := make([]storage.SequencedEntry, len(entries))
+		// Assign provisional sequence numbers to entries.
+		// We need to do this here in order to support serialisations which include the log position.
+		for i, e := range entries {
+			sequencedEntries[i] = storage.SequencedEntry{
+				BundleData: e.MarshalBundleData(next + uint64(i)),
+				LeafHash:   e.LeafHash(),
 			}
 		}
-	}()
 
-	// First we need to grab the next available sequence number from the SeqCoord table.
-	var next, id uint64
-	r := tx.QueryRowContext(ctx, "SELECT id, next FROM SeqCoord WHERE id = ? FOR UPDATE", 0)
-	if err := r.Scan(&id, &next); err != nil {
-		return fmt.Errorf("failed to read seqcoord: %v", err)
-	}
-
-	// Check whether there are too many outstanding entries and we should apply
-	// back-pressure.
-	if outstanding := next - treeSize; outstanding > s.maxOutstanding {
-		return tessera.ErrPushbackIntegration
-	}
-
-	sequencedEntries := make([]storage.SequencedEntry, len(entries))
-	// Assign provisional sequence numbers to entries.
-	// We need to do this here in order to support serialisations which include the log position.
-	for i, e := range entries {
-		sequencedEntries[i] = storage.SequencedEntry{
-			BundleData: e.MarshalBundleData(next + uint64(i)),
-			LeafHash:   e.LeafHash(),
+		// Flatten the entries into a single slice of bytes which we can store in the Seq.v column.
+		b := &bytes.Buffer{}
+		e := gob.NewEncoder(b)
+		if err := e.Encode(sequencedEntries); err != nil {
+			return fmt.Errorf("failed to serialise batch: %v", err)
 		}
-	}
+		data := b.Bytes()
+		num := uint64(len(entries))
 
-	// Flatten the entries into a single slice of bytes which we can store in the Seq.v column.
-	b := &bytes.Buffer{}
-	e := gob.NewEncoder(b)
-	if err := e.Encode(sequencedEntries); err != nil {
-		return fmt.Errorf("failed to serialise batch: %v", err)
-	}
-	data := b.Bytes()
-	num := uint64(len(entries))
+		// Insert our newly sequenced batch of entries into Seq,
+		if _, err := tx.ExecContext(ctx, "INSERT INTO Seq(id, seq, v) VALUES(?, ?, ?)", 0, next, data); err != nil {
+			return fmt.Errorf("insert into seq: %v", err)
+		}
+		// and update the next-available sequence number row in SeqCoord.
+		if _, err := tx.ExecContext(ctx, "UPDATE SeqCoord SET next = ? WHERE ID = ?", next+num, 0); err != nil {
+			return fmt.Errorf("update seqcoord: %v", err)
+		}
 
-	// Insert our newly sequenced batch of entries into Seq,
-	if _, err := tx.ExecContext(ctx, "INSERT INTO Seq(id, seq, v) VALUES(?, ?, ?)", 0, next, data); err != nil {
-		return fmt.Errorf("insert into seq: %v", err)
-	}
-	// and update the next-available sequence number row in SeqCoord.
-	if _, err := tx.ExecContext(ctx, "UPDATE SeqCoord SET next = ? WHERE ID = ?", next+num, 0); err != nil {
-		return fmt.Errorf("update seqcoord: %v", err)
-	}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit Tx: %v", err)
+		}
+		tx = nil
 
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit Tx: %v", err)
-	}
-	tx = nil
+		return nil
 
-	return nil
+	}, trace.WithAttributes(otel.PeriodicKey.Bool(true)))
 }
 
 // consumeEntries calls f with previously sequenced entries.

--- a/storage/aws/otel.go
+++ b/storage/aws/otel.go
@@ -33,6 +33,7 @@ var (
 
 var (
 	errorTypeKey  = attribute.Key("error.type")
+	numEntriesKey = attribute.Key("tessera.numEntries")
 	objectPathKey = attribute.Key("tessera.objectPath")
 	opNameKey     = attribute.Key("op_name")
 

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -333,8 +333,6 @@ func (a *Appender) integrateEntriesJob(ctx context.Context) {
 		}
 
 		if err := otel.TraceErr(ctx, "tessera.storage.gcp.integrateEntriesJob", tracer, func(ctx context.Context, span trace.Span) error {
-			span.SetAttributes(otel.PeriodicKey.Bool(true))
-
 			ctx, cancel := context.WithTimeout(ctx, defaultIntegrationTimeout)
 			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
 
@@ -349,7 +347,7 @@ func (a *Appender) integrateEntriesJob(ctx context.Context) {
 				}
 			}
 			return nil
-		}); err != nil {
+		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
 			slog.ErrorContext(ctx, "integrateEntriesJob failed", slog.Any("error", err))
 		}
 	}
@@ -370,7 +368,6 @@ func (a *Appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 		case <-t.C:
 		}
 		if err := otel.TraceErr(ctx, "tessera.storage.gcp.publishCheckpointJob", tracer, func(ctx context.Context, span trace.Span) error {
-			span.SetAttributes(otel.PeriodicKey.Bool(true))
 
 			ctx, cancel := context.WithTimeout(ctx, defaultPublicationTimeout)
 			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
@@ -379,7 +376,7 @@ func (a *Appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 				return fmt.Errorf("publishCheckpoint failed: %v", err)
 			}
 			return nil
-		}); err != nil {
+		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
 			slog.ErrorContext(ctx, "publishCheckpoint failed", slog.Any("error", err))
 		}
 	}
@@ -402,8 +399,6 @@ func (a *Appender) garbageCollectorJob(ctx context.Context, i time.Duration) {
 		case <-t.C:
 		}
 		if err := otel.TraceErr(ctx, "tessera.storage.gcp.garbageCollectJob", tracer, func(ctx context.Context, span trace.Span) error {
-			span.SetAttributes(otel.PeriodicKey.Bool(true))
-
 			ctx, cancel := context.WithTimeout(ctx, defaultGCTimeout)
 			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
 
@@ -423,7 +418,7 @@ func (a *Appender) garbageCollectorJob(ctx context.Context, i time.Duration) {
 				return fmt.Errorf("garbageCollect failed: %v", err)
 			}
 			return nil
-		}); err != nil {
+		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
 			slog.WarnContext(ctx, "garbageCollectTask failed", slog.Any("error", err))
 		}
 	}
@@ -822,7 +817,6 @@ func (s *spannerCoordinator) checkDataCompatibility(ctx context.Context) error {
 // index assigned to the first entry in the batch.
 func (s *spannerCoordinator) assignEntries(ctx context.Context, entries []*tessera.Entry) error {
 	return otel.TraceErr(ctx, "tessera.storage.gcp.assignEntries", tracer, func(ctx context.Context, span trace.Span) error {
-		span.SetAttributes(otel.PeriodicKey.Bool(true))
 		span.SetAttributes(numEntriesKey.Int(len(entries)))
 
 		span.AddEvent("Reading IntCoord:seq")
@@ -919,7 +913,7 @@ func (s *spannerCoordinator) assignEntries(ctx context.Context, entries []*tesse
 		}
 
 		return nil
-	})
+		}, trace.WithAttributes(otel.PeriodicKey.Bool(true)))
 }
 
 // addSeqMutation returns a mutation to the Seq table for the given sequence number and entries.


### PR DESCRIPTION
This makes it possible to sample periodic traces again.

Samplers are invoked at Span creation time, so only attributes (etc.) provided when the span is created are available for Samplers to make their decisions. This change makes it possible to pass through `trace.*` options when creating traces using the new helper funcs.