### PR TITLE
Prevent out-of-range slices in MigrationStorage

### DIFF
--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -629,6 +629,9 @@ func (m *MigrationStorage) fetchLeafHashes(ctx context.Context, from, to, source
 			if err != nil {
 				return fmt.Errorf("bundleHasherFunc for bundle index %d: %v", ri.Index, err)
 			}
+			if len(bh) < int(ri.First+ri.N) {
+				return fmt.Errorf("bundle index %d has fewer entries than expected (%d < %d)", ri.Index, len(bh), ri.First+ri.N)
+			}
 			toBeAdded.Store(ri.Index, bh[ri.First:ri.First+ri.N])
 			return nil
 		})

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -629,8 +629,8 @@ func (m *MigrationStorage) fetchLeafHashes(ctx context.Context, from, to, source
 			if err != nil {
 				return fmt.Errorf("bundleHasherFunc for bundle index %d: %v", ri.Index, err)
 			}
-			if len(bh) < int(ri.First+ri.N) {
-				return fmt.Errorf("bundle index %d has fewer entries than expected (%d < %d)", ri.Index, len(bh), ri.First+ri.N)
+			if l := len(bh); l < int(ri.First+ri.N) {
+				return fmt.Errorf("bundle index %d has fewer entries than expected (%d < %d)", ri.Index, l, ri.First+ri.N)
 			}
 			toBeAdded.Store(ri.Index, bh[ri.First:ri.First+ri.N])
 			return nil

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -1542,8 +1542,8 @@ func (m *MigrationStorage) fetchLeafHashes(ctx context.Context, from, to, source
 			if err != nil {
 				return fmt.Errorf("bundleHasherFunc for bundle index %d: %v", ri.Index, err)
 			}
-			if len(bh) < int(ri.First+ri.N) {
-				return fmt.Errorf("bundle index %d has fewer entries than expected (%d < %d)", ri.Index, len(bh), ri.First+ri.N)
+			if l := len(bh); l < int(ri.First+ri.N) {
+				return fmt.Errorf("bundle index %d has fewer entries than expected (%d < %d)", ri.Index, l, ri.First+ri.N)
 			}
 			toBeAdded.Store(ri.Index, bh[ri.First:ri.First+ri.N])
 			return nil

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -1542,6 +1542,9 @@ func (m *MigrationStorage) fetchLeafHashes(ctx context.Context, from, to, source
 			if err != nil {
 				return fmt.Errorf("bundleHasherFunc for bundle index %d: %v", ri.Index, err)
 			}
+			if len(bh) < int(ri.First+ri.N) {
+				return fmt.Errorf("bundle index %d has fewer entries than expected (%d < %d)", ri.Index, len(bh), ri.First+ri.N)
+			}
 			toBeAdded.Store(ri.Index, bh[ri.First:ri.First+ri.N])
 			return nil
 		})

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -1132,6 +1132,9 @@ func (m *MigrationStorage) fetchLeafHashes(ctx context.Context, from, to, source
 		if err != nil {
 			return nil, fmt.Errorf("bundleHasherFunc for bundle index %d: %v", ri.Index, err)
 		}
+		if len(bh) < int(ri.First+ri.N) {
+			return nil, fmt.Errorf("bundle index %d has fewer entries than expected (%d < %d)", ri.Index, len(bh), ri.First+ri.N)
+		}
 		lh = append(lh, bh[ri.First:ri.First+ri.N]...)
 		n++
 		if n >= maxBundles {

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -1132,8 +1132,8 @@ func (m *MigrationStorage) fetchLeafHashes(ctx context.Context, from, to, source
 		if err != nil {
 			return nil, fmt.Errorf("bundleHasherFunc for bundle index %d: %v", ri.Index, err)
 		}
-		if len(bh) < int(ri.First+ri.N) {
-			return nil, fmt.Errorf("bundle index %d has fewer entries than expected (%d < %d)", ri.Index, len(bh), ri.First+ri.N)
+		if l := len(bh); l < int(ri.First+ri.N) {
+			return nil, fmt.Errorf("bundle index %d has fewer entries than expected (%d < %d)", ri.Index, l, ri.First+ri.N)
 		}
 		lh = append(lh, bh[ri.First:ri.First+ri.N]...)
 		n++


### PR DESCRIPTION
**Problem**
If the bundle fetched from storage is corrupted, incomplete, or simply shorter than what `layout.Range` expects for that index, `bh` will have fewer elements than `ri.First + ri.N`. This will trigger a slice bounds out-of-range panic.

**Solution**
This pull request adds a bounds check in `fetchLeafHashes` across AWS, GCP, and POSIX backends to prevent a potential slice out-of-bounds panic when processing truncated entry bundles during log migration.