### PR TITLE
Add retry logic for HTTP fetcher

### DIFF
--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -270,7 +270,7 @@ func WithCheckpointRetry(f CheckpointFetcherFunc, opts ...RetryOption) Checkpoin
 // retry retries the function f with exponential backoff up to maxRetries.
 func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, error) {
 	var backoff = opts.initialBackoff
-	for attempt := 0; attempt < opts.maxRetries; attempt++ {
+	for attempt := 0; attempt <= opts.maxRetries; attempt++ {
 		res, err := f()
 		if err == nil {
 			return res, nil
@@ -278,8 +278,8 @@ func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, 
 
 		var tErr TransientError
 		if errors.As(err, &tErr) {
-			if attempt == opts.maxRetries-1 {
-				return res, fmt.Errorf("after %d attempts: %w", opts.maxRetries, err)
+			if attempt == opts.maxRetries {
+				return res, fmt.Errorf("after %d retries: %w", opts.maxRetries, err)
 			}
 			delay := backoff
 			if tErr.RetryAfter > 0 {

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -247,10 +247,12 @@ func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, 
 			if tErr.RetryAfter > 0 {
 				delay = tErr.RetryAfter
 			}
+			timer := time.NewTimer(delay)
 			select {
 			case <-ctx.Done():
+				timer.Stop()
 				return res, ctx.Err()
-			case <-time.After(delay):
+			case <-timer.C:
 				if tErr.RetryAfter == 0 {
 					backoff = min(backoff*2, opts.maxBackoff)
 				}

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -271,8 +271,10 @@ func WithCheckpointRetry(f CheckpointFetcherFunc, opts ...RetryOption) Checkpoin
 // retry retries the function f with exponential backoff up to maxRetries.
 func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, error) {
 	var backoff = opts.initialBackoff
+	var err error
+	var res T
 	for attempt := 0; attempt <= opts.maxRetries; attempt++ {
-		res, err := f()
+		res, err = f()
 		if err == nil {
 			return res, nil
 		}
@@ -280,7 +282,7 @@ func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, 
 		var tErr TransientError
 		if errors.As(err, &tErr) {
 			if attempt == opts.maxRetries {
-				return res, fmt.Errorf("after %d retries: %w", opts.maxRetries, err)
+				break
 			}
 			delay := backoff
 			if tErr.RetryAfter > 0 {
@@ -300,7 +302,7 @@ func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, 
 		}
 		return res, err
 	}
-	return *new(T), fmt.Errorf("max retries reached")
+	return res, fmt.Errorf("after %d retries: %w", opts.maxRetries, err)
 }
 
 // FileFetcher knows how to fetch log artifacts from a filesystem rooted at Root.

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -298,7 +299,9 @@ func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, 
 				return res, ctx.Err()
 			case <-timer.C:
 				if tErr.RetryAfter == 0 {
-					backoff = min(backoff*2, opts.maxBackoff)
+					// Add jitter up to 50% of the current backoff
+					jitter := time.Duration(rand.Int64N(int64(backoff / 2)))
+					backoff = min(backoff*2, opts.maxBackoff) + jitter
 				}
 				continue
 			}

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -78,6 +79,14 @@ func (h *HTTPFetcher) SetAuthorizationHeader(v string) {
 	h.authHeader = v
 }
 
+func isTransientNetworkError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}
+
 func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 	u, err := h.rootURL.Parse(p)
 	if err != nil {
@@ -92,8 +101,10 @@ func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 	}
 	r, err := h.c.Do(req)
 	if err != nil {
-		// Network errors are considered transient
-		return nil, TransientError{Err: err}
+		if isTransientNetworkError(err) {
+			return nil, TransientError{Err: err}
+		}
+		return nil, err
 	}
 	defer func() {
 		// Drain the body to ensure the underlying TCP connection can be returned

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -284,7 +284,7 @@ func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, 
 			}
 			delay := backoff
 			if tErr.RetryAfter > 0 {
-				delay = tErr.RetryAfter
+				delay = min(tErr.RetryAfter, opts.maxBackoff)
 			}
 			timer := time.NewTimer(delay)
 			select {

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -290,7 +290,10 @@ func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, 
 			}
 			delay := backoff
 			if tErr.RetryAfter > 0 {
-				delay = min(tErr.RetryAfter, opts.maxBackoff)
+				if tErr.RetryAfter > opts.maxBackoff {
+					return res, fmt.Errorf("Retry-After %v exceeds maxBackoff %v: %w", tErr.RetryAfter, opts.maxBackoff, err)
+				}
+				delay = tErr.RetryAfter
 			}
 			timer := time.NewTimer(delay)
 			select {

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -132,7 +132,11 @@ func parseRetryAfter(retryAfter string) time.Duration {
 	}
 	d, err := time.Parse(http.TimeFormat, retryAfter)
 	if err == nil {
-		return time.Until(d)
+		dur := time.Until(d)
+		if dur <= 0 {
+			return time.Nanosecond
+		}
+		return dur
 	}
 	s, err := strconv.Atoi(retryAfter)
 	if err == nil {

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"log/slog"
@@ -82,7 +83,19 @@ func (h *HTTPFetcher) SetAuthorizationHeader(v string) {
 func isTransientNetworkError(err error) bool {
 	var netErr net.Error
 	if errors.As(err, &netErr) {
-		return netErr.Timeout()
+		if netErr.Timeout() {
+			return true
+		}
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case syscall.ECONNRESET, syscall.ECONNABORTED, syscall.ECONNREFUSED:
+			return true
+		}
 	}
 	return false
 }
@@ -118,7 +131,14 @@ func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 
 	switch r.StatusCode {
 	case http.StatusOK:
-		return io.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			if isTransientNetworkError(err) {
+				return nil, TransientError{Err: err}
+			}
+			return nil, err
+		}
+		return data, nil
 	case http.StatusNotFound:
 		// Need to return ErrNotExist here, by contract.
 		return nil, fmt.Errorf("get(%q): %w", u.String(), os.ErrNotExist)

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -96,6 +96,10 @@ func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 		return nil, TransientError{Err: err}
 	}
 	defer func() {
+		// Drain the body to ensure the underlying TCP connection can be returned
+		// to the keep-alive pool and reused for future requests.
+		_, _ = io.Copy(io.Discard, r.Body)
+
 		if err := r.Body.Close(); err != nil {
 			slog.ErrorContext(ctx, "resp.Body.Close", slog.Any("error", err))
 		}

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -122,7 +122,8 @@ func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 	defer func() {
 		// Drain the body to ensure the underlying TCP connection can be returned
 		// to the keep-alive pool and reused for future requests.
-		_, _ = io.Copy(io.Discard, r.Body)
+		// Limit the drain to avoid hanging on large or infinite responses.
+		_, _ = io.Copy(io.Discard, io.LimitReader(r.Body, 4096))
 
 		if err := r.Body.Close(); err != nil {
 			slog.ErrorContext(ctx, "resp.Body.Close", slog.Any("error", err))	

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -162,7 +162,7 @@ func parseRetryAfter(retryAfter string) time.Duration {
 	if retryAfter == "" {
 		return 0
 	}
-	d, err := time.Parse(http.TimeFormat, retryAfter)
+	d, err := http.ParseTime(retryAfter)
 	if err == nil {
 		dur := time.Until(d)
 		if dur <= 0 {

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -112,7 +112,7 @@ func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 		_, _ = io.Copy(io.Discard, r.Body)
 
 		if err := r.Body.Close(); err != nil {
-			slog.ErrorContext(ctx, "resp.Body.Close", slog.Any("error", err))
+			slog.ErrorContext(ctx, "resp.Body.Close", slog.Any("error", err))	
 		}
 	}()
 
@@ -151,6 +151,9 @@ func parseRetryAfter(retryAfter string) time.Duration {
 	}
 	s, err := strconv.Atoi(retryAfter)
 	if err == nil {
+		if s <= 0 {
+			return time.Nanosecond
+		}
 		return time.Duration(s) * time.Second
 	}
 	return 0

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -16,19 +16,36 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"strings"
+	"time"
 
 	"log/slog"
 
 	"github.com/transparency-dev/tessera/api/layout"
 	"github.com/transparency-dev/tessera/internal/fetcher"
 )
+
+// TransientError indicates that an error is temporary and the operation can be retried.
+type TransientError struct {
+	Err        error
+	RetryAfter time.Duration // Optional, parsed from header if available
+}
+
+func (e TransientError) Error() string {
+	return fmt.Sprintf("transient error: %v", e.Err)
+}
+
+func (e TransientError) Unwrap() error {
+	return e.Err
+}
 
 // NewHTTPFetcher creates a new HTTPFetcher for the log rooted at the given URL, using
 // the provided HTTP client.
@@ -75,24 +92,49 @@ func (h HTTPFetcher) fetch(ctx context.Context, p string) ([]byte, error) {
 	}
 	r, err := h.c.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("get(%q): %v", u.String(), err)
+		// Network errors are considered transient
+		return nil, TransientError{Err: err}
 	}
-	switch r.StatusCode {
-	case http.StatusOK:
-		// All good, continue below
-	case http.StatusNotFound:
-		// Need to return ErrNotExist here, by contract.
-		return nil, fmt.Errorf("get(%q): %w", u.String(), os.ErrNotExist)
-	default:
-		return nil, fmt.Errorf("get(%q): %v", u.String(), r.StatusCode)
-	}
-
 	defer func() {
 		if err := r.Body.Close(); err != nil {
 			slog.ErrorContext(ctx, "resp.Body.Close", slog.Any("error", err))
 		}
 	}()
-	return io.ReadAll(r.Body)
+
+	switch r.StatusCode {
+	case http.StatusOK:
+		return io.ReadAll(r.Body)
+	case http.StatusNotFound:
+		// Need to return ErrNotExist here, by contract.
+		return nil, fmt.Errorf("get(%q): %w", u.String(), os.ErrNotExist)
+	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		var retryAfter time.Duration
+		if ra := r.Header.Get("Retry-After"); ra != "" {
+			retryAfter = parseRetryAfter(ra)
+		}
+		return nil, TransientError{
+			Err:        fmt.Errorf("get(%q): status %d", u.String(), r.StatusCode),
+			RetryAfter: retryAfter,
+		}
+	default:
+		return nil, fmt.Errorf("get(%q): %v", u.String(), r.StatusCode)
+	}
+}
+
+// parseRetryAfter parses the Retry-After header and returns a time.Duration.
+func parseRetryAfter(retryAfter string) time.Duration {
+	if retryAfter == "" {
+		return 0
+	}
+	d, err := time.Parse(http.TimeFormat, retryAfter)
+	if err == nil {
+		return time.Until(d)
+	}
+	s, err := strconv.Atoi(retryAfter)
+	if err == nil {
+		return time.Duration(s) * time.Second
+	}
+	return 0
 }
 
 func (h HTTPFetcher) ReadCheckpoint(ctx context.Context) ([]byte, error) {
@@ -109,6 +151,111 @@ func (h HTTPFetcher) ReadEntryBundle(ctx context.Context, i uint64, p uint8) ([]
 	return fetcher.PartialOrFullResource(ctx, p, func(ctx context.Context, p uint8) ([]byte, error) {
 		return h.fetch(ctx, layout.EntriesPath(i, p))
 	})
+}
+
+// retryOpts holds the configuration for retry logic.
+type retryOpts struct {
+	maxRetries     int
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+}
+
+// RetryOption is a function that modifies retryOpts.
+type RetryOption func(*retryOpts)
+
+// WithMaxRetries sets the maximum number of retries.
+func WithMaxRetries(n int) RetryOption {
+	return func(o *retryOpts) { o.maxRetries = n }
+}
+
+// WithInitialBackoff sets the initial backoff duration.
+func WithInitialBackoff(d time.Duration) RetryOption {
+	return func(o *retryOpts) { o.initialBackoff = d }
+}
+
+// WithMaxBackoff sets the maximum backoff duration.
+func WithMaxBackoff(d time.Duration) RetryOption {
+	return func(o *retryOpts) { o.maxBackoff = d }
+}
+
+func defaultRetryOpts() retryOpts {
+	return retryOpts{
+		maxRetries:     5,
+		initialBackoff: 100 * time.Millisecond,
+		maxBackoff:     2 * time.Second,
+	}
+}
+
+// WithTileRetry decorates a TileFetcherFunc with retry logic.
+func WithTileRetry(f TileFetcherFunc, opts ...RetryOption) TileFetcherFunc {
+	o := defaultRetryOpts()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
+		return retry(ctx, o, func() ([]byte, error) {
+			return f(ctx, level, index, p)
+		})
+	}
+}
+
+// WithEntryBundleRetry decorates an EntryBundleFetcherFunc with retry logic.
+func WithEntryBundleRetry(f EntryBundleFetcherFunc, opts ...RetryOption) EntryBundleFetcherFunc {
+	o := defaultRetryOpts()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return func(ctx context.Context, bundleIndex uint64, p uint8) ([]byte, error) {
+		return retry(ctx, o, func() ([]byte, error) {
+			return f(ctx, bundleIndex, p)
+		})
+	}
+}
+
+// WithCheckpointRetry decorates a CheckpointFetcherFunc with retry logic.
+func WithCheckpointRetry(f CheckpointFetcherFunc, opts ...RetryOption) CheckpointFetcherFunc {
+	o := defaultRetryOpts()
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return func(ctx context.Context) ([]byte, error) {
+		return retry(ctx, o, func() ([]byte, error) {
+			return f(ctx)
+		})
+	}
+}
+
+// retry retries the function f with exponential backoff up to maxRetries.
+func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, error) {
+	var backoff = opts.initialBackoff
+	for attempt := 0; attempt < opts.maxRetries; attempt++ {
+		res, err := f()
+		if err == nil {
+			return res, nil
+		}
+
+		var tErr TransientError
+		if errors.As(err, &tErr) {
+			if attempt == opts.maxRetries-1 {
+				return res, fmt.Errorf("after %d attempts: %w", opts.maxRetries, err)
+			}
+			delay := backoff
+			if tErr.RetryAfter > 0 {
+				delay = tErr.RetryAfter
+			}
+			select {
+			case <-ctx.Done():
+				return res, ctx.Err()
+			case <-time.After(delay):
+				if tErr.RetryAfter == 0 {
+					backoff = min(backoff*2, opts.maxBackoff)
+				}
+				continue
+			}
+		}
+		return res, err
+	}
+	return *new(T), fmt.Errorf("max retries reached")
 }
 
 // FileFetcher knows how to fetch log artifacts from a filesystem rooted at Root.

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -87,7 +87,7 @@ func isTransientNetworkError(err error) bool {
 			return true
 		}
 	}
-	if errors.Is(err, io.ErrUnexpectedEOF) {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
 	var errno syscall.Errno

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -299,12 +299,12 @@ func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, 
 				return res, ctx.Err()
 			case <-timer.C:
 				if tErr.RetryAfter == 0 {
-					// Add jitter up to 50% of the current backoff
+					nextBackoff := backoff * 2
 					var jitter time.Duration
-					if n := int64(backoff / 2); n > 0 {
+					if n := int64(backoff); n > 0 {
 						jitter = time.Duration(rand.Int64N(n))
 					}
-					backoff = min(backoff*2, opts.maxBackoff) + jitter
+					backoff = min(nextBackoff+jitter, opts.maxBackoff)
 				}
 				continue
 			}

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -81,6 +81,9 @@ func (h *HTTPFetcher) SetAuthorizationHeader(v string) {
 }
 
 func isTransientNetworkError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
 	var netErr net.Error
 	if errors.As(err, &netErr) {
 		if netErr.Timeout() {

--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -300,7 +300,10 @@ func retry[T any](ctx context.Context, opts retryOpts, f func() (T, error)) (T, 
 			case <-timer.C:
 				if tErr.RetryAfter == 0 {
 					// Add jitter up to 50% of the current backoff
-					jitter := time.Duration(rand.Int64N(int64(backoff / 2)))
+					var jitter time.Duration
+					if n := int64(backoff / 2); n > 0 {
+						jitter = time.Duration(rand.Int64N(n))
+					}
 					backoff = min(backoff*2, opts.maxBackoff) + jitter
 				}
 				continue

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -45,6 +45,7 @@ func TestHTTPFetcherRetry(t *testing.T) {
 		retryAfter    string
 		expectedError error
 		wantAttempts  int
+		minDuration   time.Duration
 	}{
 		{
 			name:         "SuccessFirstTry",
@@ -73,6 +74,14 @@ func TestHTTPFetcherRetry(t *testing.T) {
 			responses:    []int{http.StatusTooManyRequests, http.StatusOK},
 			retryAfter:   "1", // 1 second
 			wantAttempts: 2,
+			minDuration:  time.Second,
+		},
+		{
+			name:         "RetryAfterPastDate",
+			responses:    []int{http.StatusTooManyRequests, http.StatusOK},
+			retryAfter:   "Wed, 21 Oct 2015 07:28:00 GMT",
+			wantAttempts: 2,
+			minDuration:  0,
 		},
 	}
 
@@ -129,8 +138,8 @@ func TestHTTPFetcherRetry(t *testing.T) {
 				t.Errorf("got %d attempts, want %d", attempts, tc.wantAttempts)
 			}
 
-			if tc.retryAfter != "" && duration < time.Second {
-				t.Errorf("expected retry delay of at least 1s, took %v", duration)
+			if tc.minDuration > 0 && duration < tc.minDuration {
+				t.Errorf("expected retry delay of at least %v, took %v", tc.minDuration, duration)
 			}
 		})
 	}

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -275,6 +275,16 @@ func TestIsTransientNetworkError(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "ContextCanceled",
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "ContextDeadlineExceeded",
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
 			name: "TimeoutError",
 			err:  myNetError{timeout: true},
 			want: true,

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -61,9 +61,9 @@ func TestHTTPFetcherRetry(t *testing.T) {
 		},
 		{
 			name:          "MaxRetriesExceeded",
-			responses:     []int{http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable},
-			expectedError: errors.New("after 5 attempts"),
-			wantAttempts:  5,
+			responses:     []int{http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable},
+			expectedError: errors.New("after 5 retries"),
+			wantAttempts:  6,
 		},
 		{
 			name:          "NotFoundNoRetry",
@@ -174,9 +174,9 @@ func TestWithTileRetry(t *testing.T) {
 		},
 		{
 			name:          "MaxRetriesExceeded",
-			responses:     []error{TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}},
-			expectedError: errors.New("after 5 attempts"),
-			wantAttempts:  5,
+			responses:     []error{TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}},
+			expectedError: errors.New("after 5 retries"),
+			wantAttempts:  6,
 		},
 		{
 			name:          "NonTransientErrorNoRetry",
@@ -186,10 +186,10 @@ func TestWithTileRetry(t *testing.T) {
 		},
 		{
 			name:          "CustomMaxRetries",
-			responses:     []error{TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}},
+			responses:     []error{TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}},
 			options:       []RetryOption{WithMaxRetries(2)},
-			expectedError: errors.New("after 2 attempts"),
-			wantAttempts:  2,
+			expectedError: errors.New("after 2 retries"),
+			wantAttempts:  3,
 		},
 	}
 

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -92,6 +92,20 @@ func TestHTTPFetcherRetry(t *testing.T) {
 			wantAttempts: 2,
 			minDuration:  0,
 		},
+		{
+			name:         "RetryAfterRFC850",
+			responses:    []int{http.StatusTooManyRequests, http.StatusOK},
+			retryAfter:   "Sunday, 06-Nov-94 08:49:37 GMT",
+			wantAttempts: 2,
+			minDuration:  0,
+		},
+		{
+			name:         "RetryAfterANSIC",
+			responses:    []int{http.StatusTooManyRequests, http.StatusOK},
+			retryAfter:   "Sun Nov  6 08:49:37 1994",
+			wantAttempts: 2,
+			minDuration:  0,
+		},
 	}
 
 	for _, tc := range tests {

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -106,6 +106,13 @@ func TestHTTPFetcherRetry(t *testing.T) {
 			wantAttempts: 2,
 			minDuration:  0,
 		},
+		{
+			name:         "RetryAfterLargeCapped",
+			responses:    []int{http.StatusTooManyRequests, http.StatusOK},
+			retryAfter:   "3600", // 1 hour
+			wantAttempts: 2,
+			minDuration:  2 * time.Second, // Capped at maxBackoff (2s)
+		},
 	}
 
 	for _, tc := range tests {

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -3,7 +3,13 @@ package client
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestFileFetcherContextCancellation(t *testing.T) {
@@ -29,5 +35,178 @@ func TestFileFetcherContextCancellation(t *testing.T) {
 	_, err = f.ReadEntryBundle(ctx, 0, 255)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("ReadEntryBundle: got error %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestHTTPFetcherRetry(t *testing.T) {
+	tests := []struct {
+		name          string
+		responses     []int
+		retryAfter    string
+		expectedError error
+		wantAttempts  int
+	}{
+		{
+			name:         "SuccessFirstTry",
+			responses:    []int{http.StatusOK},
+			wantAttempts: 1,
+		},
+		{
+			name:         "RetryThenSuccess",
+			responses:    []int{http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusOK},
+			wantAttempts: 3,
+		},
+		{
+			name:          "MaxRetriesExceeded",
+			responses:     []int{http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable, http.StatusServiceUnavailable},
+			expectedError: errors.New("after 5 attempts"),
+			wantAttempts:  5,
+		},
+		{
+			name:          "NotFoundNoRetry",
+			responses:     []int{http.StatusNotFound},
+			expectedError: os.ErrNotExist,
+			wantAttempts:  1,
+		},
+		{
+			name:         "RetryAfterRespected",
+			responses:    []int{http.StatusTooManyRequests, http.StatusOK},
+			retryAfter:   "1", // 1 second
+			wantAttempts: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			attempts := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if attempts < len(tc.responses) {
+					status := tc.responses[attempts]
+					attempts++
+					if tc.retryAfter != "" && status == http.StatusTooManyRequests {
+						w.Header().Set("Retry-After", tc.retryAfter)
+					}
+					w.WriteHeader(status)
+					if status == http.StatusOK {
+						w.Write([]byte("data"))
+					}
+					return
+				}
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer server.Close()
+
+			u, _ := url.Parse(server.URL)
+			fetcher, err := NewHTTPFetcher(u, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Decorate the fetch call using the helper
+			decoratedFetch := func(ctx context.Context) ([]byte, error) {
+				return retry(ctx, defaultRetryOpts(), func() ([]byte, error) {
+					return fetcher.fetch(ctx, "/")
+				})
+			}
+
+			ctx := context.Background()
+			
+			startTime := time.Now()
+			_, err = decoratedFetch(ctx)
+			duration := time.Since(startTime)
+
+			if tc.expectedError != nil {
+				if err == nil {
+					t.Errorf("expected error %v, got nil", tc.expectedError)
+				} else if !errors.Is(err, tc.expectedError) && !strings.Contains(err.Error(), tc.expectedError.Error()) {
+					t.Errorf("expected error containing %v, got %v", tc.expectedError, err)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if attempts != tc.wantAttempts {
+				t.Errorf("got %d attempts, want %d", attempts, tc.wantAttempts)
+			}
+
+			if tc.retryAfter != "" && duration < time.Second {
+				t.Errorf("expected retry delay of at least 1s, took %v", duration)
+			}
+		})
+	}
+}
+
+func TestWithTileRetry(t *testing.T) {
+	tests := []struct {
+		name          string
+		responses     []error
+		options       []RetryOption
+		expectedError error
+		wantAttempts  int
+	}{
+		{
+			name:         "SuccessFirstTry",
+			responses:    []error{nil},
+			wantAttempts: 1,
+		},
+		{
+			name:         "RetryThenSuccess",
+			responses:    []error{TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, nil},
+			wantAttempts: 3,
+		},
+		{
+			name:          "MaxRetriesExceeded",
+			responses:     []error{TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}},
+			expectedError: errors.New("after 5 attempts"),
+			wantAttempts:  5,
+		},
+		{
+			name:          "NonTransientErrorNoRetry",
+			responses:     []error{errors.New("fatal")},
+			expectedError: errors.New("fatal"),
+			wantAttempts:  1,
+		},
+		{
+			name:          "CustomMaxRetries",
+			responses:     []error{TransientError{Err: errors.New("temporary")}, TransientError{Err: errors.New("temporary")}},
+			options:       []RetryOption{WithMaxRetries(2)},
+			expectedError: errors.New("after 2 attempts"),
+			wantAttempts:  2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			attempts := 0
+			dummyFetcher := func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
+				if attempts < len(tc.responses) {
+					err := tc.responses[attempts]
+					attempts++
+					if err != nil {
+						return nil, err
+					}
+					return []byte("data"), nil
+				}
+				return nil, errors.New("unexpected call")
+			}
+
+			decorated := WithTileRetry(dummyFetcher, tc.options...)
+
+			_, err := decorated(context.Background(), 0, 0, 0)
+
+			if tc.expectedError != nil {
+				if err == nil {
+					t.Errorf("expected error %v, got nil", tc.expectedError)
+				} else if !strings.Contains(err.Error(), tc.expectedError.Error()) {
+					t.Errorf("expected error containing %v, got %v", tc.expectedError, err)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if attempts != tc.wantAttempts {
+				t.Errorf("got %d attempts, want %d", attempts, tc.wantAttempts)
+			}
+		})
 	}
 }

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -290,6 +290,11 @@ func TestIsTransientNetworkError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "EOF",
+			err:  io.EOF,
+			want: true,
+		},
+		{
 			name: "ConnReset",
 			err:  syscall.ECONNRESET,
 			want: true,

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -107,11 +107,11 @@ func TestHTTPFetcherRetry(t *testing.T) {
 			minDuration:  0,
 		},
 		{
-			name:         "RetryAfterLargeCapped",
-			responses:    []int{http.StatusTooManyRequests, http.StatusOK},
-			retryAfter:   "3600", // 1 hour
-			wantAttempts: 2,
-			minDuration:  2 * time.Second, // Capped at maxBackoff (2s)
+			name:          "RetryAfterExceedsMaxBackoff",
+			responses:     []int{http.StatusTooManyRequests},
+			retryAfter:    "3600", // 1 hour
+			expectedError: errors.New("exceeds maxBackoff"),
+			wantAttempts:  1,
 		},
 	}
 

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -3,11 +3,13 @@ package client
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -260,6 +262,21 @@ func TestIsTransientNetworkError(t *testing.T) {
 			name: "NonTimeoutNetError",
 			err:  myNetError{timeout: false},
 			want: false,
+		},
+		{
+			name: "UnexpectedEOF",
+			err:  io.ErrUnexpectedEOF,
+			want: true,
+		},
+		{
+			name: "ConnReset",
+			err:  syscall.ECONNRESET,
+			want: true,
+		},
+		{
+			name: "ConnRefused",
+			err:  syscall.ECONNREFUSED,
+			want: true,
 		},
 	}
 

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -83,6 +83,13 @@ func TestHTTPFetcherRetry(t *testing.T) {
 			wantAttempts: 2,
 			minDuration:  0,
 		},
+		{
+			name:         "RetryAfterZero",
+			responses:    []int{http.StatusTooManyRequests, http.StatusOK},
+			retryAfter:   "0",
+			wantAttempts: 2,
+			minDuration:  0,
+		},
 	}
 
 	for _, tc := range tests {

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -219,3 +219,48 @@ func TestWithTileRetry(t *testing.T) {
 		})
 	}
 }
+
+type myNetError struct {
+	timeout bool
+}
+
+func (e myNetError) Error() string   { return "error" }
+func (e myNetError) Timeout() bool   { return e.timeout }
+func (e myNetError) Temporary() bool { return false }
+
+func TestIsTransientNetworkError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "NilError",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "GenericError",
+			err:  errors.New("generic error"),
+			want: false,
+		},
+		{
+			name: "TimeoutError",
+			err:  myNetError{timeout: true},
+			want: true,
+		},
+		{
+			name: "NonTimeoutNetError",
+			err:  myNetError{timeout: false},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTransientNetworkError(tc.err); got != tc.want {
+				t.Errorf("isTransientNetworkError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -212,6 +212,12 @@ func TestWithTileRetry(t *testing.T) {
 			expectedError: errors.New("after 2 retries"),
 			wantAttempts:  3,
 		},
+		{
+			name:         "InitialBackoffZero",
+			responses:    []error{TransientError{Err: errors.New("temporary")}, nil},
+			options:      []RetryOption{WithInitialBackoff(0)},
+			wantAttempts: 2,
+		},
 	}
 
 	for _, tc := range tests {

--- a/client/fetcher_test.go
+++ b/client/fetcher_test.go
@@ -88,7 +88,7 @@ func TestHTTPFetcherRetry(t *testing.T) {
 					}
 					w.WriteHeader(status)
 					if status == http.StatusOK {
-						w.Write([]byte("data"))
+						_, _ = w.Write([]byte("data"))
 					}
 					return
 				}


### PR DESCRIPTION
The pull request adds the retry logic for HTTP fetcher. The retry logic allows the following configurations:

- maximum number of retries
- initial backoff duration
- maximum backoff duration

Function Decorator pattern is used with Functional Options Pattern.

The change of the client dependencies will be done in the next pull request.