### PR TITLE
Only attempt to witness if configured to do so

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -719,7 +719,7 @@ func (o AppendOptions) CheckpointPublisher(lr LogReader, httpClient *http.Client
 
 			span.AddEvent("Starting witnessing")
 			// Handle witnessing
-			{
+			if len(o.witnesses.Components) != 0 {
 				// Figure out the likely size the witnesses are aware of, but don't fail hard if we're unable
 				// to do so:
 				// a) it could be that this is the first checkpoint we're publishing


### PR DESCRIPTION
When Witnessing is disabled, this will:
 - save a checkpoint read
 - prevent Witnessing metrics from being incremented