### PR TITLE
Fix fsck not exiting in TUI mode

### DIFF
--- a/cmd/fsck/main.go
+++ b/cmd/fsck/main.go
@@ -98,19 +98,19 @@ func main() {
 
 		checkResult <- err
 		close(checkResult)
+		cancel() // We're done, so we can exit.
 	}()
 
 	if *ui {
 		if err := tui.RunApp(ctx, f); err != nil {
 			slog.ErrorContext(ctx, "App exited", slog.Any("error", err))
 		}
-		// User may have exited the UI, cancel the context to signal to everything else.
+		// User may have exited the UI, cancel the context to signal to the async fsck process too.
 		cancel()
 	} else {
 		for {
 			select {
 			case err := <-checkResult:
-				cancel()
 				if err != nil {
 					slog.ErrorContext(ctx, "fsck failed", slog.Any("error", err))
 					os.Exit(1)


### PR DESCRIPTION
Addresses the issue where `fsck` doesn't exit after completion in TUI mode.

Fixes #962.