### PR TITLE
Add witness core

### DIFF
--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -63,11 +63,10 @@ func addCheckpoint(m Mirror) http.HandlerFunc {
 			return
 		}
 
-		sc, body, contentType, err := handleUpdate(r.Context(), m, origin, oldSize, cp, proof)
+		sc, body, contentType, err := handleCheckpointUpdate(r.Context(), m, origin, oldSize, cp, proof)
 		if err != nil {
-			status := http.StatusInternalServerError
 			slog.InfoContext(r.Context(), "Witness update failed", slog.Any("error", err.Error()))
-			w.WriteHeader(status)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
@@ -83,10 +82,10 @@ func addCheckpoint(m Mirror) http.HandlerFunc {
 	}
 }
 
-// handleUpdate submits the provided checkpoint to the witness and interprets any errors which may result.
+// handleCheckpointUpdate submits the provided checkpoint to the witness and interprets any errors which may result.
 //
 // Returns an appropriate HTTP status code, response body, and Content Type representing the outcome.
-func handleUpdate(ctx context.Context, m Mirror, origin string, oldSize uint64, cp []byte, proof [][]byte) (int, []byte, string, error) {
+func handleCheckpointUpdate(ctx context.Context, m Mirror, origin string, oldSize uint64, cp []byte, proof [][]byte) (int, []byte, string, error) {
 	sigs, trustedSize, updateErr := m.AddCheckpoint(ctx, origin, oldSize, proof, cp)
 	// Finally, handle any "soft" error from the update:
 	if updateErr != nil {
@@ -117,27 +116,28 @@ func handleUpdate(ctx context.Context, m Mirror, origin string, oldSize uint64, 
 // - a previous size line,
 // - zero or more consistency proof lines,
 // - and an empty line,
-// - followed by a [checkpoint][].
+// - followed by a checkpoint.
 func parseBody(r io.Reader) (string, uint64, [][]byte, []byte, error) {
 	b := bufio.NewReader(r)
-	sizeLine, _, err := b.ReadLine()
+	sizeLine, err := b.ReadString('\n')
 	if err != nil {
 		return "", 0, nil, nil, err
 	}
 	var size uint64
-	if n, err := fmt.Sscanf(string(sizeLine), "old %d", &size); err != nil || n != 1 {
+	if n, err := fmt.Sscanf(strings.TrimSuffix(sizeLine, "\n"), "old %d", &size); err != nil || n != 1 {
 		return "", 0, nil, nil, err
 	}
 	proof := [][]byte{}
 	for {
-		l, _, err := b.ReadLine()
+		l, err := b.ReadString('\n')
 		if err != nil {
 			return "", 0, nil, nil, err
 		}
+		l = strings.TrimSuffix(l, "\n")
 		if len(l) == 0 {
 			break
 		}
-		hash, err := base64.StdEncoding.DecodeString(string(l))
+		hash, err := base64.StdEncoding.DecodeString(l)
 		if err != nil {
 			return "", 0, nil, nil, err
 		}
@@ -149,7 +149,7 @@ func parseBody(r io.Reader) (string, uint64, [][]byte, []byte, error) {
 	}
 	s := strings.SplitN(string(cp), "\n", 2)
 	if len(s) != 2 {
-		return "", 0, nil, nil, err
+		return "", 0, nil, nil, errors.New("invalid checkpoint")
 	}
 
 	origin := s[0]

--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -22,14 +22,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
-	"strconv"
 	"strings"
 
-	"log/slog"
-
 	"github.com/transparency-dev/tessera"
-	"github.com/transparency-dev/tessera/internal/parse"
+	"github.com/transparency-dev/tessera/internal/witness"
 )
 
 const (
@@ -55,75 +53,107 @@ func New(m Mirror) http.Handler {
 }
 
 func addCheckpoint(m Mirror) http.HandlerFunc {
+	const maxRequestBodyBytes = 64 << 10
+
 	return func(w http.ResponseWriter, r *http.Request) {
-		// SPEC: The mirror implements a [tlog-]witness's add-checkpoint endpoint.
-		//       MUST be a sequence of:
-		//         - an old size line,
-		//         - zero or more consistency proof lines,
-		//         - and an empty line,
-		//         - followed by a checkpoint.
-
-		reader := bufio.NewReader(r.Body)
-
-		// 1. Read old size line.
-		oldLine, err := reader.ReadString('\n')
+		origin, oldSize, proof, cp, err := parseBody(http.MaxBytesReader(w, r.Body, maxRequestBodyBytes))
 		if err != nil {
-			http.Error(w, "missing old size", http.StatusBadRequest)
-			return
-		}
-		oldLine = strings.TrimSpace(oldLine)
-		if !strings.HasPrefix(oldLine, "old ") {
-			http.Error(w, "invalid old size line", http.StatusBadRequest)
-			return
-		}
-		oldSize, err := strconv.ParseUint(strings.TrimPrefix(oldLine, "old "), 10, 64)
-		if err != nil {
-			http.Error(w, "invalid old size", http.StatusBadRequest)
+			slog.InfoContext(r.Context(), "Invalid witness request", slog.Any("error", err.Error()))
+			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
-		// 2. Read consistency proof lines until an empty line.
-		var proof [][]byte
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				http.Error(w, "unexpected EOF while reading proof", http.StatusBadRequest)
-				return
+		sc, body, contentType, err := handleUpdate(r.Context(), m, origin, oldSize, cp, proof)
+		if err != nil {
+			status := http.StatusInternalServerError
+			slog.InfoContext(r.Context(), "Witness update failed", slog.Any("error", err.Error()))
+			w.WriteHeader(status)
+			return
+		}
+
+		if contentType != "" {
+			w.Header().Add("Content-Type", contentType)
+		}
+		w.WriteHeader(sc)
+		if len(body) > 0 {
+			if _, err := w.Write(body); err != nil {
+				slog.InfoContext(r.Context(), "Witness failed to write response", slog.Any("error", err.Error()))
 			}
-			line = strings.TrimSpace(line)
-			if line == "" {
-				break
-			}
-			p, err := base64.StdEncoding.DecodeString(line)
-			if err != nil {
-				http.Error(w, "invalid proof line", http.StatusBadRequest)
-				return
-			}
-			proof = append(proof, p)
 		}
-
-		// 3. Remaining data is the checkpoint.
-		cp, err := io.ReadAll(reader)
-		if err != nil {
-			http.Error(w, "failed to read checkpoint", http.StatusBadRequest)
-			return
-		}
-
-		// 4. Extract the origin from the checkpoint and pass the request to the backend to take action.
-		origin, _, _, err := parse.CheckpointUnsafe(cp)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("invalid checkpoint: %v", err), http.StatusBadRequest)
-			return
-		}
-		if _, _, err := m.AddCheckpoint(r.Context(), origin, oldSize, proof, cp); err != nil {
-			slog.ErrorContext(r.Context(), "AddCheckpoint failed", slog.Any("error", err))
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
-		// TODO(al): Maybe return a tlog-witness only cosignature here from a separate key?
 	}
+}
+
+// handleUpdate submits the provided checkpoint to the witness and interprets any errors which may result.
+//
+// Returns an appropriate HTTP status code, response body, and Content Type representing the outcome.
+func handleUpdate(ctx context.Context, m Mirror, origin string, oldSize uint64, cp []byte, proof [][]byte) (int, []byte, string, error) {
+	sigs, trustedSize, updateErr := m.AddCheckpoint(ctx, origin, oldSize, proof, cp)
+	// Finally, handle any "soft" error from the update:
+	if updateErr != nil {
+		switch {
+		case errors.Is(updateErr, witness.ErrCheckpointStale):
+			return http.StatusConflict, fmt.Appendf(nil, "%d\n", trustedSize), "text/x.tlog.size", nil
+		case errors.Is(updateErr, witness.ErrUnknownLog):
+			return http.StatusNotFound, nil, "", nil
+		case errors.Is(updateErr, witness.ErrNoValidSignature):
+			return http.StatusForbidden, nil, "", nil
+		case errors.Is(updateErr, witness.ErrOldSizeInvalid):
+			return http.StatusBadRequest, nil, "", nil
+		case errors.Is(updateErr, witness.ErrInvalidProof):
+			return http.StatusUnprocessableEntity, nil, "", nil
+		case errors.Is(updateErr, witness.ErrRootMismatch):
+			return http.StatusConflict, nil, "", nil
+		default:
+			return http.StatusInternalServerError, nil, "", updateErr
+		}
+	}
+
+	return http.StatusOK, sigs, "", nil
+}
+
+// parseBody reads the incoming request and parses into constituent parts.
+//
+// The request body MUST be a sequence of
+// - a previous size line,
+// - zero or more consistency proof lines,
+// - and an empty line,
+// - followed by a [checkpoint][].
+func parseBody(r io.Reader) (string, uint64, [][]byte, []byte, error) {
+	b := bufio.NewReader(r)
+	sizeLine, _, err := b.ReadLine()
+	if err != nil {
+		return "", 0, nil, nil, err
+	}
+	var size uint64
+	if n, err := fmt.Sscanf(string(sizeLine), "old %d", &size); err != nil || n != 1 {
+		return "", 0, nil, nil, err
+	}
+	proof := [][]byte{}
+	for {
+		l, _, err := b.ReadLine()
+		if err != nil {
+			return "", 0, nil, nil, err
+		}
+		if len(l) == 0 {
+			break
+		}
+		hash, err := base64.StdEncoding.DecodeString(string(l))
+		if err != nil {
+			return "", 0, nil, nil, err
+		}
+		proof = append(proof, hash)
+	}
+	cp, err := io.ReadAll(b)
+	if err != nil {
+		return "", 0, nil, nil, err
+	}
+	s := strings.SplitN(string(cp), "\n", 2)
+	if len(s) != 2 {
+		return "", 0, nil, nil, err
+	}
+
+	origin := s[0]
+	return origin, size, proof, cp, nil
 }
 
 func addEntries(m Mirror) http.HandlerFunc {

--- a/internal/witness/client.go
+++ b/internal/witness/client.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package witness contains the implementation for sending out a checkpoint to witnesses
-// and retrieving sufficient signatures to satisfy a policy.
+// Package witness contains the implementations of a witness client, used to send out a checkpoint to witnesses
+// and retrieve sufficient signatures to satisfy a policy, and a witness service, used by the tlog-mirror implementation.
 package witness
 
 import (

--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -33,10 +33,10 @@ import (
 	"github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/merkle/proof"
 	"github.com/transparency-dev/merkle/rfc6962"
-	"golang.org/x/mod/sumdb/note"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/mod/sumdb/note"
 
-	i_otel "github.com/transparency-dev/tessera/internal/otel"
+	iotel "github.com/transparency-dev/tessera/internal/otel"
 )
 
 var (
@@ -74,7 +74,7 @@ type Opts struct {
 
 // Witness is a witness for a single log.
 type Witness struct {
-	lsp         Persistence
+	p         	Persistence
 	signers     []note.Signer
 	logVerifier note.Verifier
 }
@@ -82,7 +82,7 @@ type Witness struct {
 // New creates a new witness for the configured log.
 func New(ctx context.Context, wo Opts) (*Witness, error) {
 	return &Witness{
-		lsp:         wo.Persistence,
+		p:         wo.Persistence,
 		signers:     wo.Signers,
 		logVerifier: wo.LogVerifier,
 	}, nil
@@ -105,96 +105,96 @@ func (w *Witness) verifyCheckpoint(ctx context.Context, chkptRaw []byte) (*log.C
 // - ErrCheckpointStale or ErrOldSizeInvalid: the presented checkpoint is out of date, the size of the current checkpoint is returned.
 // - Any other error, no supporting values are returned.
 func (w *Witness) Update(ctx context.Context, oldSize uint64, nextRaw []byte, cProof [][]byte) ([]byte, uint64, error) {
-	return i_otel.Trace2(ctx, "tessera.witness.server.update", tracer, func(ctx context.Context, span trace.Span) ([]byte, uint64, error) {
-	// Check the signatures on the raw checkpoint and parse it
-	// into the log.Checkpoint format.
-	//
-	// SPEC: The witness MUST verify the checkpoint signature against the public key(s) it trusts for the
-	//       checkpoint origin, and it MUST ignore signatures from unknown keys.
-	next, nextNote, err := w.verifyCheckpoint(ctx, nextRaw)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	var retSigs []byte
-	var retSize uint64
-
-	// Attempt to atomically update the latest known checkpoint for the given origin.
-	err = w.lsp.UpdateCheckpoint(ctx, func(prevRaw []byte) ([]byte, error) {
-		// If there was nothing stored already then treat this new
-		// checkpoint as trust-on-first-use (TOFU).
-		if prevRaw == nil {
-			// Store a witness cosigned version of the checkpoint.
-			signed, sigs, err := w.signChkpt(nextNote)
-			if err != nil {
-				return nil, fmt.Errorf("couldn't sign input checkpoint: %v", err)
-			}
-			retSigs = sigs
-			return signed, nil
-		}
-
-		prev, _, err := w.verifyCheckpoint(ctx, prevRaw)
+	return iotel.Trace2(ctx, "tessera.witness.server.update", tracer, func(ctx context.Context, span trace.Span) ([]byte, uint64, error) {
+		// Check the signatures on the raw checkpoint and parse it
+		// into the log.Checkpoint format.
+		//
+		// SPEC: The witness MUST verify the checkpoint signature against the public key(s) it trusts for the
+		//       checkpoint origin, and it MUST ignore signatures from unknown keys.
+		next, nextNote, err := w.verifyCheckpoint(ctx, nextRaw)
 		if err != nil {
-			retSize, retSigs = 0, nil
-			return nil, fmt.Errorf("couldn't parse stored checkpoint: %v", err)
+			return nil, 0, err
 		}
 
-		// SPEC: The old size MUST be equal to or lower than the (submitted) checkpoint size.
-		if oldSize > next.Size {
-			retSize, retSigs = prev.Size, nil
-			return nil, ErrOldSizeInvalid
-		}
-		// SPEC: The witness MUST check that the old size matches the size of the latest checkpoint it cosigned
-		//       for the checkpoint's origin (or zero if it never cosigned a checkpoint for that origin)
-		if oldSize != prev.Size {
-			retSize, retSigs = prev.Size, nil
-			return nil, fmt.Errorf("%w (%d != %d)", ErrCheckpointStale, oldSize, prev.Size)
-		}
-		// SPEC:  If the old size matches the checkpoint size, the witness MUST check that the root hashes are
-		//        also identical.
-		if next.Size == prev.Size {
-			if !bytes.Equal(next.Hash, prev.Hash) {
-				slog.ErrorContext(ctx, "INCONSISTENT CHECKPOINTS", slog.String("origin", w.logVerifier.Name()), slog.Any("prev", prev), slog.Any("next", next))
-				retSize, retSigs = 0, nil
-				return nil, ErrRootMismatch
+		var retSigs []byte
+		var retSize uint64
+
+		// Attempt to atomically update the latest known checkpoint for the given origin.
+		err = w.p.UpdateCheckpoint(ctx, func(prevRaw []byte) ([]byte, error) {
+			// If there was nothing stored already then treat this new
+			// checkpoint as trust-on-first-use (TOFU).
+			if prevRaw == nil {
+				// Store a witness cosigned version of the checkpoint.
+				signed, sigs, err := w.signChkpt(nextNote)
+				if err != nil {
+					return nil, fmt.Errorf("couldn't sign input checkpoint: %v", err)
+				}
+				retSigs = sigs
+				return signed, nil
 			}
-			// This used to short-circuit here to save work.
-			// However, having the most recently witnessed timestamp available is beneficial to demonstrate freshness.
-		}
-		// Checkpoints of size 0 are really placeholders and consistency proofs can't be performed.
-		// If we initialized on a tree size of 0, then we simply ratchet forward and effectively TOFU the new checkpoint.
-		if prev.Size == 0 {
-			// SPEC:  The proof MUST be empty if the old size is zero.
-			if len(cProof) > 0 {
-				retSize, retSigs = 0, nil
-				return nil, ErrInvalidProof
-			}
-			signed, sigs, err := w.signChkpt(nextNote)
+
+			prev, _, err := w.verifyCheckpoint(ctx, prevRaw)
 			if err != nil {
 				retSize, retSigs = 0, nil
+				return nil, fmt.Errorf("couldn't parse stored checkpoint: %v", err)
+			}
+
+			switch {
+			case oldSize > next.Size:
+				// SPEC: The old size MUST be equal to or lower than the (submitted) checkpoint size.
+				retSize, retSigs = prev.Size, nil
+				return nil, ErrOldSizeInvalid
+
+			case oldSize != prev.Size:
+				// SPEC: The witness MUST check that the old size matches the size of the latest checkpoint it cosigned
+				//       for the checkpoint's origin (or zero if it never cosigned a checkpoint for that origin)
+				retSize, retSigs = prev.Size, nil
+				return nil, fmt.Errorf("%w (%d != %d)", ErrCheckpointStale, oldSize, prev.Size)
+
+			case next.Size == prev.Size:
+				// SPEC:  If the old size matches the checkpoint size, the witness MUST check that the root hashes are
+				//        also identical.
+				if !bytes.Equal(next.Hash, prev.Hash) {
+					slog.ErrorContext(ctx, "INCONSISTENT CHECKPOINTS", slog.String("origin", w.logVerifier.Name()), slog.Any("prev", prev), slog.Any("next", next))
+					retSize, retSigs = 0, nil
+					return nil, ErrRootMismatch
+				}
+				// We'll continue on to signing the checkpoints below, so the log gets a fresh cosignature with updated timestamp.
+
+			case prev.Size == 0:
+				// SPEC:  The proof MUST be empty if the old size is zero.
+				//
+				// Checkpoints of size 0 are really placeholders and consistency proofs can't be performed.
+				// If we initialized on a tree size of 0, then we simply ratchet forward and effectively TOFU the new checkpoint.
+				if len(cProof) > 0 {
+					retSize, retSigs = 0, nil
+					return nil, ErrInvalidProof
+				}
+
+			case next.Size > prev.Size:
+				// The only remaining option is next.Size > prev.Size. This might be valid so we verify the consistency proof.
+				if err := proof.VerifyConsistency(rfc6962.DefaultHasher, prev.Size, next.Size, cProof, prev.Hash, next.Hash); err != nil {
+					// Complain if the checkpoints aren't consistent.
+					return nil, ErrInvalidProof
+				}
+
+			default:
+				// This should never occur, but if it does, fail safe.
+				slog.ErrorContext(ctx, "unexpected state in Update", slog.String("origin", w.logVerifier.Name()), slog.Any("prev", prev), slog.Any("next", next))
+				return nil, fmt.Errorf("unexpected state: prev.Size=%d, next.Size=%d", prev.Size, next.Size)
+			}
+
+			// All checks complete, we're satisfied with the new checkpoint and will sign it.
+			signed, sigs, err := w.signChkpt(nextNote)
+			if err != nil {
+				retSize, retSigs = 0, nil
 				return nil, fmt.Errorf("couldn't sign input checkpoint: %v", err)
 			}
-			retSize, retSigs = 0, sigs
+
+			retSize, retSigs = next.Size, sigs
 			return signed, nil
-		}
-
-		// The only remaining option is next.Size > prev.Size. This might be
-		// valid so we verify the consistency proofs.
-		if err := proof.VerifyConsistency(rfc6962.DefaultHasher, prev.Size, next.Size, cProof, prev.Hash, next.Hash); err != nil {
-			// Complain if the checkpoints aren't consistent.
-			return nil, ErrInvalidProof
-		}
-		// If the consistency proof is good we store the witness cosigned nextRaw.
-		signed, sigs, err := w.signChkpt(nextNote)
-		if err != nil {
-			retSize, retSigs = 0, nil
-			return nil, fmt.Errorf("couldn't sign input checkpoint: %v", err)
-		}
-
-		retSize, retSigs = 0, sigs
-		return signed, nil
-	})
-	return retSigs, retSize, err
+		})
+		return retSigs, retSize, err
 	})
 }
 

--- a/internal/witness/witness.go
+++ b/internal/witness/witness.go
@@ -1,4 +1,4 @@
-// Copyright 2026 The Tessera authors. All Rights Reserved.
+// Copyright 2021 Google LLC. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,32 +11,253 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+
+// This file contains an implementation of the tlog-witness server logic.
+// Large parts of this come from github.com/transparency-dev/witness.
 
 package witness
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/binary"
 	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/transparency-dev/formats/log"
+	"github.com/transparency-dev/merkle/proof"
+	"github.com/transparency-dev/merkle/rfc6962"
+	"golang.org/x/mod/sumdb/note"
+	"go.opentelemetry.io/otel/trace"
+
+	i_otel "github.com/transparency-dev/tessera/internal/otel"
 )
 
-// Persistence is the contract for a storage implementation used by a witness.
+var (
+	// ErrNoValidSignature is returned by calls to Update if the provided checkpoint has no valid signature by the expected key.
+	ErrNoValidSignature = errors.New("no valid signatures")
+	// ErrUnknownLog is returned by calls to Update if the provided checkpoint carries an Origin which is unknown to the
+	// witness.
+	ErrUnknownLog = errors.New("unknown log")
+	// ErrOldSizeInvalid is returned by calls to Update if the provided oldSize parameter is larger than the size of the
+	// submitted checkpoint.
+	ErrOldSizeInvalid = errors.New("old size > current")
+	// ErrCheckpointStale is returned by calls to Update if the oldSize parameter does not match the size of the currently
+	// stored checkpoint for the same log.
+	ErrCheckpointStale = errors.New("old size != current")
+	// ErrInvalidProof is returned by calls to Update if the provided consistency proof is invalid.
+	ErrInvalidProof = errors.New("consistency proof invalid")
+	// ErrRootMismatch is returned by calls to Update if the provided checkpoint is for the same size tree as the currently
+	// stored one, but their root hashes differ.
+	ErrRootMismatch = errors.New("roots do not match")
+)
+
+// Persistence is the storage contract for a witness's checkpoints.
 type Persistence interface {
-	// UpdateCheckpoint atomically updates the latest checkpoint, given the original.
-	// The provided function should be called by the storage with the current latest checkpoint, and will return
-	// an updated checkpoint to be stored in its place.
-	// Implementations MUST ensure this operation is atomic and thread-safe.
-	UpdateCheckpoint(ctx context.Context, f func(oldCP []byte) (newCP []byte, err error)) error
+	// UpdateCheckpoint must atomically call the provided update func with the witness' current latest checkpoint for the log, and update
+	// that view with the checkpoint the function returns.
+	UpdateCheckpoint(ctx context.Context, update func(oldCP []byte) (newCP []byte, err error)) error
 }
 
-// Witness is an implementation of the core logic of a tlog-witness.
+// Opts is the options passed to a witness.
+type Opts struct {
+	Persistence Persistence
+	Signers     []note.Signer
+	LogVerifier note.Verifier
+}
+
+// Witness is a witness for a single log.
 type Witness struct {
-	storage Persistence
+	lsp         Persistence
+	signers     []note.Signer
+	logVerifier note.Verifier
 }
 
-func New(s Persistence) *Witness {
-	return &Witness{storage: s}
+// New creates a new witness for the configured log.
+func New(ctx context.Context, wo Opts) (*Witness, error) {
+	return &Witness{
+		lsp:         wo.Persistence,
+		signers:     wo.Signers,
+		logVerifier: wo.LogVerifier,
+	}, nil
 }
 
+// verifyCheckpoint verifies the checkpoint under the configured key & origin and returns
+// the parsed checkpoint and the note itself.
+func (w *Witness) verifyCheckpoint(ctx context.Context, chkptRaw []byte) (*log.Checkpoint, *note.Note, error) {
+	cp, _, n, err := log.ParseCheckpoint(chkptRaw, w.logVerifier.Name(), w.logVerifier)
+	return cp, n, err
+}
+
+// Update updates the latest checkpoint if nextRaw is consistent with the current
+// latest one for this log.
+//
+// The values returned depend on whether or not the new checkpoint is accepted, and
+// if not, the reason it was rejected. This can be determined through the error:
+//
+// - no error: The checkpoint was accepted, and a serialised note-signature is returned.
+// - ErrCheckpointStale or ErrOldSizeInvalid: the presented checkpoint is out of date, the size of the current checkpoint is returned.
+// - Any other error, no supporting values are returned.
 func (w *Witness) Update(ctx context.Context, oldSize uint64, nextRaw []byte, cProof [][]byte) ([]byte, uint64, error) {
-	return nil, 0, errors.New("unimplemented")
+	return i_otel.Trace2(ctx, "tessera.witness.server.update", tracer, func(ctx context.Context, span trace.Span) ([]byte, uint64, error) {
+	// Check the signatures on the raw checkpoint and parse it
+	// into the log.Checkpoint format.
+	//
+	// SPEC: The witness MUST verify the checkpoint signature against the public key(s) it trusts for the
+	//       checkpoint origin, and it MUST ignore signatures from unknown keys.
+	next, nextNote, err := w.verifyCheckpoint(ctx, nextRaw)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var retSigs []byte
+	var retSize uint64
+
+	// Attempt to atomically update the latest known checkpoint for the given origin.
+	err = w.lsp.UpdateCheckpoint(ctx, func(prevRaw []byte) ([]byte, error) {
+		// If there was nothing stored already then treat this new
+		// checkpoint as trust-on-first-use (TOFU).
+		if prevRaw == nil {
+			// Store a witness cosigned version of the checkpoint.
+			signed, sigs, err := w.signChkpt(nextNote)
+			if err != nil {
+				return nil, fmt.Errorf("couldn't sign input checkpoint: %v", err)
+			}
+			retSigs = sigs
+			return signed, nil
+		}
+
+		prev, _, err := w.verifyCheckpoint(ctx, prevRaw)
+		if err != nil {
+			retSize, retSigs = 0, nil
+			return nil, fmt.Errorf("couldn't parse stored checkpoint: %v", err)
+		}
+
+		// SPEC: The old size MUST be equal to or lower than the (submitted) checkpoint size.
+		if oldSize > next.Size {
+			retSize, retSigs = prev.Size, nil
+			return nil, ErrOldSizeInvalid
+		}
+		// SPEC: The witness MUST check that the old size matches the size of the latest checkpoint it cosigned
+		//       for the checkpoint's origin (or zero if it never cosigned a checkpoint for that origin)
+		if oldSize != prev.Size {
+			retSize, retSigs = prev.Size, nil
+			return nil, fmt.Errorf("%w (%d != %d)", ErrCheckpointStale, oldSize, prev.Size)
+		}
+		// SPEC:  If the old size matches the checkpoint size, the witness MUST check that the root hashes are
+		//        also identical.
+		if next.Size == prev.Size {
+			if !bytes.Equal(next.Hash, prev.Hash) {
+				slog.ErrorContext(ctx, "INCONSISTENT CHECKPOINTS", slog.String("origin", w.logVerifier.Name()), slog.Any("prev", prev), slog.Any("next", next))
+				retSize, retSigs = 0, nil
+				return nil, ErrRootMismatch
+			}
+			// This used to short-circuit here to save work.
+			// However, having the most recently witnessed timestamp available is beneficial to demonstrate freshness.
+		}
+		// Checkpoints of size 0 are really placeholders and consistency proofs can't be performed.
+		// If we initialized on a tree size of 0, then we simply ratchet forward and effectively TOFU the new checkpoint.
+		if prev.Size == 0 {
+			// SPEC:  The proof MUST be empty if the old size is zero.
+			if len(cProof) > 0 {
+				retSize, retSigs = 0, nil
+				return nil, ErrInvalidProof
+			}
+			signed, sigs, err := w.signChkpt(nextNote)
+			if err != nil {
+				retSize, retSigs = 0, nil
+				return nil, fmt.Errorf("couldn't sign input checkpoint: %v", err)
+			}
+			retSize, retSigs = 0, sigs
+			return signed, nil
+		}
+
+		// The only remaining option is next.Size > prev.Size. This might be
+		// valid so we verify the consistency proofs.
+		if err := proof.VerifyConsistency(rfc6962.DefaultHasher, prev.Size, next.Size, cProof, prev.Hash, next.Hash); err != nil {
+			// Complain if the checkpoints aren't consistent.
+			return nil, ErrInvalidProof
+		}
+		// If the consistency proof is good we store the witness cosigned nextRaw.
+		signed, sigs, err := w.signChkpt(nextNote)
+		if err != nil {
+			retSize, retSigs = 0, nil
+			return nil, fmt.Errorf("couldn't sign input checkpoint: %v", err)
+		}
+
+		retSize, retSigs = 0, sigs
+		return signed, nil
+	})
+	return retSigs, retSize, err
+	})
+}
+
+// signChkpt adds the witness' signature to a checkpoint.
+//
+// Returns:
+// - A serialised signed note including new witness signatures.
+// - A serialised representation of just the witness signature line(s).
+func (w *Witness) signChkpt(n *note.Note) ([]byte, []byte, error) {
+	// Code below is a lightly tweaked snippet from sumdb/note/note.go
+	// https://cs.opensource.google/go/x/mod/+/refs/tags/v0.24.0:sumdb/note/note.go;l=625-649
+
+	// Prepare signatures.
+	//
+	// We need to return both a full serialised signed note, as well as the just the
+	// signature lines we're adding - this is because we want to _store_ the full note, but
+	// the tlog-witness API requires that we only return the signature lines.
+	//
+	// Rather than using note.Sign, then running note.Open in order to get access to our
+	// signatures, we'll instead use our note.Signer(s) directly to sign the note message
+	// and then use the returned signature bytes to create both the serialised signed note
+	// as well as the serialised signature lines.
+
+	var sigs = bytes.Buffer{}
+	for _, s := range w.signers {
+		name := s.Name()
+		hash := s.KeyHash()
+		if !isValidSignerName(name) {
+			return nil, nil, errors.New("invalid signer")
+		}
+
+		sig, err := s.Sign([]byte(n.Text))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Create serialised signature line and append it to our sigs buffer:
+		var hbuf [4]byte
+		binary.BigEndian.PutUint32(hbuf[:], hash)
+		b64 := base64.StdEncoding.EncodeToString(append(hbuf[:], sig...))
+		sigs.WriteString("— ")
+		sigs.WriteString(name)
+		sigs.WriteString(" ")
+		sigs.WriteString(b64)
+		sigs.WriteString("\n")
+
+		// Also create a new note.Signature and pop it into the note's Sigs list (this will cause
+		// the signature to be present in the output when we call note.Sign below.
+		n.Sigs = append(n.Sigs, note.Signature{Name: name, Hash: hash, Base64: b64})
+	}
+	// Serialise the full signed note by calling Sign.
+	// Note that we're not passing any signers here because we've already added signatures in the loop above, so
+	// this call becomes just a serialisation function.
+	signed, err := note.Sign(n)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return signed, sigs.Bytes(), nil
+}
+
+// isValidSignerName reports whether name is valid.
+// It must be non-empty and not have any Unicode spaces or pluses.
+func isValidSignerName(name string) bool {
+	return name != "" && utf8.ValidString(name) && strings.IndexFunc(name, unicode.IsSpace) < 0 && !strings.Contains(name, "+")
 }

--- a/internal/witness/witness_test.go
+++ b/internal/witness/witness_test.go
@@ -31,8 +31,8 @@ import (
 
 var (
 	// https://go.dev/play/p/FVJgyhl7URt to regenerate any messages if needed.
-	mPK       = "monkeys+db4d9f7e+AULaJMvTtDLHPUcUrjdDad9vDlh/PTfC2VV60JUtCfWT"
-	mSK       = "PRIVATE+KEY+monkeys+db4d9f7e+ATWIAF3yVBG+Hv1rZFQoNt/BaURkLPtOFMAM2HrEeIr6"
+	mPK = "monkeys+db4d9f7e+AULaJMvTtDLHPUcUrjdDad9vDlh/PTfC2VV60JUtCfWT"
+	mSK = "PRIVATE+KEY+monkeys+db4d9f7e+ATWIAF3yVBG+Hv1rZFQoNt/BaURkLPtOFMAM2HrEeIr6"
 	// wPK       = "witness+f13a86db+AdYV1Ztajd9BvyjP2HgpwrqYL6TjOwIjGMOq8Bu42xbN"
 	wSK       = "PRIVATE+KEY+witness+f13a86db+AaLa/dfyBhyo/m0Z7WCi98ENVZWtrP8pxgRNrx7tIWiA"
 	mInit     = []byte("monkeys\n5\n41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=\n\n— monkeys 202fftzGl3LVoqjXfwCFZZXs8I+5G22+Ek2K0AOyBuSJ/8/CZawNF+6fNlTKOCd622pbzJNkkJFWuw9DbicZCkEx9AY=\n")
@@ -43,7 +43,6 @@ var (
 		dh("89d0f753f66a290c483b39cd5e9eafb12021293395fad3d4a2ad053cfbcfdc9e", 32),
 		dh("29e40bb79c966f4c6fe96aff6f30acfce5f3e8d84c02215175d6e018a5dee833", 32),
 	}
-
 )
 
 type logOpts struct {
@@ -107,23 +106,23 @@ func mustCreateCheckpoint(t *testing.T, sk string, origin string, size uint64, r
 
 func TestUpdate(t *testing.T) {
 	for _, test := range []struct {
-		desc      string
-		origin    string
-		initC     []byte
-		oldSize   uint64
-		newC      []byte
-		pf        [][]byte
-		wantUpdate    bool
-		wantError error
+		desc       string
+		origin     string
+		initC      []byte
+		oldSize    uint64
+		newC       []byte
+		pf         [][]byte
+		wantUpdate bool
+		wantError  error
 	}{
 		{
-			desc:    "vanilla consistency happy path",
-			origin:  "monkeys",
-			initC:   mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
-			oldSize: 5,
-			newC:    mNext,
-			pf:      consProof,
-			wantUpdate:  true,
+			desc:       "vanilla consistency happy path",
+			origin:     "monkeys",
+			initC:      mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			oldSize:    5,
+			newC:       mNext,
+			pf:         consProof,
+			wantUpdate: true,
 		}, {
 			desc:      "oldSize doesn't match current state",
 			origin:    "monkeys",
@@ -141,12 +140,12 @@ func TestUpdate(t *testing.T) {
 			// Proof should be empty for oldSize=zero.
 			wantError: ErrInvalidProof,
 		}, {
-			desc:    "vanilla resubmit known CP",
-			origin:  "monkeys",
-			initC:   mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
-			oldSize: 5,
-			newC:    mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
-			wantUpdate:  true,
+			desc:       "vanilla resubmit known CP",
+			origin:     "monkeys",
+			initC:      mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			oldSize:    5,
+			newC:       mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			wantUpdate: true,
 		}, {
 			desc:      "resubmit known CP with changed root",
 			origin:    "monkeys",
@@ -222,10 +221,9 @@ func newPersistence() *testPersistence {
 }
 
 type testPersistence struct {
-	mu          sync.RWMutex
+	mu         sync.RWMutex
 	checkpoint []byte
 }
-
 
 func (p *testPersistence) latest(_ context.Context) ([]byte, error) {
 	p.mu.RLock()

--- a/internal/witness/witness_test.go
+++ b/internal/witness/witness_test.go
@@ -1,0 +1,251 @@
+// Copyright 2021 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package witness
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/transparency-dev/formats/log"
+	f_note "github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/merkle/rfc6962"
+	"golang.org/x/mod/sumdb/note"
+)
+
+var (
+	// https://go.dev/play/p/FVJgyhl7URt to regenerate any messages if needed.
+	mPK       = "monkeys+db4d9f7e+AULaJMvTtDLHPUcUrjdDad9vDlh/PTfC2VV60JUtCfWT"
+	mSK       = "PRIVATE+KEY+monkeys+db4d9f7e+ATWIAF3yVBG+Hv1rZFQoNt/BaURkLPtOFMAM2HrEeIr6"
+	// wPK       = "witness+f13a86db+AdYV1Ztajd9BvyjP2HgpwrqYL6TjOwIjGMOq8Bu42xbN"
+	wSK       = "PRIVATE+KEY+witness+f13a86db+AaLa/dfyBhyo/m0Z7WCi98ENVZWtrP8pxgRNrx7tIWiA"
+	mInit     = []byte("monkeys\n5\n41smjBUiAU70EtKlT6lIOIYtRTYxYXsDB+XHfcvu/BE=\n\n— monkeys 202fftzGl3LVoqjXfwCFZZXs8I+5G22+Ek2K0AOyBuSJ/8/CZawNF+6fNlTKOCd622pbzJNkkJFWuw9DbicZCkEx9AY=\n")
+	mNext     = []byte("monkeys\n8\nV8K9aklZ4EPB+RMOk1/8VsJUdFZR77GDtZUQq84vSbo=\n\n— monkeys 202ffoUEboiQYpHzICeaFmoy3RNviHTpAxYrq/eO4QQVQMvu9UebKBMX2MJC76NLthZaKsnKbCA8GxrjePZhvDCH7Ag=\n")
+	consProof = [][]byte{
+		dh("b9e1d62618f7fee8034e4c5010f727ab24d8e4705cb296c374bf2025a87a10d2", 32),
+		dh("aac66cd7a79ce4012d80762fe8eec3a77f22d1ca4145c3f4cee022e7efcd599d", 32),
+		dh("89d0f753f66a290c483b39cd5e9eafb12021293395fad3d4a2ad053cfbcfdc9e", 32),
+		dh("29e40bb79c966f4c6fe96aff6f30acfce5f3e8d84c02215175d6e018a5dee833", 32),
+	}
+
+)
+
+type logOpts struct {
+	origin string
+	PK     string
+}
+
+func newWitness(t *testing.T, log logOpts, p *testPersistence) *Witness {
+	// Set up Opts for the witness.
+	ns, err := f_note.NewSignerForCosignatureV1(wSK)
+	if err != nil {
+		t.Fatalf("couldn't create a witness signer: %v", err)
+	}
+	logV, err := note.NewVerifier(log.PK)
+	if err != nil {
+		t.Fatalf("couldn't create a log verifier: %v", err)
+	}
+	opts := Opts{
+		Persistence: p,
+		Signers:     []note.Signer{ns},
+		LogVerifier: logV,
+	}
+	// Create the witness
+	w, err := New(t.Context(), opts)
+	if err != nil {
+		t.Fatalf("couldn't create witness: %v", err)
+	}
+	return w
+}
+
+// dh is taken from https://github.com/google/trillian/blob/master/merkle/logverifier/log_verifier_test.go.
+func dh(h string, expLen int) []byte {
+	r, err := hex.DecodeString(h)
+	if err != nil {
+		panic(err)
+	}
+	if got := len(r); got != expLen {
+		panic(fmt.Sprintf("decode %q: len=%d, want %d", h, got, expLen))
+	}
+	return r
+}
+
+func mustCreateCheckpoint(t *testing.T, sk string, origin string, size uint64, rootHash []byte) []byte {
+	t.Helper()
+	cp := log.Checkpoint{
+		Origin: origin,
+		Size:   size,
+		Hash:   rootHash,
+	}
+	signer, err := note.NewSigner(sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := note.Sign(&note.Note{Text: string(cp.Marshal())}, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return msg
+}
+
+func TestUpdate(t *testing.T) {
+	for _, test := range []struct {
+		desc      string
+		origin    string
+		initC     []byte
+		oldSize   uint64
+		newC      []byte
+		pf        [][]byte
+		wantUpdate    bool
+		wantError error
+	}{
+		{
+			desc:    "vanilla consistency happy path",
+			origin:  "monkeys",
+			initC:   mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			oldSize: 5,
+			newC:    mNext,
+			pf:      consProof,
+			wantUpdate:  true,
+		}, {
+			desc:      "oldSize doesn't match current state",
+			origin:    "monkeys",
+			initC:     mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			oldSize:   2,
+			newC:      mNext,
+			wantError: ErrCheckpointStale,
+		}, {
+			desc:    "vanilla consistency starting from tree size 0 with proof",
+			origin:  "monkeys",
+			initC:   mustCreateCheckpoint(t, mSK, "monkeys", 0, rfc6962.DefaultHasher.EmptyRoot()),
+			oldSize: 0,
+			newC:    mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			pf:      consProof,
+			// Proof should be empty for oldSize=zero.
+			wantError: ErrInvalidProof,
+		}, {
+			desc:    "vanilla resubmit known CP",
+			origin:  "monkeys",
+			initC:   mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			oldSize: 5,
+			newC:    mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			wantUpdate:  true,
+		}, {
+			desc:      "resubmit known CP with changed root",
+			origin:    "monkeys",
+			initC:     mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			oldSize:   5,
+			newC:      mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("fffffffffffffffef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			wantError: ErrRootMismatch,
+		}, {
+			desc:      "missing proof",
+			origin:    "monkeys",
+			initC:     mustCreateCheckpoint(t, mSK, "monkeys", 4, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			oldSize:   4,
+			newC:      mustCreateCheckpoint(t, mSK, "monkeys", 5, dh("e35b268c1522014ef412d2a54fa94838862d453631617b0307e5c77dcbeefc11", 32)),
+			pf:        [][]byte{},
+			wantError: ErrInvalidProof,
+		}, {
+			desc:      "submit smaller checkpoint",
+			initC:     mNext,
+			oldSize:   8,
+			newC:      mInit,
+			pf:        consProof,
+			wantError: ErrOldSizeInvalid,
+		}, {
+			desc:    "vanilla consistency garbage proof",
+			initC:   mInit,
+			oldSize: 5,
+			newC:    mNext,
+			pf: [][]byte{
+				dh("aaaa", 2),
+				dh("bbbb", 2),
+				dh("cccc", 2),
+				dh("dddd", 2),
+			},
+			wantError: ErrInvalidProof,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := context.Background()
+			p := newPersistence()
+			// Set up witness.
+			w := newWitness(t, logOpts{
+				origin: "monkeys",
+				PK:     mPK,
+			}, p)
+			// Set an initial checkpoint for the log.
+			if _, _, err := w.Update(ctx, 0, test.initC, nil); err != nil {
+				t.Errorf("failed to set checkpoint: %v", err)
+			}
+			// Now update from this checkpoint to a newer one.
+			_, _, err := w.Update(ctx, test.oldSize, test.newC, test.pf)
+			if err != nil {
+				if !errors.Is(err, test.wantError) {
+					t.Fatalf("Got error %v, want %v", err, test.wantError)
+				}
+				return
+			}
+			if test.wantUpdate {
+				curCP, err := p.latest(ctx)
+				if err != nil {
+					t.Fatalf("failed to get latest checkpoint: %v", err)
+				}
+				// curCP should be a prefix of the new CP as the witness will have added a signature.
+				if !bytes.HasPrefix(curCP, test.newC) {
+					t.Fatalf("updated checkpoint != test.newC:\nGot:\n%s\nWant:\n%s\n", curCP, test.newC)
+				}
+			}
+		})
+	}
+}
+
+func newPersistence() *testPersistence {
+	return &testPersistence{}
+}
+
+type testPersistence struct {
+	mu          sync.RWMutex
+	checkpoint []byte
+}
+
+
+func (p *testPersistence) latest(_ context.Context) ([]byte, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.checkpoint, nil
+}
+
+func (p *testPersistence) UpdateCheckpoint(_ context.Context, f func([]byte) ([]byte, error)) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	u, err := f(p.checkpoint)
+	if err != nil {
+		return err
+	}
+
+	bits := bytes.Split(u, []byte{'\n'})
+	if len(bits) == 0 {
+		return errors.New("invalid checkpoint")
+	}
+
+	p.checkpoint = u
+	return nil
+}

--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -49,6 +49,11 @@ func (o *MirrorOptions) WithSigner(s note.Signer) *MirrorOptions {
 	return o
 }
 
+// LogVerifier returns the configured note.Verifier.
+func (o *MirrorOptions) LogVerifier() note.Verifier {
+	return o.logVerifier
+}
+
 // Signer returns the configured note.Signer.
 func (o *MirrorOptions) Signer() note.Signer {
 	return o.signer
@@ -110,8 +115,17 @@ func NewMirrorTarget(ctx context.Context, d Driver, opts *MirrorOptions) (*Mirro
 	if err != nil {
 		return nil, fmt.Errorf("failed to init MirrorTarget lifecycle: %v", err)
 	}
+	w, err := witness.New(ctx, witness.Opts{
+		Persistence: mw,
+		Signers:     []note.Signer{opts.signer},
+		LogVerifier: opts.logVerifier,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create witness: %v", err)
+	}
 	return &MirrorTarget{
-		witness: witness.New(mw),
+		witness: w,
 		writer:  mw,
 		reader:  r,
 	}, nil


### PR DESCRIPTION
This PR adds the logic for a witness to the MTC mirror code.

Towards #945 