### PR TITLE
[MTC] Add first cut of mirror HTTP handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Tessera is generally available and production ready. The following items are pla
 |  10 | Mirrored logs ([#576][])                                  |   ⚠️   |
 |  11 | Preordered logs ([#575][])                                |   ❌   |
 |  12 | Trillian v1 to Tessera migration ([#577][])               |   ❌   |
+|  13 | Merkle Tree Certificates support ([#945][])               |   ⚠️   |
 |  N  | Fancy features (to be expanded upon later)                |   ❌   |
 
 ### What’s happening to Trillian v1?
@@ -451,3 +452,4 @@ transparency ecosystems over the years.
 [#575]: https://github.com/transparency-dev/tessera/issues/575
 [#576]: https://github.com/transparency-dev/tessera/issues/576
 [#577]: https://github.com/transparency-dev/tessera/issues/577
+[#945]: https://github.com/transparency-dev/tessera/issues/945

--- a/cmd/mtc/README.md
+++ b/cmd/mtc/README.md
@@ -1,0 +1,8 @@
+# MTC
+
+This directory contains some experimental/WIP binaries which implement the
+[MTC](https://datatracker.ietf.org/doc/html/draft-ietf-plants-merkle-tree-certs) and 
+[tlog-mirror](https://github.com/C2SP/C2SP/blob/main/tlog-mirror.md) specs.
+
+Everything under this directory, along with any other in-progress MTC-related support elsewhere in this repo, may be subject to large and unannounced
+changes and so should be considered excluded from the SemVer policy for the time being.

--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -1,0 +1,289 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"log/slog"
+
+	"github.com/transparency-dev/tessera/cmd/mtc/mirror/internal/mirror"
+	"github.com/transparency-dev/tessera/internal/parse"
+)
+
+const (
+	// maxOriginLen is the maximum length of a valid log origin.
+	// This value comes from the MLDSA cosigner spec.
+	maxOriginLen = 255
+	// maxTicketSize is the maximum length of a tlog-mirror ticket.
+	maxTicketSize = 1<<16 - 1
+)
+
+// Mirror is the interface that the handler uses to interact with the mirror's state.
+type Mirror interface {
+	AddCheckpoint(ctx context.Context, cp []byte, oldSize uint64, proof [][]byte) error
+	AddEntries(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error)
+}
+
+// New returns a new http.Handler for the mirror service.
+func New(m Mirror) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /add-checkpoint", addCheckpoint(m))
+	mux.HandleFunc("POST /add-entries", addEntries(m))
+	return mux
+}
+
+func addCheckpoint(m Mirror) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// SPEC: The mirror implements a [tlog-]witness's add-checkpoint endpoint.
+		//       MUST be a sequence of:
+		//         - an old size line,
+		//         - zero or more consistency proof lines,
+		//         - and an empty line,
+		//         - followed by a checkpoint.
+
+		reader := bufio.NewReader(r.Body)
+
+		// 1. Read old size line.
+		oldLine, err := reader.ReadString('\n')
+		if err != nil {
+			http.Error(w, "missing old size", http.StatusBadRequest)
+			return
+		}
+		oldLine = strings.TrimSpace(oldLine)
+		if !strings.HasPrefix(oldLine, "old ") {
+			http.Error(w, "invalid old size line", http.StatusBadRequest)
+			return
+		}
+		oldSize, err := strconv.ParseUint(strings.TrimPrefix(oldLine, "old "), 10, 64)
+		if err != nil {
+			http.Error(w, "invalid old size", http.StatusBadRequest)
+			return
+		}
+
+		// 2. Read consistency proof lines until an empty line.
+		var proof [][]byte
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				http.Error(w, "unexpected EOF while reading proof", http.StatusBadRequest)
+				return
+			}
+			line = strings.TrimSpace(line)
+			if line == "" {
+				break
+			}
+			p, err := base64.StdEncoding.DecodeString(line)
+			if err != nil {
+				http.Error(w, "invalid proof line", http.StatusBadRequest)
+				return
+			}
+			proof = append(proof, p)
+		}
+
+		// 3. Remaining data is the checkpoint.
+		cp, err := io.ReadAll(reader)
+		if err != nil {
+			http.Error(w, "failed to read checkpoint", http.StatusBadRequest)
+			return
+		}
+
+		if _, _, _, err := parse.CheckpointUnsafe(cp); err != nil {
+			http.Error(w, fmt.Sprintf("invalid checkpoint: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		if err := m.AddCheckpoint(r.Context(), cp, oldSize, proof); err != nil {
+			slog.ErrorContext(r.Context(), "AddCheckpoint failed", slog.Any("error", err))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		// TODO(al): Maybe return a tlog-witness only cosignature here from a separate key?
+	}
+}
+
+func addEntries(m Mirror) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := parseAddEntriesPreamble(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to parse header: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		cosigs, err := m.AddEntries(r.Context(), req.logOrigin, req.uploadStart, req.uploadEnd, req.ticket, req.NextPackage)
+		if err != nil {
+			// TODO(al): Handle Conflict (409) if it's a conflict error.
+			slog.ErrorContext(r.Context(), "AddEntries failed", slog.Any("error", err))
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write(cosigs)
+	}
+}
+
+// addEntriesRequest represents the body of a request to the tlog-mirror add-entries endpoint.
+type addEntriesRequest struct {
+	logOrigin   string
+	uploadStart uint64
+	uploadEnd   uint64
+	ticket      []byte
+	body        io.Reader
+
+	// start is the index of the next entry in the stream of entry packages.
+	// Initially it will be equal to uploadStart, and will be moved forwards
+	// by calls to NextPackage().
+	start uint64
+}
+
+// NextPackage returns the next entry package in the request, if any.
+//
+// Once all packages from the request have been consumed, this func will continue
+// to return io.EOF.
+//
+// Not thread-safe.
+func (a *addEntriesRequest) NextPackage() (*mirror.Package, error) {
+	if a.start >= a.uploadEnd {
+		return nil, io.EOF
+	}
+
+	// Calculate how many entries in this package
+	end := min(a.uploadEnd, (a.start/256+1)*256)
+	numEntries := int(end - a.start)
+
+	// Now parse the package.
+	//
+	// SPEC: The package MUST contain the following values, concatenated.
+	//         - The log entries in [start, end), each with a big-endian uint16 length prefix,
+	//         - 1 byte, encoding an 8-bit unsigned integer, num_hashes, which MUST be at most 63,
+	//         - num_hashes subtree consistency proof hash values.
+
+	// First the entries themselves.
+	var entries [][]byte
+	for range numEntries {
+		var entryLen uint16
+		if err := binary.Read(a.body, binary.BigEndian, &entryLen); err != nil {
+			return nil, fmt.Errorf("failed to read entry length: %v", err)
+		}
+		entry := make([]byte, entryLen)
+		if _, err := io.ReadFull(a.body, entry); err != nil {
+			return nil, fmt.Errorf("failed to read entry: %v", err)
+		}
+		entries = append(entries, entry)
+	}
+
+	// Now the proof length.
+	var numHashes uint8
+	if err := binary.Read(a.body, binary.BigEndian, &numHashes); err != nil {
+		return nil, fmt.Errorf("failed to read num_hashes: %v", err)
+	}
+	if numHashes > 63 {
+		return nil, fmt.Errorf("too many hashes: %d", numHashes)
+	}
+
+	// Finally, the proof itself.
+	var proofs [][]byte
+	for i := 0; i < int(numHashes); i++ {
+		hash := make([]byte, 32) // Proof is comprised of SHA256 hashes.
+		if _, err := io.ReadFull(a.body, hash); err != nil {
+			return nil, fmt.Errorf("failed to read hash: %v", err)
+		}
+		proofs = append(proofs, hash)
+	}
+
+	// Update next expected entry index.
+	a.start = end
+	return &mirror.Package{Entries: entries, Proof: proofs}, nil
+}
+
+// parseAddEntriesPreamble consumes the body of the Add-Entries request.
+//
+// This func effectively takes ownership of the provided Reader, it MUST NOT be
+// further used by the caller.
+//
+// Returns a struct which represents the request, and provides streaming access to the entry packages.
+func parseAddEntriesPreamble(r io.Reader) (*addEntriesRequest, error) {
+	//SPEC: The request body MUST have Content-Type of application/octet-stream and contain the
+	//      following values, concatenated.
+	//        2 bytes, encoding a big-endian uint16: log_origin_size
+	//        log_origin_size bytes, containing the log origin: log_origin
+	//        8 bytes, encoding a big-endian uint64: upload_start
+	//        8 bytes, encoding a big-endian uint64: upload_end
+	//        2 bytes, encoding a big-endian uint16: ticket_size
+	//        ticket_size bytes, containing an opaque ticket value, described below
+	//        A sequence of entry packages
+	var logOriginSize uint16
+	if err := binary.Read(r, binary.BigEndian, &logOriginSize); err != nil {
+		return nil, err
+	}
+	if logOriginSize > maxOriginLen {
+		return nil, errors.New("log origin too long")
+	}
+	logOrigin := make([]byte, logOriginSize)
+	if _, err := io.ReadFull(r, logOrigin); err != nil {
+		return nil, err
+	}
+
+	var uploadStart uint64
+	if err := binary.Read(r, binary.BigEndian, &uploadStart); err != nil {
+		return nil, err
+	}
+
+	var uploadEnd uint64
+	if err := binary.Read(r, binary.BigEndian, &uploadEnd); err != nil {
+		return nil, err
+	}
+
+	var ticketSize uint16
+	if err := binary.Read(r, binary.BigEndian, &ticketSize); err != nil {
+		return nil, err
+	}
+	if ticketSize > maxTicketSize {
+		return nil, errors.New("ticket too large")
+	}
+	var ticket []byte
+	if ticketSize > 0 {
+		ticket = make([]byte, ticketSize)
+		if _, err := io.ReadFull(r, ticket); err != nil {
+			return nil, err
+		}
+	}
+
+	// SPEC: upload_start MUST be less or equal to upload_end
+	if uploadStart > uploadEnd {
+		return nil, fmt.Errorf("uploadStart (%d) > uploadEnd (%d)", uploadStart, uploadEnd)
+	}
+
+	return &addEntriesRequest{
+		logOrigin:   string(logOrigin),
+		uploadStart: uploadStart,
+		uploadEnd:   uploadEnd,
+		ticket:      ticket,
+		body:        r,
+		start:       uploadStart,
+	}, nil
+}

--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -42,7 +42,7 @@ const (
 
 // Mirror is the interface that the handler uses to interact with the mirror's state.
 type Mirror interface {
-	AddCheckpoint(ctx context.Context, cp []byte, oldSize uint64, proof [][]byte) error
+	AddCheckpoint(ctx context.Context, oldSize uint64, proof [][]byte, cp []byte) error
 	AddEntries(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error)
 }
 
@@ -114,7 +114,7 @@ func addCheckpoint(m Mirror) http.HandlerFunc {
 			return
 		}
 
-		if err := m.AddCheckpoint(r.Context(), cp, oldSize, proof); err != nil {
+		if err := m.AddCheckpoint(r.Context(), oldSize, proof, cp); err != nil {
 			slog.ErrorContext(r.Context(), "AddCheckpoint failed", slog.Any("error", err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -127,6 +127,11 @@ func addCheckpoint(m Mirror) http.HandlerFunc {
 
 func addEntries(m Mirror) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// SPEC: The request body MUST have Content-Type of application/octet-stream ...
+		if t := strings.ToLower(r.Header.Get("Content-Type")); t != "application/octet-stream" {
+			http.Error(w, fmt.Sprintf("invalid Content-Type %q", t), http.StatusBadRequest)
+			return
+		}
 		req, err := parseAddEntriesPreamble(r.Body)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to parse header: %v", err), http.StatusBadRequest)
@@ -227,15 +232,14 @@ func (a *addEntriesRequest) NextPackage() (*mirror.Package, error) {
 //
 // Returns a struct which represents the request, and provides streaming access to the entry packages.
 func parseAddEntriesPreamble(r io.Reader) (*addEntriesRequest, error) {
-	//SPEC: The request body MUST have Content-Type of application/octet-stream and contain the
-	//      following values, concatenated.
-	//        2 bytes, encoding a big-endian uint16: log_origin_size
-	//        log_origin_size bytes, containing the log origin: log_origin
-	//        8 bytes, encoding a big-endian uint64: upload_start
-	//        8 bytes, encoding a big-endian uint64: upload_end
-	//        2 bytes, encoding a big-endian uint16: ticket_size
-	//        ticket_size bytes, containing an opaque ticket value, described below
-	//        A sequence of entry packages
+	// SPEC: The request body MUST ... contain the following values, concatenated:
+	//         2 bytes, encoding a big-endian uint16: log_origin_size
+	//         log_origin_size bytes, containing the log origin: log_origin
+	//         8 bytes, encoding a big-endian uint64: upload_start
+	//         8 bytes, encoding a big-endian uint64: upload_end
+	//         2 bytes, encoding a big-endian uint16: ticket_size
+	//         ticket_size bytes, containing an opaque ticket value, described below
+	//         A sequence of entry packages
 	var logOriginSize uint16
 	if err := binary.Read(r, binary.BigEndian, &logOriginSize); err != nil {
 		return nil, err

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/transparency-dev/tessera/cmd/mtc/mirror/internal/mirror"
+)
+
+type mockMirror struct {
+	addCheckpointFunc func(ctx context.Context, cp []byte, oldSize uint64, proof [][]byte) error
+	addEntriesFunc    func(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error)
+}
+
+func (m *mockMirror) AddCheckpoint(ctx context.Context, cp []byte, oldSize uint64, proof [][]byte) error {
+	if m.addCheckpointFunc != nil {
+		return m.addCheckpointFunc(ctx, cp, oldSize, proof)
+	}
+	return nil
+}
+
+func (m *mockMirror) AddEntries(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error) {
+	if m.addEntriesFunc != nil {
+		return m.addEntriesFunc(ctx, logOrigin, uploadStart, uploadEnd, ticket, next)
+	}
+	return []byte("— dummy-cosig\n"), nil
+}
+
+func TestAddCheckpoint(t *testing.T) {
+	const cpOld = 100
+
+	mock := &mockMirror{
+		addCheckpointFunc: func(ctx context.Context, cp []byte, oldSize uint64, proof [][]byte) error {
+			if oldSize != cpOld {
+				return fmt.Errorf("want oldSize %d, got %d", cpOld, oldSize)
+			}
+			if len(proof) != 1 {
+				return fmt.Errorf("want 1 proof hash, got %d", len(proof))
+			}
+			return nil
+		},
+	}
+	h := New(mock)
+
+	cp := "example-log\n123\nSGVsbG8sIHdvcmxkIQ==\n\n"
+	proofHash := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	body := fmt.Sprintf("old %d\n%s\n\n%s", cpOld, proofHash, cp)
+
+	req := httptest.NewRequest(http.MethodPost, "/add-checkpoint", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want status 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAddEntries(t *testing.T) {
+	const (
+		testOrigin      = "example-log"
+		testTicket      = "ticket"
+		testUploadStart = 100
+		testUploadEnd   = 110
+	)
+
+	mock := &mockMirror{
+		addEntriesFunc: func(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error) {
+			if logOrigin != testOrigin {
+				return nil, fmt.Errorf("want logOrigin %s, got %s", testOrigin, logOrigin)
+			}
+			if uploadStart != testUploadStart || uploadEnd != testUploadEnd {
+				return nil, fmt.Errorf("want range %d-%d, got %d-%d", testUploadStart, testUploadEnd, uploadStart, uploadEnd)
+			}
+
+			pkg, err := next()
+			if err != nil {
+				return nil, fmt.Errorf("failed to read next package: %v", err)
+			}
+			wantNumEntries := testUploadEnd - testUploadStart
+			if len(pkg.Entries) != wantNumEntries {
+				return nil, fmt.Errorf("want %d entries in first package, got %d", wantNumEntries, len(pkg.Entries))
+			}
+
+			// Try to read one more, expecting EOF
+			_, err = next()
+			if err == nil {
+				return nil, fmt.Errorf("expected EOF, got nil")
+			}
+
+			return []byte("— test-cosig\n"), nil
+		},
+	}
+	h := New(mock)
+
+	var body bytes.Buffer
+
+	// Write preamble
+	_ = binary.Write(&body, binary.BigEndian, uint16(len(testOrigin)))
+	_, _ = body.WriteString(testOrigin)
+	_ = binary.Write(&body, binary.BigEndian, uint64(testUploadStart))
+	_ = binary.Write(&body, binary.BigEndian, uint64(testUploadEnd))
+	_ = binary.Write(&body, binary.BigEndian, uint16(len(testTicket)))
+	_, _ = body.WriteString(testTicket)
+
+	// Write entry package
+	for i := range testUploadEnd - testUploadStart {
+		entry := fmt.Appendf(nil, "entry-%d", i)
+		_ = binary.Write(&body, binary.BigEndian, uint16(len(entry)))
+		_, _ = body.Write(entry)
+	}
+	_ = body.WriteByte(1)               // num proof hashes
+	_, _ = body.Write(make([]byte, 32)) // 1 hash
+
+	req := httptest.NewRequest(http.MethodPost, "/add-entries", &body)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want status 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("— test-cosig\n")) {
+		t.Errorf("response does not contain expected cosignature: %s", w.Body.String())
+	}
+}

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -28,13 +28,13 @@ import (
 )
 
 type mockMirror struct {
-	addCheckpointFunc func(ctx context.Context, cp []byte, oldSize uint64, proof [][]byte) error
+	addCheckpointFunc func(ctx context.Context, oldSize uint64, proof [][]byte, cp []byte) error
 	addEntriesFunc    func(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error)
 }
 
-func (m *mockMirror) AddCheckpoint(ctx context.Context, cp []byte, oldSize uint64, proof [][]byte) error {
+func (m *mockMirror) AddCheckpoint(ctx context.Context, oldSize uint64, proof [][]byte, cp []byte) error {
 	if m.addCheckpointFunc != nil {
-		return m.addCheckpointFunc(ctx, cp, oldSize, proof)
+		return m.addCheckpointFunc(ctx, oldSize, proof, cp)
 	}
 	return nil
 }
@@ -50,7 +50,7 @@ func TestAddCheckpoint(t *testing.T) {
 	const cpOld = 100
 
 	mock := &mockMirror{
-		addCheckpointFunc: func(ctx context.Context, cp []byte, oldSize uint64, proof [][]byte) error {
+		addCheckpointFunc: func(ctx context.Context, oldSize uint64, proof [][]byte, cp []byte) error {
 			if oldSize != cpOld {
 				return fmt.Errorf("want oldSize %d, got %d", cpOld, oldSize)
 			}
@@ -132,6 +132,7 @@ func TestAddEntries(t *testing.T) {
 	_, _ = body.Write(make([]byte, 32)) // 1 hash
 
 	req := httptest.NewRequest(http.MethodPost, "/add-entries", &body)
+	req.Header.Add("Content-Type", "application/octet-stream")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 

--- a/cmd/mtc/mirror/internal/mirror/mirror.go
+++ b/cmd/mtc/mirror/internal/mirror/mirror.go
@@ -30,8 +30,8 @@ type Package struct {
 	Proof   [][]byte
 }
 
-func (m *Mirror) AddCheckpoint(ctx context.Context, cp []byte, oldSize uint64, proof [][]byte) error {
-	slog.InfoContext(ctx, "AddCheckpoint", slog.Int("cp_len", len(cp)), slog.Uint64("old_size", oldSize), slog.Int("proof_len", len(proof)))
+func (m *Mirror) AddCheckpoint(ctx context.Context, oldSize uint64, proof [][]byte, cpRaw []byte) error {
+	slog.InfoContext(ctx, "AddCheckpoint", slog.Uint64("old_size", oldSize), slog.Int("proof_len", len(proof)), slog.String("cp", string(cpRaw)))
 	return nil
 }
 

--- a/cmd/mtc/mirror/internal/mirror/mirror.go
+++ b/cmd/mtc/mirror/internal/mirror/mirror.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"context"
+	"io"
+	"log/slog"
+)
+
+// Mirror is a placeholder. TBD where this actually lives, and how much is inside a storage lifecycle.
+type Mirror struct {
+}
+
+// Package represents a single package of entries and its subtree consistency proof.
+type Package struct {
+	Entries [][]byte
+	Proof   [][]byte
+}
+
+func (m *Mirror) AddCheckpoint(ctx context.Context, cp []byte, oldSize uint64, proof [][]byte) error {
+	slog.InfoContext(ctx, "AddCheckpoint", slog.Int("cp_len", len(cp)), slog.Uint64("old_size", oldSize), slog.Int("proof_len", len(proof)))
+	return nil
+}
+
+func (m *Mirror) AddEntries(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*Package, error)) ([]byte, error) {
+	slog.InfoContext(ctx, "AddEntries", slog.String("origin", logOrigin), slog.Uint64("start", uploadStart), slog.Uint64("end", uploadEnd))
+
+	// Drain the packages
+	for {
+		pkg, err := next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		slog.InfoContext(ctx, "AddEntries received package", slog.Int("num_entries", len(pkg.Entries)), slog.Int("num_proof_hashes", len(pkg.Proof)))
+	}
+
+	// SPEC: "Success (200 OK): A sequence of one or more cosignature lines"
+	// Return a dummy cosignature for now.
+	return []byte("— mirror-dummy-cosignature\n"), nil
+}

--- a/cmd/mtc/mirror/posix/main.go
+++ b/cmd/mtc/mirror/posix/main.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"net/http"
+	"os"
+
+	"log/slog"
+
+	"github.com/transparency-dev/tessera/cmd/mtc/mirror/internal/handler"
+	"github.com/transparency-dev/tessera/cmd/mtc/mirror/internal/mirror"
+)
+
+var (
+	listenAddr = flag.String("listen_addr", ":8080", "The address to listen on for HTTP requests.")
+)
+
+func main() {
+	flag.Parse()
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	ctx := context.Background()
+
+	m := &mirror.Mirror{}
+	h := handler.New(m)
+
+	slog.InfoContext(ctx, "Starting mirror service", slog.String("addr", *listenAddr))
+	if err := http.ListenAndServe(*listenAddr, h); err != nil {
+		slog.ErrorContext(ctx, "ListenAndServe failed", slog.Any("error", err))
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This PR adds a very rough sketch for an MTC mirror API server, primarily intended to enable work on the lower storage layers, subtree proofs, and test client to proceed.

Towards #945 