### PR TITLE
[POSIX] Fixed symlinking partial tiles

### DIFF
--- a/api/layout/paths.go
+++ b/api/layout/paths.go
@@ -122,7 +122,7 @@ func EntriesPath(n uint64, p uint8) string {
 	return fmt.Sprintf("tile/entries/%s", NWithSuffix(0, n, p))
 }
 
-// TilePath builds the path to the subtree tile with the given level and index in tile space.
+// TilePath builds the relative path to the subtree tile with the given level and index in tile space.
 // If p > 0 the path represents a partial tile.
 func TilePath(tileLevel, tileIndex uint64, p uint8) string {
 	return fmt.Sprintf("tile/%d/%s", tileLevel, NWithSuffix(tileLevel, tileIndex, p))

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -511,23 +511,36 @@ func (lrs *logResourceStorage) writeTile(ctx context.Context, level, index uint6
 		}
 
 		if partial == 0 {
-			partials, err := filepath.Glob(fmt.Sprintf("%s.p/*", tPath))
+			// If this is a full tile, replace all partial tiles with symlinks to the new full tile
+			fullTPath := filepath.Join(lrs.s.cfg.Path, tPath)
+			partials, err := filepath.Glob(fmt.Sprintf("%s.p/*", fullTPath))
 			if err != nil {
 				return fmt.Errorf("failed to list partial tiles for clean up; %w", err)
 			}
-			// Clean up old partial tiles by symlinking them to the new full tile.
-			for _, p := range partials {
-				slog.DebugContext(ctx, "relink partial", slog.String("p", p), slog.String("tpath", tPath))
-				// We have to do a little dance here to get POSIX atomicity:
-				// 1. Create a new temporary symlink to the full tile
-				// 2. Rename the temporary symlink over the top of the old partial tile
-				tmp := fmt.Sprintf("%s.link", tPath)
-				_ = os.Remove(tmp)
-				if err := os.Symlink(tPath, tmp); err != nil {
-					return fmt.Errorf("failed to create temp link to full tile: %w", err)
-				}
-				if err := os.Rename(tmp, p); err != nil {
-					return fmt.Errorf("failed to rename temp link over partial tile: %w", err)
+			if len(partials) > 0 {
+				// This tmp file is where the symlink that will be used to link each partial to full is created.
+				// Note that this is created in the parent directory (by the full tiles), and then renamed/moved to the partial dir.
+				tmp := fmt.Sprintf("%s.link", fullTPath)
+				defer func() {
+					_ = os.Remove(tmp)
+				}()
+				// Clean up old partial tiles by symlinking them to the new full tile.
+				for _, p := range partials {
+					slog.DebugContext(ctx, "relink partial", slog.String("p", p), slog.String("tpath", tPath))
+					// We have to do a little dance here to get POSIX atomicity:
+					// 1. Create a new temporary symlink to the full tile
+					// 2. Rename the temporary symlink over the top of the old partial tile
+					_ = os.Remove(tmp)
+					target, err := filepath.Rel(filepath.Dir(p), fullTPath)
+					if err != nil {
+						return fmt.Errorf("failed to calculate relative path for symlink: %w", err)
+					}
+					if err := os.Symlink(target, tmp); err != nil {
+						return fmt.Errorf("failed to create temp link to full tile: %w", err)
+					}
+					if err := os.Rename(tmp, p); err != nil {
+						return fmt.Errorf("failed to rename temp link over partial tile: %w", err)
+					}
 				}
 			}
 		}

--- a/storage/posix/files_test.go
+++ b/storage/posix/files_test.go
@@ -456,3 +456,83 @@ func defaultMerkleLeafHasher(bundle []byte) ([][]byte, error) {
 	}
 	return r, nil
 }
+
+func TestWriteTileSymlinks(t *testing.T) {
+	ctx := t.Context()
+
+	// Helper to check if a file path is a symlink.
+	isSymlink := func(p string) bool {
+		fi, err := os.Lstat(p)
+		if err != nil {
+			return false
+		}
+		return fi.Mode()&os.ModeSymlink != 0
+	}
+
+	t.Run("relative glob failure", func(t *testing.T) {
+		tempDir := t.TempDir()
+		s := &Storage{
+			cfg: Config{
+				HTTPClient: http.DefaultClient,
+				Path:       tempDir,
+			},
+		}
+		lrs := &logResourceStorage{
+			s:           s,
+			entriesPath: tessera.NewAppendOptions().EntriesPath(),
+		}
+
+		// 1. Write a partial tile
+		if err := lrs.writeTile(ctx, 0, 0, 1, []byte("partial")); err != nil {
+			t.Fatalf("writeTile (partial): %v", err)
+		}
+
+		// 2. Write the full tile
+		if err := lrs.writeTile(ctx, 0, 0, 0, []byte("full")); err != nil {
+			t.Fatalf("writeTile (full): %v", err)
+		}
+
+		partialPath := filepath.Join(tempDir, layout.TilePath(0, 0, 1))
+		if !isSymlink(partialPath) {
+			t.Fatalf("partial tile was not converted to a symlink (still a regular file)")
+		}
+	})
+
+	t.Run("incorrect symlink target", func(t *testing.T) {
+		tempDir := t.TempDir()
+		s := &Storage{
+			cfg: Config{
+				HTTPClient: http.DefaultClient,
+				Path:       tempDir,
+			},
+		}
+		lrs := &logResourceStorage{
+			s:           s,
+			entriesPath: tessera.NewAppendOptions().EntriesPath(),
+		}
+
+		// 1. Write a partial tile
+		if err := lrs.writeTile(ctx, 0, 0, 1, []byte("partial")); err != nil {
+			t.Fatalf("writeTile (partial): %v", err)
+		}
+
+		// 2. Write the full tile
+		if err := lrs.writeTile(ctx, 0, 0, 0, []byte("full")); err != nil {
+			t.Fatalf("writeTile (full): %v", err)
+		}
+
+		partialPath := filepath.Join(tempDir, layout.TilePath(0, 0, 1))
+		if !isSymlink(partialPath) {
+			t.Fatalf("expected partial tile to be a symlink")
+		}
+
+		// Try reading the file contents via the symlink.
+		content, err := os.ReadFile(partialPath)
+		if err != nil {
+			t.Fatalf("symlink is broken: %v", err)
+		}
+		if string(content) != "full" {
+			t.Fatalf("expected symlink to resolve to full tile content 'full', got %q", string(content))
+		}
+	})
+}


### PR DESCRIPTION
The POSIX storage driver in `writeTile` cleanup failed to clean up old partial tiles due to two path-resolution bugs:
 1. it ran `filepath.Glob` using relative tile paths, causing searches to resolve relative to the process's current working directory (CWD) instead of the log storage root
 2. it created symlinks pointing to `tPath` (e.g., `tile/0/000`), which became broken once renamed into the `.p/` subdirectory (resolving as `tile/0/000.p/tile/0/000`).

Fixed these bugs by prepending the storage root to all glob and temp paths to ensure CWD independence, calculating the correct relative target pointing from the symlink directory to the full tile using `filepath.Rel`.
