### PR TITLE
Improve checkpoint publication scheduling

### DIFF
--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -128,7 +128,7 @@ type sequencer interface {
 	nextIndex(ctx context.Context) (uint64, error)
 
 	// publishCheckpoint coordinates the publication of new checkpoints based on the current integrated tree.
-	publishCheckpoint(ctx context.Context, minStaleActive, minStaleRepub time.Duration, f func(ctx context.Context, size uint64, root []byte) error) error
+	publishCheckpoint(ctx context.Context, minStaleActive, minStaleRepub time.Duration, f func(ctx context.Context, size uint64, root []byte) error) (time.Time, error)
 
 	// garbageCollect coordinates the removal of unneeded partial tiles/entry bundles for the provided tree size, up to a maximum number of deletes per invocation.
 	garbageCollect(ctx context.Context, treeSize uint64, maxDeletes uint, removePrefix func(ctx context.Context, prefix string) error, entriesPath func(uint64, uint8) string) error
@@ -332,11 +332,19 @@ func (a *Appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 			ctx, cancel := context.WithTimeout(ctx, defaultPublicationTimeout)
 			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
 
-			if err := a.sequencer.publishCheckpoint(ctx, pubInterval, republishInterval, a.updateCheckpoint); err != nil {
+			publishedAt, err := a.sequencer.publishCheckpoint(ctx, pubInterval, republishInterval, a.updateCheckpoint)
+			if err != nil {
 				return fmt.Errorf("publishCheckpoint failed: %v", err)
+			}
+			nextPublication := pubInterval - time.Since(publishedAt)
+			if nextPublication <= 0 {
+				t.Reset(time.Millisecond) // Schedule a checkpoint update immediately.
+			} else {
+				t.Reset(nextPublication)
 			}
 			return nil
 		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
+			t.Reset(pubInterval)
 			slog.ErrorContext(ctx, "Failed to execute checkpoint publisher job", slog.Any("error", err))
 		}
 	}
@@ -1250,9 +1258,11 @@ func (s *mySQLSequencer) nextIndex(ctx context.Context) (uint64, error) {
 // publishCheckpoint checks when the last checkpoint was published, and if it was more than minAge ago, calls the provided
 // function to publish a new one.
 //
+// Returns the time at which the checkpoint is published, or was last published.
+//
 // This function uses PubCoord with an exclusive lock to guarantee that only one tessera instance can attempt to publish
 // a checkpoint at any given time.
-func (s *mySQLSequencer) publishCheckpoint(ctx context.Context, minStaleActive, minStaleRepub time.Duration, f func(context.Context, uint64, []byte) error) (errR error) {
+func (s *mySQLSequencer) publishCheckpoint(ctx context.Context, minStaleActive, minStaleRepub time.Duration, f func(context.Context, uint64, []byte) error) (publishedAt time.Time, errR error) {
 	start := time.Now()
 	defer func() {
 		// Detect any errors and update metrics accordingly.
@@ -1264,7 +1274,7 @@ func (s *mySQLSequencer) publishCheckpoint(ctx context.Context, minStaleActive, 
 
 	tx, err := s.dbPool.Begin()
 	if err != nil {
-		return err
+		return time.Time{}, err
 	}
 	defer func() {
 		if tx != nil {
@@ -1276,20 +1286,20 @@ func (s *mySQLSequencer) publishCheckpoint(ctx context.Context, minStaleActive, 
 	var pubAt int64
 	var lastSize sql.NullInt64
 	if err := pRow.Scan(&pubAt, &lastSize); err != nil {
-		return fmt.Errorf("failed to parse PubCoord: %v", err)
+		return time.Time{}, fmt.Errorf("failed to parse PubCoord: %v", err)
 	}
 	cpAge := time.Since(time.Unix(pubAt, 0))
 	if cpAge < minStaleActive {
 		slog.DebugContext(ctx, "publishCheckpoint: last checkpoint published too recently, not publishing new checkpoint", slog.Duration("age", cpAge), slog.Duration("minstaleactive", minStaleActive))
 		publishCount.Add(ctx, 1, metric.WithAttributes(errorTypeKey.String("skipped")))
-		return nil
+		return time.Unix(pubAt, 0), nil
 	}
 
 	row := tx.QueryRowContext(ctx, "SELECT seq, rootHash FROM IntCoord WHERE id = ?", 0)
 	var fromSeq uint64
 	var rootHash []byte
 	if err := row.Scan(&fromSeq, &rootHash); err != nil {
-		return fmt.Errorf("failed to read IntCoord: %v", err)
+		return time.Time{}, fmt.Errorf("failed to read IntCoord: %v", err)
 	}
 
 	currentSize := fromSeq
@@ -1307,26 +1317,27 @@ func (s *mySQLSequencer) publishCheckpoint(ctx context.Context, minStaleActive, 
 	if !shouldPublish {
 		slog.DebugContext(ctx, "publishCheckpoint: skipping publish because tree hasn't grown and previous checkpoint is too recent")
 		publishCount.Add(ctx, 1, metric.WithAttributes(errorTypeKey.String("skipped_no_growth")))
-		return nil
+		return time.Unix(pubAt, 0), nil
 	}
 
 	slog.DebugContext(ctx, "publishCheckpoint: updating checkpoint (replacing old checkpoint)", slog.Duration("age", cpAge))
 
 	if err := f(ctx, fromSeq, rootHash); err != nil {
-		return err
+		return time.Time{}, err
 	}
 
-	if _, err := tx.ExecContext(ctx, "UPDATE PubCoord SET publishedAt=?, size=? WHERE id=?", time.Now().Unix(), currentSize, 0); err != nil {
-		return err
+	publishedAt = time.Now()
+	if _, err := tx.ExecContext(ctx, "UPDATE PubCoord SET publishedAt=?, size=? WHERE id=?", publishedAt.Unix(), currentSize, 0); err != nil {
+		return time.Time{}, err
 	}
 	if err := tx.Commit(); err != nil {
-		return err
+		return time.Time{}, err
 	}
 	opsHistogram.Record(ctx, time.Since(start).Milliseconds(), metric.WithAttributes(opNameKey.String("publishCheckpoint")))
 	publishCount.Add(ctx, 1)
 	tx = nil
 
-	return nil
+	return publishedAt, nil
 }
 
 // garbageCollect will identify up to maxBundles unneeded partial entry bundles (and any unneeded partial tiles which sit above them in the tree) and

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -336,12 +336,8 @@ func (a *Appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 			if err != nil {
 				return fmt.Errorf("publishCheckpoint failed: %v", err)
 			}
-			nextPublication := pubInterval - time.Since(publishedAt)
-			if nextPublication <= 0 {
-				t.Reset(time.Millisecond) // Schedule a checkpoint update immediately.
-			} else {
-				t.Reset(nextPublication)
-			}
+			// Schedule a checkpoint update immediately, if an updated is due.
+			t.Reset(max(time.Millisecond, pubInterval-time.Since(publishedAt)))
 			return nil
 		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
 			t.Reset(pubInterval)

--- a/storage/aws/aws_test.go
+++ b/storage/aws/aws_test.go
@@ -439,7 +439,7 @@ func TestPublishTree(t *testing.T) {
 			if err := storage.init(ctx); err != nil {
 				t.Fatalf("storage.init: %v", err)
 			}
-			if err := s.publishCheckpoint(ctx, test.publishInterval, test.republishInterval, storage.updateCheckpoint); err != nil {
+			if _, err := s.publishCheckpoint(ctx, test.publishInterval, test.republishInterval, storage.updateCheckpoint); err != nil {
 				t.Fatalf("publishTree: %v", err)
 			}
 			cpOld := []byte("bananas")
@@ -449,7 +449,7 @@ func TestPublishTree(t *testing.T) {
 			updatesSeen := 0
 			for _, d := range test.attempts {
 				time.Sleep(d)
-				if err := s.publishCheckpoint(ctx, test.publishInterval, test.republishInterval, storage.updateCheckpoint); err != nil {
+				if _, err := s.publishCheckpoint(ctx, test.publishInterval, test.republishInterval, storage.updateCheckpoint); err != nil {
 					t.Fatalf("publishTree: %v", err)
 				}
 				cpNew, err := m.getObject(ctx, layout.CheckpointPath)

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -75,7 +75,7 @@ const (
 	// GCS has a rate limit 1 update per second for individual objects, but we've observed that attempting
 	// to update at exactly that rate still results in the occasional refusal, so bake in a little wiggle
 	// room.
-	minCheckpointInterval = 1200 * time.Millisecond
+	minCheckpointInterval = 1100 * time.Millisecond
 
 	logContType      = "application/octet-stream"
 	ckptContType     = "text/plain; charset=utf-8"

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -388,12 +388,8 @@ func (a *Appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 			if err != nil {
 				return fmt.Errorf("publishCheckpoint failed: %v", err)
 			}
-			nextPublication := pubInterval - time.Since(publishedAt)
-			if nextPublication <= 0 {
-				t.Reset(time.Millisecond) // Schedule a checkpoint update immediately.
-			} else {
-				t.Reset(nextPublication)
-			}
+			// Schedule a checkpoint update immediately, if an updated is due.
+			t.Reset(max(time.Millisecond, pubInterval-time.Since(publishedAt)))
 			return nil
 		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
 			t.Reset(pubInterval)
@@ -1104,16 +1100,16 @@ func (s *spannerCoordinator) nextIndex(ctx context.Context) (uint64, error) {
 // This function uses PubCoord with an exclusive lock to guarantee that only one tessera instance can attempt to publish
 // a checkpoint at any given time.
 func (s *spannerCoordinator) publishCheckpoint(ctx context.Context, minStaleActive, minStaleRepub time.Duration, f func(context.Context, uint64, []byte) error) (time.Time, error) {
-	var pubAt time.Time
-	currentSize, rootHash, err := s.currentTree(ctx)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to get current tree: %v", err)
-	}
-
-	if err := otel.TraceErr(ctx, "tessera.storage.gcp.publishCheckpoint", tracer, func(ctx context.Context, span trace.Span) error {
+	return otel.Trace(ctx, "tessera.storage.gcp.publishCheckpoint", tracer, func(ctx context.Context, span trace.Span) (time.Time, error) {
 		// outcomeAttr records the outcome of the checkpoint publication attempt for metrics and traces.
 		var outcomeAttr attribute.KeyValue
+		var pubAt time.Time
 		start := time.Now()
+
+		currentSize, rootHash, err := s.currentTree(ctx)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("failed to get current tree: %v", err)
+		}
 
 		span.AddEvent("Starting ReadWriteTransaction")
 		if _, err := s.dbPool.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
@@ -1175,17 +1171,13 @@ func (s *spannerCoordinator) publishCheckpoint(ctx context.Context, minStaleActi
 		}, spanner.TransactionOptions{TransactionTag: "tessera.op=publishCheckpoint"}); err != nil {
 			span.SetAttributes(outcomeTypeKey.String("error"))
 			publishCount.Add(ctx, 1, metric.WithAttributes(outcomeTypeKey.String("error")))
-			return err
+			return time.Time{}, err
 		}
 		opsHistogram.Record(ctx, time.Since(start).Milliseconds(), metric.WithAttributes(opNameKey.String("publishCheckpoint")))
 		span.SetAttributes(outcomeAttr)
 		publishCount.Add(ctx, 1, metric.WithAttributes(outcomeAttr))
-		return nil
-	}); err != nil {
-		return time.Time{}, err
-	}
-
-	return pubAt, nil
+		return pubAt, nil
+	})
 }
 
 // garbageCollect will identify up to maxBundles unneeded partial entry bundles (and any unneeded partial tiles which sit above them in the tree) and

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -129,7 +129,7 @@ type sequencer interface {
 	// nextIndex returns the next available index in the log.
 	nextIndex(ctx context.Context) (uint64, error)
 	// publishCheckpoint coordinates the publication of new checkpoints based on the current integrated tree.
-	publishCheckpoint(ctx context.Context, minStaleActive, minStaleRepub time.Duration, f func(ctx context.Context, size uint64, root []byte) error) error
+	publishCheckpoint(ctx context.Context, minStaleActive, minStaleRepub time.Duration, f func(ctx context.Context, size uint64, root []byte) error) (time.Time, error)
 	// garbageCollect coordinates the removal of unneeded partial tiles/entry bundles for the provided tree size, up to a maximum number of deletes per invocation.
 	garbageCollect(ctx context.Context, treeSize uint64, maxDeletes uint, removePrefix func(ctx context.Context, prefix string) error, entriesPath func(uint64, uint8) string) error
 }
@@ -384,11 +384,19 @@ func (a *Appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 			ctx, cancel := context.WithTimeout(ctx, defaultPublicationTimeout)
 			defer cancel() // Note: ok because we're in a func passed to TraceErr here!
 
-			if err := a.sequencer.publishCheckpoint(ctx, pubInterval, republishInterval, a.updateCheckpoint); err != nil {
+			publishedAt, err := a.sequencer.publishCheckpoint(ctx, pubInterval, republishInterval, a.updateCheckpoint)
+			if err != nil {
 				return fmt.Errorf("publishCheckpoint failed: %v", err)
+			}
+			nextPublication := pubInterval - time.Since(publishedAt)
+			if nextPublication <= 0 {
+				t.Reset(time.Millisecond) // Schedule a checkpoint update immediately.
+			} else {
+				t.Reset(nextPublication)
 			}
 			return nil
 		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
+			t.Reset(pubInterval)
 			slog.ErrorContext(ctx, "publishCheckpoint failed", slog.Any("error", err))
 		}
 	}
@@ -1086,6 +1094,8 @@ func (s *spannerCoordinator) nextIndex(ctx context.Context) (uint64, error) {
 // publishCheckpoint checks when the last checkpoint was published, and if appropriate, calls the provided
 // function to publish a new one.
 //
+// Returns the time at which the checkpoint is published, or was last published.
+//
 // A checkpoint will not be published if either:
 //   - the currently published checkpoint was published less than minStaleActive ago
 //   - the new checkpoint is the same size as the currently published one, AND the currently published checkpoint
@@ -1093,13 +1103,14 @@ func (s *spannerCoordinator) nextIndex(ctx context.Context) (uint64, error) {
 //
 // This function uses PubCoord with an exclusive lock to guarantee that only one tessera instance can attempt to publish
 // a checkpoint at any given time.
-func (s *spannerCoordinator) publishCheckpoint(ctx context.Context, minStaleActive, minStaleRepub time.Duration, f func(context.Context, uint64, []byte) error) error {
+func (s *spannerCoordinator) publishCheckpoint(ctx context.Context, minStaleActive, minStaleRepub time.Duration, f func(context.Context, uint64, []byte) error) (time.Time, error) {
+	var pubAt time.Time
 	currentSize, rootHash, err := s.currentTree(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get current tree: %v", err)
+		return time.Time{}, fmt.Errorf("failed to get current tree: %v", err)
 	}
 
-	return otel.TraceErr(ctx, "tessera.storage.gcp.publishCheckpoint", tracer, func(ctx context.Context, span trace.Span) error {
+	if err := otel.TraceErr(ctx, "tessera.storage.gcp.publishCheckpoint", tracer, func(ctx context.Context, span trace.Span) error {
 		// outcomeAttr records the outcome of the checkpoint publication attempt for metrics and traces.
 		var outcomeAttr attribute.KeyValue
 		start := time.Now()
@@ -1114,7 +1125,6 @@ func (s *spannerCoordinator) publishCheckpoint(ctx context.Context, minStaleActi
 			if err != nil {
 				return fmt.Errorf("failed to read PubCoord: %w", err)
 			}
-			var pubAt time.Time
 			var lastSize spanner.NullInt64
 			if err := pRow.Columns(&pubAt, &lastSize); err != nil {
 				return fmt.Errorf("failed to parse PubCoord: %v", err)
@@ -1156,7 +1166,8 @@ func (s *spannerCoordinator) publishCheckpoint(ctx context.Context, minStaleActi
 				return err
 			}
 			span.AddEvent("Updating PubCoord")
-			if err := txn.BufferWrite([]*spanner.Mutation{spanner.Update("PubCoord", []string{"id", "publishedAt", "size"}, []any{0, time.Now(), int64(currentSize)})}); err != nil {
+			pubAt = time.Now()
+			if err := txn.BufferWrite([]*spanner.Mutation{spanner.Update("PubCoord", []string{"id", "publishedAt", "size"}, []any{0, pubAt, int64(currentSize)})}); err != nil {
 				return err
 			}
 
@@ -1170,7 +1181,11 @@ func (s *spannerCoordinator) publishCheckpoint(ctx context.Context, minStaleActi
 		span.SetAttributes(outcomeAttr)
 		publishCount.Add(ctx, 1, metric.WithAttributes(outcomeAttr))
 		return nil
-	})
+	}); err != nil {
+		return time.Time{}, err
+	}
+
+	return pubAt, nil
 }
 
 // garbageCollect will identify up to maxBundles unneeded partial entry bundles (and any unneeded partial tiles which sit above them in the tree) and

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -518,7 +518,7 @@ func TestPublishTree(t *testing.T) {
 				t.Fatalf("storage.init: %v", err)
 			}
 
-			if err := s.publishCheckpoint(ctx, test.publishInterval, test.republishInterval, storage.updateCheckpoint); err != nil {
+			if _, err := s.publishCheckpoint(ctx, test.publishInterval, test.republishInterval, storage.updateCheckpoint); err != nil {
 				t.Fatalf("publishTree: %v", err)
 			}
 			cpOld := []byte("bananas")
@@ -528,7 +528,7 @@ func TestPublishTree(t *testing.T) {
 			updatesSeen := 0
 			for _, d := range test.attempts {
 				time.Sleep(d)
-				if err := s.publishCheckpoint(ctx, test.publishInterval, test.republishInterval, storage.updateCheckpoint); err != nil {
+				if _, err := s.publishCheckpoint(ctx, test.publishInterval, test.republishInterval, storage.updateCheckpoint); err != nil {
 					t.Fatalf("publishTree: %v", err)
 				}
 				cpNew, _, err := m.getObject(ctx, layout.CheckpointPath)

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -179,11 +179,19 @@ func (a *appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 		if err := otel.TraceErr(ctx, "tessera.storage.posix.publishCheckpointJob", tracer, func(ctx context.Context, span trace.Span) error {
 			ctx, cancel := context.WithTimeout(ctx, defaultPublicationTimeout)
 			defer cancel()
-			if err := a.publishCheckpoint(ctx, pubInterval, republishInterval); err != nil {
+			publishedAt, err := a.publishCheckpoint(ctx, pubInterval, republishInterval)
+			if err != nil {
 				return err
+			}
+			nextPublication := pubInterval - time.Since(publishedAt)
+			if nextPublication <= 0 {
+				t.Reset(time.Millisecond) // Schedule a checkpoint update immediately.
+			} else {
+				t.Reset(nextPublication)
 			}
 			return nil
 		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
+			t.Reset(pubInterval)
 			slog.WarnContext(ctx, "publishCheckpoint failed", slog.Any("error", err))
 		}
 	}
@@ -578,7 +586,7 @@ func (a *appender) initialise(ctx context.Context) error {
 			return fmt.Errorf("failed to write tree-state checkpoint: %v", err)
 		}
 		if a.newCP != nil {
-			if err := a.publishCheckpoint(ctx, 0, 0); err != nil {
+			if _, err := a.publishCheckpoint(ctx, 0, 0); err != nil {
 				return fmt.Errorf("failed to publish checkpoint: %v", err)
 			}
 		}
@@ -666,16 +674,12 @@ func (s *Storage) readTreeState(ctx context.Context) (uint64, []byte, error) {
 // publishCheckpoint checks whether the currently published checkpoint (if any) is more than
 // minStaleness old, and, if so, creates and published a fresh checkpoint from the current
 // stored tree state.
-func (a *appender) publishCheckpoint(ctx context.Context, minStalenessActive, minStalenessRepub time.Duration) (errR error) {
-	return otel.TraceErr(ctx, "tessera.storage.posix.publishCheckpoint", tracer, func(ctx context.Context, span trace.Span) error {
+//
+// Returns the time at which the checkpoint is published, or was last published.
+func (a *appender) publishCheckpoint(ctx context.Context, minStalenessActive, minStalenessRepub time.Duration) (time.Time, error) {
+	var publishedAt time.Time
+	if err := otel.TraceErr(ctx, "tessera.storage.posix.publishCheckpoint", tracer, func(ctx context.Context, span trace.Span) error {
 		now := time.Now()
-		defer func() {
-			// Detect any errors and update metrics accordingly.
-			// Non-error cases are explicitly handled in the body of the function below.
-			if errR != nil {
-				publishCount.Add(ctx, 1, metric.WithAttributes(errorTypeKey.String("error")))
-			}
-		}()
 
 		// Lock the destination "published" checkpoint location:
 		unlock, err := a.s.lockFile(ctx, publishLock)
@@ -698,6 +702,7 @@ func (a *appender) publishCheckpoint(ctx context.Context, minStalenessActive, mi
 		} else if err != nil {
 			return fmt.Errorf("stat(%s): %v", layout.CheckpointPath, err)
 		} else {
+			publishedAt = info.ModTime()
 			publishedAge = time.Since(info.ModTime())
 			if publishedAge < minStalenessActive {
 				slog.DebugContext(ctx, "publishCheckpoint: skipping publish because previous checkpoint too fresh", slog.Duration("age", publishedAge), slog.Duration("minstalenessactive", minStalenessActive))
@@ -732,6 +737,7 @@ func (a *appender) publishCheckpoint(ctx context.Context, minStalenessActive, mi
 		if err := a.s.createOverwrite(layout.CheckpointPath, cpRaw); err != nil {
 			return fmt.Errorf("createOverwrite(%s): %v", layout.CheckpointPath, err)
 		}
+		publishedAt = time.Now()
 
 		slog.DebugContext(ctx, "Published latest checkpoint", slog.Uint64("size", size), slog.String("root", fmt.Sprintf("%x", root)))
 
@@ -739,7 +745,12 @@ func (a *appender) publishCheckpoint(ctx context.Context, minStalenessActive, mi
 		publishCount.Add(ctx, 1)
 
 		return nil
-	})
+	}); err != nil {
+		publishCount.Add(ctx, 1, metric.WithAttributes(errorTypeKey.String("error")))
+		return time.Time{}, err
+	}
+
+	return publishedAt, nil
 }
 
 // publishedSize returns the size of tree that the currently published checkpoint, if any, commits to.

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -672,15 +672,21 @@ func (s *Storage) readTreeState(ctx context.Context) (uint64, []byte, error) {
 // stored tree state.
 //
 // Returns the time at which the checkpoint is published, or was last published.
-func (a *appender) publishCheckpoint(ctx context.Context, minStalenessActive, minStalenessRepub time.Duration) (time.Time, error) {
-	var publishedAt time.Time
-	if err := otel.TraceErr(ctx, "tessera.storage.posix.publishCheckpoint", tracer, func(ctx context.Context, span trace.Span) error {
+func (a *appender) publishCheckpoint(ctx context.Context, minStalenessActive, minStalenessRepub time.Duration) (publishedAt time.Time, errR error) {
+	return otel.Trace(ctx, "tessera.storage.posix.publishCheckpoint", tracer, func(ctx context.Context, span trace.Span) (time.Time, error) {
 		now := time.Now()
+		defer func() {
+			// Detect any errors and update metrics accordingly.
+			// Non-error cases are explicitly handled in the body of the function below.
+			if errR != nil {
+				publishCount.Add(ctx, 1, metric.WithAttributes(errorTypeKey.String("error")))
+			}
+		}()
 
 		// Lock the destination "published" checkpoint location:
 		unlock, err := a.s.lockFile(ctx, publishLock)
 		if err != nil {
-			return fmt.Errorf("lockFile(%s): %v", publishLock, err)
+			return time.Time{}, fmt.Errorf("lockFile(%s): %v", publishLock, err)
 		}
 		defer func() {
 			if err := unlock(); err != nil {
@@ -696,42 +702,42 @@ func (a *appender) publishCheckpoint(ctx context.Context, minStalenessActive, mi
 			slog.DebugContext(ctx, "No checkpoint exists, publishing")
 			cpExists = false
 		} else if err != nil {
-			return fmt.Errorf("stat(%s): %v", layout.CheckpointPath, err)
+			return time.Time{}, fmt.Errorf("stat(%s): %v", layout.CheckpointPath, err)
 		} else {
 			publishedAt = info.ModTime()
 			publishedAge = time.Since(info.ModTime())
 			if publishedAge < minStalenessActive {
 				slog.DebugContext(ctx, "publishCheckpoint: skipping publish because previous checkpoint too fresh", slog.Duration("age", publishedAge), slog.Duration("minstalenessactive", minStalenessActive))
 				publishCount.Add(ctx, 1, metric.WithAttributes(errorTypeKey.String("skipped")))
-				return nil
+				return publishedAt, nil
 			}
 			publishedSize, err = a.publishedSize(ctx)
 			if err != nil {
 				slog.DebugContext(ctx, "publishCheckpoint: skipping publish because unable to determine previously published size", slog.Any("error", err))
-				return err
+				return time.Time{}, err
 			}
 		}
 
 		size, root, err := a.s.readTreeState(ctx)
 		if err != nil {
 			publishCount.Add(ctx, 1, metric.WithAttributes(errorTypeKey.String("error")))
-			return fmt.Errorf("readTreeState: %v", err)
+			return time.Time{}, fmt.Errorf("readTreeState: %v", err)
 		}
 		if cpExists && size == publishedSize {
 			if minStalenessRepub == 0 || publishedAge < minStalenessRepub {
 				slog.DebugContext(ctx, "publishCheckpoint: skipping publish because tree hasn't grown and previous checkpoint is too recent")
 				publishCount.Add(ctx, 1, metric.WithAttributes(errorTypeKey.String("skipped_no_growth")))
-				return nil
+				return publishedAt, nil
 			}
 		}
 
 		cpRaw, err := a.newCP(ctx, size, root)
 		if err != nil {
-			return fmt.Errorf("newCP: %v", err)
+			return time.Time{}, fmt.Errorf("newCP: %v", err)
 		}
 
 		if err := a.s.createOverwrite(layout.CheckpointPath, cpRaw); err != nil {
-			return fmt.Errorf("createOverwrite(%s): %v", layout.CheckpointPath, err)
+			return time.Time{}, fmt.Errorf("createOverwrite(%s): %v", layout.CheckpointPath, err)
 		}
 		publishedAt = time.Now()
 
@@ -740,13 +746,8 @@ func (a *appender) publishCheckpoint(ctx context.Context, minStalenessActive, mi
 		posixOpsHistogram.Record(ctx, time.Since(now).Milliseconds(), metric.WithAttributes(opNameKey.String("publishCheckpoint")))
 		publishCount.Add(ctx, 1)
 
-		return nil
-	}); err != nil {
-		publishCount.Add(ctx, 1, metric.WithAttributes(errorTypeKey.String("error")))
-		return time.Time{}, err
-	}
-
-	return publishedAt, nil
+		return publishedAt, nil
+	})
 }
 
 // publishedSize returns the size of tree that the currently published checkpoint, if any, commits to.

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -739,6 +739,7 @@ func (a *appender) publishCheckpoint(ctx context.Context, minStalenessActive, mi
 		if err := a.s.createOverwrite(layout.CheckpointPath, cpRaw); err != nil {
 			return time.Time{}, fmt.Errorf("createOverwrite(%s): %v", layout.CheckpointPath, err)
 		}
+		// This is not the actual ModTime of the file, but it's close enough.
 		publishedAt = time.Now()
 
 		slog.DebugContext(ctx, "Published latest checkpoint", slog.Uint64("size", size), slog.String("root", fmt.Sprintf("%x", root)))

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -183,12 +183,8 @@ func (a *appender) publishCheckpointJob(ctx context.Context, pubInterval, republ
 			if err != nil {
 				return err
 			}
-			nextPublication := pubInterval - time.Since(publishedAt)
-			if nextPublication <= 0 {
-				t.Reset(time.Millisecond) // Schedule a checkpoint update immediately.
-			} else {
-				t.Reset(nextPublication)
-			}
+			// Schedule a checkpoint update immediately, if an updated is due.
+			t.Reset(max(time.Millisecond, pubInterval-time.Since(publishedAt)))
 			return nil
 		}, trace.WithAttributes(otel.PeriodicKey.Bool(true))); err != nil {
 			t.Reset(pubInterval)

--- a/storage/posix/files_test.go
+++ b/storage/posix/files_test.go
@@ -61,7 +61,7 @@ func TestGarbageCollect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Appender: %v", err)
 	}
-	if err := appender.publishCheckpoint(ctx, 0, 0); err != nil {
+	if _, err := appender.publishCheckpoint(ctx, 0, 0); err != nil {
 		t.Fatalf("publishCheckpoint: %v", err)
 	}
 
@@ -174,7 +174,7 @@ func TestGarbageCollectOption(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Appender: %v", err)
 			}
-			if err := appender.publishCheckpoint(ctx, 0, 0); err != nil {
+			if _, err := appender.publishCheckpoint(ctx, 0, 0); err != nil {
 				t.Fatalf("publishCheckpoint: %v", err)
 			}
 
@@ -337,7 +337,7 @@ func TestPublishTree(t *testing.T) {
 				return fmt.Appendf(nil, "origin\n%d\n%x\n%d\n,", size, hash, time.Now().Unix()), nil
 			}
 
-			if err := appender.publishCheckpoint(ctx, test.publishInterval, test.republishInterval); err != nil {
+			if _, err := appender.publishCheckpoint(ctx, test.publishInterval, test.republishInterval); err != nil {
 				t.Fatalf("publishTree: %v", err)
 			}
 
@@ -357,7 +357,7 @@ func TestPublishTree(t *testing.T) {
 
 			for _, d := range test.attempts {
 				time.Sleep(d)
-				if err := appender.publishCheckpoint(ctx, test.publishInterval, test.republishInterval); err != nil {
+				if _, err := appender.publishCheckpoint(ctx, test.publishInterval, test.republishInterval); err != nil {
 					t.Fatalf("publishTree: %v", err)
 				}
 				cpNew, err := lr.ReadCheckpoint(ctx)


### PR DESCRIPTION
This PR schedules checkpoint publication operations as early as possible, as per `checkpoint_interval and the last publication timestamp.