### PR TITLE
Add mirror multiplexer

### DIFF
--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -42,8 +42,8 @@ const (
 
 // Mirror is the interface that the handler uses to interact with the mirror's state.
 type Mirror interface {
-	AddCheckpoint(ctx context.Context, oldSize uint64, proof [][]byte, cp []byte) error
-	AddEntries(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error)
+	AddCheckpoint(ctx context.Context, origin string, oldSize uint64, proof [][]byte, cp []byte) error
+	AddEntries(ctx context.Context, origin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error)
 }
 
 // New returns a new http.Handler for the mirror service.
@@ -109,12 +109,13 @@ func addCheckpoint(m Mirror) http.HandlerFunc {
 			return
 		}
 
-		if _, _, _, err := parse.CheckpointUnsafe(cp); err != nil {
+		// 4. Extract the origin from the checkpoint and pass the request to the backend to take action.
+		origin, _, _, err := parse.CheckpointUnsafe(cp)
+		if err != nil {
 			http.Error(w, fmt.Sprintf("invalid checkpoint: %v", err), http.StatusBadRequest)
 			return
 		}
-
-		if err := m.AddCheckpoint(r.Context(), oldSize, proof, cp); err != nil {
+		if err := m.AddCheckpoint(r.Context(), origin, oldSize, proof, cp); err != nil {
 			slog.ErrorContext(r.Context(), "AddCheckpoint failed", slog.Any("error", err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -140,7 +141,7 @@ func addEntries(m Mirror) http.HandlerFunc {
 
 		cosigs, err := m.AddEntries(r.Context(), req.logOrigin, req.uploadStart, req.uploadEnd, req.ticket, req.NextPackage)
 		if err != nil {
-			// TODO(al): Handle Conflict (409) if it's a conflict error.
+			// TODO(al): Handle various errors and respond accordingly.
 			slog.ErrorContext(r.Context(), "AddEntries failed", slog.Any("error", err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -28,13 +28,13 @@ import (
 )
 
 type mockMirror struct {
-	addCheckpointFunc func(ctx context.Context, oldSize uint64, proof [][]byte, cp []byte) error
+	addCheckpointFunc func(ctx context.Context, logOrigin string, oldSize uint64, proof [][]byte, cp []byte) error
 	addEntriesFunc    func(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error)
 }
 
-func (m *mockMirror) AddCheckpoint(ctx context.Context, oldSize uint64, proof [][]byte, cp []byte) error {
+func (m *mockMirror) AddCheckpoint(ctx context.Context, logOrigin string, oldSize uint64, proof [][]byte, cp []byte) error {
 	if m.addCheckpointFunc != nil {
-		return m.addCheckpointFunc(ctx, oldSize, proof, cp)
+		return m.addCheckpointFunc(ctx, logOrigin, oldSize, proof, cp)
 	}
 	return nil
 }
@@ -50,7 +50,7 @@ func TestAddCheckpoint(t *testing.T) {
 	const cpOld = 100
 
 	mock := &mockMirror{
-		addCheckpointFunc: func(ctx context.Context, oldSize uint64, proof [][]byte, cp []byte) error {
+		addCheckpointFunc: func(ctx context.Context, logOrigin string, oldSize uint64, proof [][]byte, cp []byte) error {
 			if oldSize != cpOld {
 				return fmt.Errorf("want oldSize %d, got %d", cpOld, oldSize)
 			}

--- a/cmd/mtc/mirror/internal/mirror/mirror.go
+++ b/cmd/mtc/mirror/internal/mirror/mirror.go
@@ -16,13 +16,16 @@ package mirror
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
+	"sync"
 )
 
-// Mirror is a placeholder. TBD where this actually lives, and how much is inside a storage lifecycle.
-type Mirror struct {
-}
+var (
+	// ErrUnknownLog is returned when a requested log is unknown to the mirror.
+	ErrUnknownLog = errors.New("unknown log origin")
+)
 
 // Package represents a single package of entries and its subtree consistency proof.
 type Package struct {
@@ -30,13 +33,65 @@ type Package struct {
 	Proof   [][]byte
 }
 
-func (m *Mirror) AddCheckpoint(ctx context.Context, oldSize uint64, proof [][]byte, cpRaw []byte) error {
-	slog.InfoContext(ctx, "AddCheckpoint", slog.Uint64("old_size", oldSize), slog.Int("proof_len", len(proof)), slog.String("cp", string(cpRaw)))
+// New creates a new Mirror.
+//
+// TODO(al): Add some way to configure and create targets.
+func New() *Mirror {
+	return &Mirror{
+		targets: make(map[string]*target),
+	}
+}
+
+// Mirror is the backend for the tlog-mirror HTTP service.
+//
+// Mirror is mostly a multiplexer over the various log targets. It knows about
+// the configured logs and routes requests to the appropriate target.
+type Mirror struct {
+	lock    sync.RWMutex
+	targets map[string]*target
+}
+
+func (m *Mirror) AddCheckpoint(ctx context.Context, origin string, oldSize uint64, proof [][]byte, cpRaw []byte) error {
+	t, err := m.target(origin)
+	if err != nil {
+		return err
+	}
+	return t.AddCheckpoint(ctx, oldSize, proof, cpRaw)
+}
+
+func (m *Mirror) AddEntries(ctx context.Context, origin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*Package, error)) ([]byte, error) {
+	t, err := m.target(origin)
+	if err != nil {
+		return nil, err
+	}
+	return t.AddEntries(ctx, uploadStart, uploadEnd, ticket, next)
+}
+
+// target returns the target for the given origin, or ErrUnknownLog if it doesn't exist.
+func (m *Mirror) target(origin string) (*target, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	r, ok := m.targets[origin]
+	if !ok {
+		return nil, ErrUnknownLog
+	}
+	return r, nil
+}
+
+// target represents a single log that the mirror is configured to maintain.
+type target struct {
+	origin string
+	// TODO: MirrorLifecycle
+}
+
+
+func (t *target) AddCheckpoint(ctx context.Context, oldSize uint64, proof [][]byte, cpRaw []byte) error {
+	slog.InfoContext(ctx, "AddCheckpoint", slog.String("origin", t.origin), slog.Uint64("old_size", oldSize), slog.Int("proof_len", len(proof)), slog.String("cp", string(cpRaw)))
 	return nil
 }
 
-func (m *Mirror) AddEntries(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*Package, error)) ([]byte, error) {
-	slog.InfoContext(ctx, "AddEntries", slog.String("origin", logOrigin), slog.Uint64("start", uploadStart), slog.Uint64("end", uploadEnd))
+func (t *target) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*Package, error)) ([]byte, error) {
+	slog.InfoContext(ctx, "AddEntries", slog.String("origin", t.origin), slog.Uint64("start", uploadStart), slog.Uint64("end", uploadEnd))
 
 	// Drain the packages
 	for {


### PR DESCRIPTION
This PR introduces a thin multiplexing layer inside the mirror, based on the requested log origin.

This is intended to allow a single deployment to manage multiple mirrored trees.

Towards #945 