### PR TITLE
[POSIX] Don't loop forever creating temp files

### DIFF
--- a/storage/posix/file_ops.go
+++ b/storage/posix/file_ops.go
@@ -89,7 +89,7 @@ func mkdirAll(name string, perm os.FileMode) error {
 		return syncDir(dir, func() error {
 			// We'll see ErrNotExist if the final entry in the requested path doesn't exist,
 			// so we simply attempt to create it in here.
-			// 
+			//
 			// Ignore ErrExist as that just means someone else raced us and got there first.
 			if err := os.Mkdir(name, perm); err != nil && !errors.Is(err, os.ErrExist) {
 				return fmt.Errorf("%q: %w", name, err)
@@ -176,11 +176,13 @@ func createTemp(prefix string, d []byte) (name string, err error) {
 		f, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL|os.O_SYNC, filePerm)
 		if err == nil {
 			break
-		} else if os.IsExist(err) {
+		} else if errors.Is(err, os.ErrExist) {
 			if try++; try < 10000 {
 				continue
 			}
 			return "", &os.PathError{Op: "createtemp", Path: prefix + "*", Err: os.ErrExist}
+		} else {
+			return "", err
 		}
 	}
 

--- a/storage/posix/files_test.go
+++ b/storage/posix/files_test.go
@@ -536,3 +536,27 @@ func TestWriteTileSymlinks(t *testing.T) {
 		}
 	})
 }
+
+func TestCreateTemp_ErrorReturns(t *testing.T) {
+	tempDir := t.TempDir()
+	nonExistentDir := filepath.Join(tempDir, "nonexistent-subdir")
+	prefix := filepath.Join(nonExistentDir, "prefix")
+
+	done := make(chan struct{})
+	var err error
+	var name string
+
+	go func() {
+		name, err = createTemp(prefix, []byte("test data"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if err == nil {
+			t.Errorf("expected error opening file in non-existent directory, got nil (file: %s)", name)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Test timed out: createTemp is likely in an infinite loop")
+	}
+}


### PR DESCRIPTION
If the file creation failed for any reason other than the file existing, this would get stuck in an infinite loop. We now return immediately with the error.
