### PR TITLE
Add MirrorLifecycle outline

### DIFF
--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -28,7 +28,7 @@ import (
 
 	"log/slog"
 
-	"github.com/transparency-dev/tessera/cmd/mtc/mirror/internal/mirror"
+	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/internal/parse"
 )
 
@@ -42,8 +42,8 @@ const (
 
 // Mirror is the interface that the handler uses to interact with the mirror's state.
 type Mirror interface {
-	AddCheckpoint(ctx context.Context, origin string, oldSize uint64, proof [][]byte, cp []byte) error
-	AddEntries(ctx context.Context, origin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error)
+	AddCheckpoint(ctx context.Context, origin string, oldSize uint64, proof [][]byte, cp []byte) ([]byte, uint64, error)
+	AddEntries(ctx context.Context, origin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error)
 }
 
 // New returns a new http.Handler for the mirror service.
@@ -115,7 +115,7 @@ func addCheckpoint(m Mirror) http.HandlerFunc {
 			http.Error(w, fmt.Sprintf("invalid checkpoint: %v", err), http.StatusBadRequest)
 			return
 		}
-		if err := m.AddCheckpoint(r.Context(), origin, oldSize, proof, cp); err != nil {
+		if _, _, err := m.AddCheckpoint(r.Context(), origin, oldSize, proof, cp); err != nil {
 			slog.ErrorContext(r.Context(), "AddCheckpoint failed", slog.Any("error", err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -172,7 +172,7 @@ type addEntriesRequest struct {
 // to return io.EOF.
 //
 // Not thread-safe.
-func (a *addEntriesRequest) NextPackage() (*mirror.Package, error) {
+func (a *addEntriesRequest) NextPackage() (*tessera.MirrorPackage, error) {
 	if a.start >= a.uploadEnd {
 		return nil, io.EOF
 	}
@@ -223,7 +223,7 @@ func (a *addEntriesRequest) NextPackage() (*mirror.Package, error) {
 
 	// Update next expected entry index.
 	a.start = end
-	return &mirror.Package{Entries: entries, Proof: proofs}, nil
+	return &tessera.MirrorPackage{Entries: entries, Proof: proofs}, nil
 }
 
 // parseAddEntriesPreamble consumes the body of the Add-Entries request.

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -24,22 +24,22 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/transparency-dev/tessera/cmd/mtc/mirror/internal/mirror"
+	"github.com/transparency-dev/tessera"
 )
 
 type mockMirror struct {
-	addCheckpointFunc func(ctx context.Context, logOrigin string, oldSize uint64, proof [][]byte, cp []byte) error
-	addEntriesFunc    func(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error)
+	addCheckpointFunc func(ctx context.Context, logOrigin string, oldSize uint64, proof [][]byte, cp []byte) ([]byte, uint64, error)
+	addEntriesFunc    func(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error)
 }
 
-func (m *mockMirror) AddCheckpoint(ctx context.Context, logOrigin string, oldSize uint64, proof [][]byte, cp []byte) error {
+func (m *mockMirror) AddCheckpoint(ctx context.Context, logOrigin string, oldSize uint64, proof [][]byte, cp []byte) ([]byte, uint64, error) {
 	if m.addCheckpointFunc != nil {
 		return m.addCheckpointFunc(ctx, logOrigin, oldSize, proof, cp)
 	}
-	return nil
+	return nil, 0, nil
 }
 
-func (m *mockMirror) AddEntries(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error) {
+func (m *mockMirror) AddEntries(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error) {
 	if m.addEntriesFunc != nil {
 		return m.addEntriesFunc(ctx, logOrigin, uploadStart, uploadEnd, ticket, next)
 	}
@@ -50,14 +50,14 @@ func TestAddCheckpoint(t *testing.T) {
 	const cpOld = 100
 
 	mock := &mockMirror{
-		addCheckpointFunc: func(ctx context.Context, logOrigin string, oldSize uint64, proof [][]byte, cp []byte) error {
+		addCheckpointFunc: func(ctx context.Context, logOrigin string, oldSize uint64, proof [][]byte, cp []byte) ([]byte, uint64, error) {
 			if oldSize != cpOld {
-				return fmt.Errorf("want oldSize %d, got %d", cpOld, oldSize)
+				return nil, cpOld, fmt.Errorf("want oldSize %d, got %d", cpOld, oldSize)
 			}
 			if len(proof) != 1 {
-				return fmt.Errorf("want 1 proof hash, got %d", len(proof))
+				return nil, cpOld, fmt.Errorf("want 1 proof hash, got %d", len(proof))
 			}
-			return nil
+			return nil, 0, nil
 		},
 	}
 	h := New(mock)
@@ -84,7 +84,7 @@ func TestAddEntries(t *testing.T) {
 	)
 
 	mock := &mockMirror{
-		addEntriesFunc: func(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*mirror.Package, error)) ([]byte, error) {
+		addEntriesFunc: func(ctx context.Context, logOrigin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error) {
 			if logOrigin != testOrigin {
 				return nil, fmt.Errorf("want logOrigin %s, got %s", testOrigin, logOrigin)
 			}

--- a/cmd/mtc/mirror/internal/mirror/mirror.go
+++ b/cmd/mtc/mirror/internal/mirror/mirror.go
@@ -17,9 +17,11 @@ package mirror
 import (
 	"context"
 	"errors"
-	"io"
 	"log/slog"
+	"maps"
 	"sync"
+
+	"github.com/transparency-dev/tessera"
 )
 
 var (
@@ -27,19 +29,12 @@ var (
 	ErrUnknownLog = errors.New("unknown log origin")
 )
 
-// Package represents a single package of entries and its subtree consistency proof.
-type Package struct {
-	Entries [][]byte
-	Proof   [][]byte
-}
-
-// New creates a new Mirror.
-//
-// TODO(al): Add some way to configure and create targets.
-func New() *Mirror {
-	return &Mirror{
-		targets: make(map[string]*target),
+// New creates a new Mirror from the provided map of origins to mirror target.
+func New(targets map[string]Target) *Mirror {
+	m := &Mirror{
+		targets: maps.Clone(targets),
 	}
+	return m
 }
 
 // Mirror is the backend for the tlog-mirror HTTP service.
@@ -48,27 +43,29 @@ func New() *Mirror {
 // the configured logs and routes requests to the appropriate target.
 type Mirror struct {
 	lock    sync.RWMutex
-	targets map[string]*target
+	targets map[string]Target
 }
 
-func (m *Mirror) AddCheckpoint(ctx context.Context, origin string, oldSize uint64, proof [][]byte, cpRaw []byte) error {
+func (m *Mirror) AddCheckpoint(ctx context.Context, origin string, oldSize uint64, proof [][]byte, cpRaw []byte) ([]byte, uint64, error) {
 	t, err := m.target(origin)
 	if err != nil {
-		return err
+		return nil, 0, err
 	}
+	slog.InfoContext(ctx, "AddCheckpoint", slog.String("origin", origin), slog.Uint64("old_size", oldSize), slog.Int("proof_len", len(proof)), slog.String("cp", string(cpRaw)))
 	return t.AddCheckpoint(ctx, oldSize, proof, cpRaw)
 }
 
-func (m *Mirror) AddEntries(ctx context.Context, origin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*Package, error)) ([]byte, error) {
+func (m *Mirror) AddEntries(ctx context.Context, origin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error) {
 	t, err := m.target(origin)
 	if err != nil {
 		return nil, err
 	}
+	slog.InfoContext(ctx, "AddEntries", slog.String("origin", origin), slog.Uint64("start", uploadStart), slog.Uint64("end", uploadEnd))
 	return t.AddEntries(ctx, uploadStart, uploadEnd, ticket, next)
 }
 
 // target returns the target for the given origin, or ErrUnknownLog if it doesn't exist.
-func (m *Mirror) target(origin string) (*target, error) {
+func (m *Mirror) target(origin string) (Target, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	r, ok := m.targets[origin]
@@ -78,34 +75,10 @@ func (m *Mirror) target(origin string) (*target, error) {
 	return r, nil
 }
 
-// target represents a single log that the mirror is configured to maintain.
-type target struct {
-	origin string
-	// TODO: MirrorLifecycle
-}
-
-
-func (t *target) AddCheckpoint(ctx context.Context, oldSize uint64, proof [][]byte, cpRaw []byte) error {
-	slog.InfoContext(ctx, "AddCheckpoint", slog.String("origin", t.origin), slog.Uint64("old_size", oldSize), slog.Int("proof_len", len(proof)), slog.String("cp", string(cpRaw)))
-	return nil
-}
-
-func (t *target) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*Package, error)) ([]byte, error) {
-	slog.InfoContext(ctx, "AddEntries", slog.String("origin", t.origin), slog.Uint64("start", uploadStart), slog.Uint64("end", uploadEnd))
-
-	// Drain the packages
-	for {
-		pkg, err := next()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
-		}
-		slog.InfoContext(ctx, "AddEntries received package", slog.Int("num_entries", len(pkg.Entries)), slog.Int("num_proof_hashes", len(pkg.Proof)))
-	}
-
-	// SPEC: "Success (200 OK): A sequence of one or more cosignature lines"
-	// Return a dummy cosignature for now.
-	return []byte("— mirror-dummy-cosignature\n"), nil
+// Target describes the contract that a mirror target must satisfy.
+type Target interface {
+	// AddCheckpoint is a tlog-witness.
+	AddCheckpoint(ctx context.Context, oldSize uint64, proof [][]byte, cpRaw []byte) ([]byte, uint64, error)
+	// AddEntries adds verified consistent entries to the mirror.
+	AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error)
 }

--- a/cmd/mtc/mirror/internal/mirror/mirror_test.go
+++ b/cmd/mtc/mirror/internal/mirror/mirror_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/transparency-dev/tessera"
+)
+
+const (
+	testLogOrigin = "example.com/log"
+)
+
+func TestAddCheckpointUnknownLog(t *testing.T) {
+	ctx := t.Context()
+	m := New(nil)
+	if _, _, err := m.AddCheckpoint(ctx, "unknown-log", 0, nil, nil); !errors.Is(err, ErrUnknownLog) {
+		t.Errorf("AddCheckpoint() error = %v, want %v", err, ErrUnknownLog)
+	}
+}
+
+func TestAddCheckpointHitsTarget(t *testing.T) {
+	ctx := t.Context()
+	dummy := &dummyTarget{}
+	oldSize := uint64(10)
+	proof := [][]byte{{1}}
+	cpRaw := []byte("hello")
+	m := New(map[string]Target{testLogOrigin: dummy})
+	if _, _, err := m.AddCheckpoint(ctx, testLogOrigin, oldSize, proof, cpRaw); err != nil {
+		t.Errorf("AddCheckpoint() error = %v, want %v", err, nil)
+	}
+	if !dummy.calledAddCheckpoint {
+		t.Errorf("AddCheckpoint() was not called")
+	}
+	if dummy.addCheckpointOldSize != oldSize {
+		t.Errorf("AddCheckpoint() was called with oldSize %d, want %d", dummy.addCheckpointOldSize, oldSize)
+	}
+	if !bytes.Equal(dummy.addCheckpointProof[0], []byte{1}) {
+		t.Errorf("AddCheckpoint() was called with proof %v, want %v", dummy.addCheckpointProof, proof)
+	}
+	if !bytes.Equal(dummy.addCheckpointCpRaw, []byte("hello")) {
+		t.Errorf("AddCheckpoint() was called with cpRaw %v, want %v", dummy.addCheckpointCpRaw, cpRaw)
+	}
+}
+
+type dummyTarget struct {
+	calledAddCheckpoint bool
+	addCheckpointOldSize uint64
+	addCheckpointProof [][]byte
+	addCheckpointCpRaw   []byte
+}
+
+func (d *dummyTarget) AddCheckpoint(ctx context.Context, oldSize uint64, proof [][]byte, cpRaw []byte) (cosig []byte, wantSize uint64, err error) {
+	d.addCheckpointCpRaw = cpRaw
+	d.addCheckpointOldSize = oldSize
+	d.addCheckpointProof = proof
+	d.calledAddCheckpoint = true
+	return nil, 0, nil
+}
+
+func (d *dummyTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error) {
+	return nil, nil
+}
+
+func (d *dummyTarget) IntegratedSize(ctx context.Context) (uint64, error) {
+	return 0, nil
+}

--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package witness
+
+import (
+	"context"
+	"errors"
+)
+
+// Persistence is the contract for a storage implementation used by a witness.
+type Persistence interface {
+	// UpdateCheckpoint atomically updates the latest checkpoint, given the original.
+	// The provided function should be called by the storage with the current latest checkpoint, and will return
+	// an updated checkpoint to be stored in its place.
+	// Implementations MUST ensure this operation is atomic and thread-safe.
+	UpdateCheckpoint(ctx context.Context, f func(oldCP []byte) (newCP []byte, err error)) error
+}
+
+// Witness is an implementation of the core logic of a tlog-witness.
+type Witness struct {
+	storage Persistence
+}
+
+func New(s Persistence) *Witness {
+	return &Witness{storage: s}
+}
+
+func (w *Witness) Update(ctx context.Context, oldSize uint64, nextRaw []byte, cProof [][]byte) ([]byte, uint64, error) {
+	return nil, 0, errors.New("unimplemented")
+}

--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -1,0 +1,147 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tessera
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+
+	"github.com/transparency-dev/tessera/api"
+	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/internal/witness"
+	"golang.org/x/mod/sumdb/note"
+)
+
+// MirrorOptions holds mirror lifecycle settings for all storage implementations.
+type MirrorOptions struct {
+	logVerifier note.Verifier
+	signer      note.Signer
+}
+
+// NewMirrorOptions creates a new options struct with defaults.
+func NewMirrorOptions() *MirrorOptions {
+	return &MirrorOptions{}
+}
+
+// WithLogVerifier configures the note.Verifier to use when verifying log checkpoints.
+func (o *MirrorOptions) WithLogVerifier(v note.Verifier) *MirrorOptions {
+	o.logVerifier = v
+	return o
+}
+
+// WithSigner configures the note.Signer to use when cosigning checkpoints.
+func (o *MirrorOptions) WithSigner(s note.Signer) *MirrorOptions {
+	o.signer = s
+	return o
+}
+
+// Signer returns the configured note.Signer.
+func (o *MirrorOptions) Signer() note.Signer {
+	return o.signer
+}
+
+func (o *MirrorOptions) EntriesPath() func(index uint64, partial uint8) string {
+	return layout.EntriesPath
+}
+
+func (o *MirrorOptions) LeafHasher() func(bundle []byte) (leafHashes [][]byte, err error) {
+	return defaultMerkleLeafHasher
+}
+
+func (o *MirrorOptions) valid() error {
+	if o.logVerifier == nil {
+		return errors.New("invalid MirrorOptions: WithLogVerifier must be set")
+	}
+	if o.signer == nil {
+		return errors.New("invalid MirrorOptions: WithSigner must be set")
+	}
+	return nil
+}
+
+// mirrorWriter describes the contract for storage implementation required to support the mirroring lifecycle.
+type MirrorWriter interface {
+	// MirrorWriters must also implement the contract for storing witness data.
+	witness.Persistence
+	// IntegrateBundles integrates bundles of log entries, starting at the given index, into the local tree.
+	// Returns the size of the tree and its new root hash if successful.
+	IntegrateBundles(ctx context.Context, from uint64, bundles iter.Seq[api.EntryBundle]) (uint64, []byte, error)
+	// IntegratedSize returns the size of the local integrated tree.
+	IntegratedSize(ctx context.Context) (uint64, error)
+}
+
+// MirrorTarget is a high-level wrapper that manages the process of mirroring
+// a source log into a Tessera instance.
+type MirrorTarget struct {
+	witness *witness.Witness
+	writer  MirrorWriter
+	reader  LogReader
+}
+
+// NewMirrorTarget instantiates a new MirrorTarget for the given driver and options.
+func NewMirrorTarget(ctx context.Context, d Driver, opts *MirrorOptions) (*MirrorTarget, error) {
+	type mirrorLifecycle interface {
+		MirrorWriter(context.Context, *MirrorOptions) (MirrorWriter, LogReader, error)
+	}
+	lc, ok := d.(mirrorLifecycle)
+	if !ok {
+		return nil, fmt.Errorf("driver %T does not implement MirrorTarget lifecycle", d)
+	}
+	if opts == nil {
+		return nil, errors.New("opts cannot be nil")
+	}
+	if err := opts.valid(); err != nil {
+		return nil, err
+	}
+	mw, r, err := lc.MirrorWriter(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init MirrorTarget lifecycle: %v", err)
+	}
+	return &MirrorTarget{
+		witness: witness.New(mw),
+		writer:  mw,
+		reader:  r,
+	}, nil
+}
+
+// Package represents a single package of entries and its subtree consistency proof.
+type MirrorPackage struct {
+	Entries [][]byte
+	Proof   [][]byte
+}
+
+// AddCheckpoint attempt to register a new checkpoint from the configured log, updating the local latest consistent view if possible.
+//
+// Returns a cosignature for the checkpoint.
+// If unsuccessful, returns an error describing the reason for the failure, and, if that reason is a conflict, returns the size of the current consistent view.
+//
+// TODO(al): something, something, pending checkpoints.
+func (mt *MirrorTarget) AddCheckpoint(ctx context.Context, oldSize uint64, proof [][]byte, cp []byte) (cosig []byte, wantSize uint64, err error) {
+	return mt.witness.Update(ctx, oldSize, cp, proof)
+}
+
+// AddEntries processes a stream of entry packages, verifies subtree consistency proofs,
+// and durably commits entries to the log.
+//
+// TODO(al): Need to have integrated provided entries when we return so we can produce a signature.
+func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*MirrorPackage, error)) ([]byte, error) {
+	return nil, errors.New("unimplemented")
+}
+
+// IntegratedSize returns the size of the current integrated log.
+func (mt *MirrorTarget) IntegratedSize(ctx context.Context) (uint64, error) {
+	return mt.reader.IntegratedSize(ctx)
+}


### PR DESCRIPTION
This PR adds an outline of an [MTC] MirrorLifecycle.

Towards #945 