### PR TITLE
Implement tlog-mirror client `parseConflict` function

### DIFF
--- a/client/mirror/client.go
+++ b/client/mirror/client.go
@@ -19,7 +19,7 @@
 package mirror
 
 import (
-	"bufio"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/base64"
@@ -156,43 +156,28 @@ func (e ErrConflict) Error() string {
 //   - The next entry, in decimal
 //   - An opaque, possibly zero length, ticket value, encoded in base64
 func parseConflict(r io.Reader) error {
-	scanner := bufio.NewScanner(r)
-
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("error reading pending tree size: %w", err)
-		}
-		return errors.New("missing pending tree size")
-	}
-	pendingSize, err := strconv.ParseUint(scanner.Text(), 10, 64)
+	all, err := io.ReadAll(&io.LimitedReader{N: 10 << 10, R: r})
 	if err != nil {
-		return fmt.Errorf("invalid pending tree size %q: %w", scanner.Text(), err)
+		return err
 	}
 
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("error reading next entry: %w", err)
-		}
-		return errors.New("missing next entry")
+	bits := bytes.Split(all, []byte("\n"))
+	if len(bits) != 4 {
+		return fmt.Errorf("got %d fields, want 4", len(bits))
 	}
-	nextEntry, err := strconv.ParseUint(scanner.Text(), 10, 64)
+	pendingSize, err := strconv.ParseUint(string(bits[0]), 10, 64)
 	if err != nil {
-		return fmt.Errorf("invalid next entry %q: %w", scanner.Text(), err)
+		return fmt.Errorf("invalid pending tree size %q: %w", bits[0], err)
 	}
 
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return fmt.Errorf("error reading ticket: %w", err)
-		}
-		return errors.New("missing ticket")
+	nextEntry, err := strconv.ParseUint(string(bits[1]), 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid next entry %q: %w", bits[1], err)
 	}
-	ticket, err := base64.StdEncoding.DecodeString(scanner.Text())
+
+	ticket, err := base64.StdEncoding.DecodeString(string(bits[2]))
 	if err != nil {
 		return fmt.Errorf("invalid base64 ticket: %w", err)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("error reading conflict body: %w", err)
 	}
 
 	return ErrConflict{

--- a/client/mirror/client.go
+++ b/client/mirror/client.go
@@ -19,13 +19,16 @@
 package mirror
 
 import (
+	"bufio"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/transparency-dev/tessera/client"
 )
@@ -153,9 +156,50 @@ func (e ErrConflict) Error() string {
 //   - The next entry, in decimal
 //   - An opaque, possibly zero length, ticket value, encoded in base64
 func parseConflict(r io.Reader) error {
-	// TODO(roger2hk): Implement this.
+	scanner := bufio.NewScanner(r)
 
-	return errors.New("TODO")
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("error reading pending tree size: %w", err)
+		}
+		return errors.New("missing pending tree size")
+	}
+	pendingSize, err := strconv.ParseUint(scanner.Text(), 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid pending tree size %q: %w", scanner.Text(), err)
+	}
+
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("error reading next entry: %w", err)
+		}
+		return errors.New("missing next entry")
+	}
+	nextEntry, err := strconv.ParseUint(scanner.Text(), 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid next entry %q: %w", scanner.Text(), err)
+	}
+
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("error reading ticket: %w", err)
+		}
+		return errors.New("missing ticket")
+	}
+	ticket, err := base64.StdEncoding.DecodeString(scanner.Text())
+	if err != nil {
+		return fmt.Errorf("invalid base64 ticket: %w", err)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading conflict body: %w", err)
+	}
+
+	return ErrConflict{
+		PendingSize: pendingSize,
+		NextEntry:   nextEntry,
+		Ticket:      ticket,
+	}
 }
 
 // pushEntries streams entry packages and their proofs to the mirror's /add-entries endpoint.

--- a/client/mirror/client_test.go
+++ b/client/mirror/client_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestParseConflict(t *testing.T) {
+	for _, tc := range []struct {
+		desc    string
+		body    string
+		wantErr bool
+		want    ErrConflict
+	}{
+		{
+			desc: "valid conflict with ticket",
+			body: "123\n456\ndGlja2V0LXZhbHVl\n", // dGlja2V0LXZhbHVl is base64 for "ticket-value"
+			want: ErrConflict{
+				PendingSize: 123,
+				NextEntry:   456,
+				Ticket:      []byte("ticket-value"),
+			},
+		},
+		{
+			desc: "valid conflict with empty ticket",
+			body: "999\n1000\n\n",
+			want: ErrConflict{
+				PendingSize: 999,
+				NextEntry:   1000,
+				Ticket:      []byte{},
+			},
+		},
+		{
+			desc: "missing newline at the end",
+			body: "123\n456\ndGlja2V0LXZhbHVl",
+			want: ErrConflict{
+				PendingSize: 123,
+				NextEntry:   456,
+				Ticket:      []byte("ticket-value"),
+			},
+		},
+		{
+			desc:    "invalid pending size",
+			body:    "abc\n456\ndGlja2V0\n",
+			wantErr: true,
+		},
+		{
+			desc:    "invalid next entry",
+			body:    "123\nxyz\ndGlja2V0\n",
+			wantErr: true,
+		},
+		{
+			desc:    "invalid base64 ticket",
+			body:    "123\n456\nnot-base64-%\n",
+			wantErr: true,
+		},
+		{
+			desc:    "too few lines",
+			body:    "123\n456\n",
+			wantErr: true,
+		},
+		{
+			desc:    "empty body",
+			body:    "",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := parseConflict(bytes.NewBufferString(tc.body))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseConflict() succeeded, want error")
+				}
+				var ec ErrConflict
+				if errors.As(err, &ec) {
+					t.Fatalf("parseConflict() returned ErrConflict %v, want parsing error", ec)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("parseConflict() returned nil, want ErrConflict")
+			}
+			var ec ErrConflict
+			if !errors.As(err, &ec) {
+				t.Fatalf("parseConflict() returned error %v, want ErrConflict", err)
+			}
+			if ec.PendingSize != tc.want.PendingSize {
+				t.Errorf("PendingSize = %d, want %d", ec.PendingSize, tc.want.PendingSize)
+			}
+			if ec.NextEntry != tc.want.NextEntry {
+				t.Errorf("NextEntry = %d, want %d", ec.NextEntry, tc.want.NextEntry)
+			}
+			if !bytes.Equal(ec.Ticket, tc.want.Ticket) {
+				t.Errorf("Ticket = %q, want %q", string(ec.Ticket), string(tc.want.Ticket))
+			}
+		})
+	}
+}

--- a/client/mirror/client_test.go
+++ b/client/mirror/client_test.go
@@ -46,13 +46,9 @@ func TestParseConflict(t *testing.T) {
 			},
 		},
 		{
-			desc: "missing newline at the end",
-			body: "123\n456\ndGlja2V0LXZhbHVl",
-			want: ErrConflict{
-				PendingSize: 123,
-				NextEntry:   456,
-				Ticket:      []byte("ticket-value"),
-			},
+			desc:    "missing newline at the end",
+			body:    "123\n456\ndGlja2V0LXZhbHVl",
+			wantErr: true,
 		},
 		{
 			desc:    "invalid pending size",


### PR DESCRIPTION
Towards https://github.com/transparency-dev/tessera/issues/945.