### PR TITLE
Update `NewClient` to accept a pointer to `Options` instead of a value

### DIFF
--- a/client/mirror/client.go
+++ b/client/mirror/client.go
@@ -131,12 +131,12 @@ type Client struct {
 }
 
 // NewClient creates a new Client with the provided options.
-func NewClient(_ context.Context, opts Options) (*Client, error) {
+func NewClient(_ context.Context, opts *Options) (*Client, error) {
 	if err := opts.validate(); err != nil {
 		return nil, err
 	}
 
-	return &Client{opts: &opts}, nil
+	return &Client{opts: opts}, nil
 }
 
 // ErrConflict is returned by tlog-mirror client operations when the mirror returns a 409 Conflict.

--- a/client/mirror/client_test.go
+++ b/client/mirror/client_test.go
@@ -16,10 +16,15 @@ package mirror
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"errors"
 	"io"
+	"net/http"
+	"net/url"
 	"testing"
+
+	"github.com/transparency-dev/tessera/client"
 )
 
 func TestParseConflict(t *testing.T) {
@@ -165,6 +170,235 @@ func TestBuildCheckpointRequestBody(t *testing.T) {
 			}
 			if got := string(gotBytes); got != tc.want {
 				t.Errorf("buildCheckpointRequestBody() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewOptions tests that NewOptions returns an Options struct with correct default values.
+func TestNewOptions(t *testing.T) {
+	opts := NewOptions()
+	if opts.httpClient != http.DefaultClient {
+		t.Errorf("NewOptions().httpClient = %v, want http.DefaultClient", opts.httpClient)
+	}
+	if opts.mirrorURL != nil {
+		t.Errorf("NewOptions().mirrorURL = %v, want nil", opts.mirrorURL)
+	}
+	if opts.logOrigin != "" {
+		t.Errorf("NewOptions().logOrigin = %q, want empty", opts.logOrigin)
+	}
+	if opts.tileFetcher != nil {
+		t.Errorf("NewOptions().tileFetcher = %v, want nil", opts.tileFetcher)
+	}
+	if opts.bundleFetcher != nil {
+		t.Errorf("NewOptions().bundleFetcher = %v, want nil", opts.bundleFetcher)
+	}
+	if opts.mirrorCheckpointFetcher != nil {
+		t.Errorf("NewOptions().mirrorCheckpointFetcher = %v, want nil", opts.mirrorCheckpointFetcher)
+	}
+	if opts.packageProver != nil {
+		t.Errorf("NewOptions().packageProver = %v, want nil", opts.packageProver)
+	}
+}
+
+// TestOptionsBuilders tests that each of the With... builder methods correctly sets the corresponding field in Options.
+func TestOptionsBuilders(t *testing.T) {
+	u, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatalf("failed to parse test URL: %v", err)
+	}
+	httpClient := &http.Client{}
+	logOrigin := "test-origin"
+	var tileFetcher client.TileFetcherFunc = func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
+		return nil, nil
+	}
+	var bundleFetcher client.EntryBundleFetcherFunc = func(ctx context.Context, index uint64, size uint8) ([]byte, error) {
+		return nil, nil
+	}
+	var mirrorCheckpointFetcher client.CheckpointFetcherFunc = func(ctx context.Context) ([]byte, error) {
+		return nil, nil
+	}
+	var packageProver PackageProverFunc = func(ctx context.Context, start, end uint64) ([][]byte, error) {
+		return nil, nil
+	}
+
+	opts := NewOptions().
+		WithMirrorURL(u).
+		WithHTTPClient(httpClient).
+		WithLogOrigin(logOrigin).
+		WithTileFetcher(tileFetcher).
+		WithBundleFetcher(bundleFetcher).
+		WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
+		WithPackageProver(packageProver)
+
+	if opts.mirrorURL != u {
+		t.Errorf("WithMirrorURL() = %v, want %v", opts.mirrorURL, u)
+	}
+	if opts.httpClient != httpClient {
+		t.Errorf("WithHTTPClient() = %v, want %v", opts.httpClient, httpClient)
+	}
+	if opts.logOrigin != logOrigin {
+		t.Errorf("WithLogOrigin() = %q, want %q", opts.logOrigin, logOrigin)
+	}
+	if opts.tileFetcher == nil {
+		t.Errorf("WithTileFetcher() tileFetcher is nil")
+	}
+	if opts.bundleFetcher == nil {
+		t.Errorf("WithBundleFetcher() bundleFetcher is nil")
+	}
+	if opts.mirrorCheckpointFetcher == nil {
+		t.Errorf("WithMirrorCheckpointFetcher() mirrorCheckpointFetcher is nil")
+	}
+	if opts.packageProver == nil {
+		t.Errorf("WithPackageProver() packageProver is nil")
+	}
+}
+
+// TestNewClientValidation tests that NewClient validates the provided Options and returns errors when required fields are missing.
+func TestNewClientValidation(t *testing.T) {
+	u, _ := url.Parse("https://example.com")
+	httpClient := &http.Client{}
+	logOrigin := "test-origin"
+	var tileFetcher client.TileFetcherFunc = func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) { return nil, nil }
+	var bundleFetcher client.EntryBundleFetcherFunc = func(ctx context.Context, index uint64, size uint8) ([]byte, error) { return nil, nil }
+	var mirrorCheckpointFetcher client.CheckpointFetcherFunc = func(ctx context.Context) ([]byte, error) { return nil, nil }
+	var packageProver PackageProverFunc = func(ctx context.Context, start, end uint64) ([][]byte, error) { return nil, nil }
+
+	tests := []struct {
+		desc    string
+		setup   func() *Options
+		wantErr string
+	}{
+		{
+			desc: "valid options",
+			setup: func() *Options {
+				return NewOptions().
+					WithMirrorURL(u).
+					WithHTTPClient(httpClient).
+					WithLogOrigin(logOrigin).
+					WithTileFetcher(tileFetcher).
+					WithBundleFetcher(bundleFetcher).
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
+					WithPackageProver(packageProver)
+			},
+		},
+		{
+			desc: "missing mirror URL",
+			setup: func() *Options {
+				return NewOptions().
+					WithHTTPClient(httpClient).
+					WithLogOrigin(logOrigin).
+					WithTileFetcher(tileFetcher).
+					WithBundleFetcher(bundleFetcher).
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
+					WithPackageProver(packageProver)
+			},
+			wantErr: "mirror URL is required",
+		},
+		{
+			desc: "missing HTTP client",
+			setup: func() *Options {
+				opts := NewOptions().
+					WithMirrorURL(u).
+					WithLogOrigin(logOrigin).
+					WithTileFetcher(tileFetcher).
+					WithBundleFetcher(bundleFetcher).
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
+					WithPackageProver(packageProver)
+				opts.httpClient = nil
+				return opts
+			},
+			wantErr: "HTTP client is required",
+		},
+		{
+			desc: "missing log origin",
+			setup: func() *Options {
+				return NewOptions().
+					WithMirrorURL(u).
+					WithHTTPClient(httpClient).
+					WithTileFetcher(tileFetcher).
+					WithBundleFetcher(bundleFetcher).
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
+					WithPackageProver(packageProver)
+			},
+			wantErr: "log origin is required",
+		},
+		{
+			desc: "missing tile fetcher",
+			setup: func() *Options {
+				return NewOptions().
+					WithMirrorURL(u).
+					WithHTTPClient(httpClient).
+					WithLogOrigin(logOrigin).
+					WithBundleFetcher(bundleFetcher).
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
+					WithPackageProver(packageProver)
+			},
+			wantErr: "tile fetcher is required",
+		},
+		{
+			desc: "missing bundle fetcher",
+			setup: func() *Options {
+				return NewOptions().
+					WithMirrorURL(u).
+					WithHTTPClient(httpClient).
+					WithLogOrigin(logOrigin).
+					WithTileFetcher(tileFetcher).
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
+					WithPackageProver(packageProver)
+			},
+			wantErr: "bundle fetcher is required",
+		},
+		{
+			desc: "missing mirror checkpoint fetcher",
+			setup: func() *Options {
+				return NewOptions().
+					WithMirrorURL(u).
+					WithHTTPClient(httpClient).
+					WithLogOrigin(logOrigin).
+					WithTileFetcher(tileFetcher).
+					WithBundleFetcher(bundleFetcher).
+					WithPackageProver(packageProver)
+			},
+			wantErr: "mirror checkpoint fetcher is required",
+		},
+		{
+			desc: "missing package prover",
+			setup: func() *Options {
+				return NewOptions().
+					WithMirrorURL(u).
+					WithHTTPClient(httpClient).
+					WithLogOrigin(logOrigin).
+					WithTileFetcher(tileFetcher).
+					WithBundleFetcher(bundleFetcher).
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
+			},
+			wantErr: "package prover is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := tc.setup()
+			ctx := context.Background()
+			client, err := NewClient(ctx, opts)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("NewClient() succeeded, want error containing %q", tc.wantErr)
+				}
+				if got, want := err.Error(), tc.wantErr; got != want {
+					t.Errorf("NewClient() err = %q, want %q", got, want)
+				}
+				if client != nil {
+					t.Errorf("NewClient() returned non-nil client on error: %v", client)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("NewClient() failed: %v", err)
+				}
+				if client == nil {
+					t.Errorf("NewClient() returned nil client on success")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Towards https://github.com/transparency-dev/tessera/issues/945.