### PR TITLE
[POSIX] Use flock instead of fcntl

### DIFF
--- a/storage/posix/README.md
+++ b/storage/posix/README.md
@@ -34,7 +34,6 @@ of actions we can avoid corrupt or partially written files being part of the tre
 1. The storage library batches these entries up in memory, and, after a configurable period of time has elapsed
    or the batch reaches a configurable size threshold, the batch is sequenced and appended to the tree:
    1. An advisory lock is taken on `.state/treeState.lock` file.
-      This helps prevent multiple frontends from stepping on each other, but isn't necessary for safety.
    1. Flushed entries are assigned contiguous sequence numbers, and written out into entry bundle files.
    1. Integrate newly added leaves into Merkle tree, and write tiles out as files.
    1. Update `./state/treeState` file with the new size & root hash.

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -217,8 +217,8 @@ func (s *Storage) lockFile(ctx context.Context, p string) (func() error, error) 
 		for {
 			if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != syscall.EINTR {
 				if err != nil {
-					_ = f.Close()
-					return nil, err
+					errClose := f.Close()
+					return nil, errors.Join(err, errClose)
 				}
 				span.AddEvent("Lock taken")
 				posixOpsHistogram.Record(ctx, time.Since(now).Milliseconds(), metric.WithAttributes(opNameKey.String(fmt.Sprintf("lock-%s", p))))

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"net/http"
 	"os"
@@ -208,30 +207,28 @@ func (s *Storage) lockFile(ctx context.Context, p string) (func() error, error) 
 
 		span.AddEvent("Open file")
 		p = filepath.Join(s.cfg.Path, stateDir, p)
-		f, err := os.OpenFile(p, syscall.O_CREAT|syscall.O_RDWR|syscall.O_CLOEXEC, filePerm)
+		f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR, filePerm)
 		if err != nil {
 			return nil, err
 		}
 
-		flockT := syscall.Flock_t{
-			Type:   syscall.F_WRLCK,
-			Whence: io.SeekStart,
-			Start:  0,
-			Len:    0,
-		}
-		// Keep trying until we manage to get an answer without being interrupted.
+		// Keep trying until we manage to get a lock without being interrupted.
 		span.AddEvent("Lock attempt")
 		for {
-			if err := syscall.FcntlFlock(f.Fd(), syscall.F_SETLKW, &flockT); err != syscall.EINTR {
-				if err == nil {
-					span.AddEvent("Lock taken")
-					posixOpsHistogram.Record(ctx, time.Since(now).Milliseconds(), metric.WithAttributes(opNameKey.String(fmt.Sprintf("lock-%s", p))))
+			if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != syscall.EINTR {
+				if err != nil {
+					_ = f.Close()
+					return nil, err
 				}
+				span.AddEvent("Lock taken")
+				posixOpsHistogram.Record(ctx, time.Since(now).Milliseconds(), metric.WithAttributes(opNameKey.String(fmt.Sprintf("lock-%s", p))))
 				c := func() error {
 					span.AddEvent("Lock released")
-					return f.Close()
+					errFlock := syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+					errClose := f.Close()
+					return errors.Join(errFlock, errClose)
 				}
-				return c, err
+				return c, nil
 			}
 		}
 	})

--- a/storage/posix/files_test.go
+++ b/storage/posix/files_test.go
@@ -560,3 +560,129 @@ func TestCreateTemp_ErrorReturns(t *testing.T) {
 		t.Fatal("Test timed out: createTemp is likely in an infinite loop")
 	}
 }
+
+func TestFlockLockingCorrectness(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+
+	// Create the state directory where locks are placed
+	if err := os.MkdirAll(filepath.Join(dir, ".state"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	s1 := &Storage{
+		cfg: Config{
+			HTTPClient: http.DefaultClient,
+			Path:       dir,
+		},
+	}
+	s2 := &Storage{
+		cfg: Config{
+			HTTPClient: http.DefaultClient,
+			Path:       dir,
+		},
+	}
+
+	lockName := "test.lock"
+	outputPath := filepath.Join(dir, "output.txt")
+
+	startedA := make(chan struct{})
+	proceedA := make(chan struct{})
+	tryingB := make(chan struct{})
+	doneB := make(chan struct{})
+
+	// Worker A
+	go func() {
+		unlock1, err := s1.lockFile(ctx, lockName)
+		if err != nil {
+			t.Errorf("s1.lockFile failed: %v", err)
+			return
+		}
+		close(startedA)
+		<-proceedA
+
+		// Append "A"
+		f, err := os.OpenFile(outputPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			t.Errorf("Worker A failed to open output file: %v", err)
+			_ = unlock1()
+			return
+		}
+		if _, err := f.WriteString("A\n"); err != nil {
+			t.Errorf("Worker A failed to write output: %v", err)
+		}
+		_ = f.Close()
+		_ = unlock1()
+	}()
+
+	// Worker B
+	go func() {
+		<-startedA
+		close(tryingB)
+		unlock2, err := s2.lockFile(ctx, lockName)
+		if err != nil {
+			t.Errorf("s2.lockFile failed: %v", err)
+			return
+		}
+		defer func() {
+			_ = unlock2()
+			close(doneB)
+		}()
+
+		// Append "B"
+		f, err := os.OpenFile(outputPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			t.Errorf("Worker B failed to open output file: %v", err)
+			return
+		}
+		if _, err := f.WriteString("B\n"); err != nil {
+			t.Errorf("Worker B failed to write output: %v", err)
+		}
+		_ = f.Close()
+	}()
+
+	// Coordinator
+	select {
+	case <-startedA:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Worker A failed to start and lock")
+	}
+
+	select {
+	case <-tryingB:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Worker B failed to start")
+	}
+
+	// Sleep briefly to allow Worker B to reach the lockFile call.
+	// Under BSD flock, Worker B MUST block and should not finish yet.
+	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-doneB:
+		t.Fatal("Worker B finished prematurely; lock did not block same-process concurrent access")
+	default:
+		// Expected: Worker B is blocked waiting for Worker A to release the lock.
+	}
+
+	// Let Worker A proceed and unlock
+	close(proceedA)
+
+	// Worker B should now unblock, acquire the lock, write "B", and finish.
+	select {
+	case <-doneB:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Worker B timed out waiting to acquire lock")
+	}
+
+	// Verify the final write sequence was correct: A then B
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read output file: %v", err)
+	}
+
+	expected := "A\nB\n"
+	if string(content) != expected {
+		t.Fatalf("expected output file to contain %q, got %q (serialization failed)", expected, string(content))
+	}
+}


### PR DESCRIPTION
BSD flock locks are associated with the open file description rather than the PID, which prevents different file descriptors in the same process from concurrently acquiring the lock. This avoids a silent-release vulnerability where closing any file descriptor to the lock file in the process immediately drops the lock for all other descriptors.

This doesn't fix any immediate known issues. However, it does make things less brittle. Should we change which files are written from different goroutines in the future, this will protect against multiple workers ignoring each other's locks.

It also avoids a risk that a library user could create 2 instances of a POSIX storage backed by the same directory. Previously these would have ignored each other's locks, but now they will respect them.
