### PR TITLE
[Dependabot] Don't bump go version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: /
+  ignore:
+    - dependency-name: "go"
+      versions: ["> 1.25"]
   groups:
     all-go-deps:
       patterns:


### PR DESCRIPTION
We don't want our upstream deps being in control of this. We can change it, but on our own cadence. Obviously major security issues that require a bump can change this cadence, but in general, we do this when the next version of Go is released.
