### PR TITLE
[PublicationAwaiter] Don't fail awaiting on a single error

### DIFF
--- a/await.go
+++ b/await.go
@@ -101,10 +101,8 @@ func (a *PublicationAwaiter) Await(ctx context.Context, future IndexFuture) (Ind
 				if errorObserved {
 					return i, a.checkpoint, a.err // Second consecutive error
 				}
-				errorObserved = true
-			} else {
-				errorObserved = false
-			}
+            }
+			errorObserved = a.err != nil
 			a.c.Wait()
 		}
 


### PR DESCRIPTION
This changes the Await loop so that it no longer fails on a single transient error when fetching/parsing the checkpoint. For now this is set to fail on two consecutive errors, but perhaps this should be changed to keep trying until the context is cancelled for maximum stickiness. For now, this seems like a pragmatic compromise between these worlds.

This is important because it will make the write path for logs more likely to return happy status codes if there are intermittent problems reading checkpoint storage.
