### PR TITLE
Add tlog-mirror client `Sync` unit test

### DIFF
--- a/client/mirror/client_test.go
+++ b/client/mirror/client_test.go
@@ -16,11 +16,15 @@ package mirror
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/base64"
+	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 
@@ -401,5 +405,241 @@ func TestNewClientValidation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// fakeMirror is a mock implementation of a tlog-mirror compliant server.
+type fakeMirror struct {
+	t                   *testing.T
+	origin              string
+	ticket              []byte
+	targetCheckpoint    []byte
+	expectedCosigs      []byte
+	numEntries          int
+	proofHashes         [][]byte
+	addEntriesStatus    int
+	addCheckpointStatus int
+}
+
+// newFakeMirror returns a fakeMirror initialized with default mock options for testing.
+func newFakeMirror(t *testing.T, origin string) *fakeMirror {
+	return &fakeMirror{
+		t:                   t,
+		origin:              origin,
+		ticket:              []byte("ticket-value"),
+		targetCheckpoint:    []byte("checkpoint-raw-bytes"),
+		expectedCosigs:      []byte("mock-cosignatures"),
+		numEntries:          5,
+		proofHashes:         [][]byte{bytes.Repeat([]byte{1}, 32)},
+		addEntriesStatus:    http.StatusOK,
+		addCheckpointStatus: http.StatusOK,
+	}
+}
+
+// ServeHTTP handles incoming HTTP requests to mock mirror endpoints (/add-entries, /add-checkpoint).
+func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/add-entries":
+		if r.Method != http.MethodPost {
+			fm.t.Errorf("Method = %q, want %q", r.Method, http.MethodPost)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		gr, err := gzip.NewReader(r.Body)
+		if err != nil {
+			fm.t.Errorf("gzip.NewReader failed: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		defer func() {
+			_ = gr.Close()
+		}()
+
+		var originLen uint16
+		if err := binary.Read(gr, binary.BigEndian, &originLen); err != nil {
+			fm.t.Errorf("failed to read origin length: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		gotOrigin := make([]byte, originLen)
+		if _, err := io.ReadFull(gr, gotOrigin); err != nil {
+			fm.t.Errorf("failed to read origin: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if string(gotOrigin) != fm.origin {
+			fm.t.Errorf("origin = %q, want %q", string(gotOrigin), fm.origin)
+		}
+
+		var start uint64
+		if err := binary.Read(gr, binary.BigEndian, &start); err != nil {
+			fm.t.Errorf("failed to read start: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var end uint64
+		if err := binary.Read(gr, binary.BigEndian, &end); err != nil {
+			fm.t.Errorf("failed to read end: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var gotTicketLen uint16
+		if err := binary.Read(gr, binary.BigEndian, &gotTicketLen); err != nil {
+			fm.t.Errorf("failed to read ticket length: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		gotTicket := make([]byte, gotTicketLen)
+		if _, err := io.ReadFull(gr, gotTicket); err != nil {
+			fm.t.Errorf("failed to read ticket: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if start == 0 && end == 0 {
+			w.WriteHeader(http.StatusConflict)
+			ticketB64 := base64.StdEncoding.EncodeToString(fm.ticket)
+			_, _ = fmt.Fprintf(w, "0\n0\n%s\n", ticketB64)
+			return
+		}
+
+		if start != 0 || end != uint64(fm.numEntries) {
+			fm.t.Errorf("got start/end = %d/%d, want 0/%d", start, end, fm.numEntries)
+		}
+		if !bytes.Equal(gotTicket, fm.ticket) {
+			fm.t.Errorf("got ticket = %q, want %q", string(gotTicket), string(fm.ticket))
+		}
+
+		for i := range fm.numEntries {
+			var entryLen uint16
+			if err := binary.Read(gr, binary.BigEndian, &entryLen); err != nil {
+				fm.t.Errorf("failed to read entry %d length: %v", i, err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			entry := make([]byte, entryLen)
+			if _, err := io.ReadFull(gr, entry); err != nil {
+				fm.t.Errorf("failed to read entry %d: %v", i, err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			expectedEntry := []byte(fmt.Sprintf("entry-%d", i))
+			if !bytes.Equal(entry, expectedEntry) {
+				fm.t.Errorf("entry %d = %q, want %q", i, string(entry), string(expectedEntry))
+			}
+		}
+
+		var numHashes uint8
+		if err := binary.Read(gr, binary.BigEndian, &numHashes); err != nil {
+			fm.t.Errorf("failed to read numHashes: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if int(numHashes) != len(fm.proofHashes) {
+			fm.t.Errorf("numHashes = %d, want %d", numHashes, len(fm.proofHashes))
+		}
+		for i, expectedHash := range fm.proofHashes {
+			gotHash := make([]byte, 32)
+			if _, err := io.ReadFull(gr, gotHash); err != nil {
+				fm.t.Errorf("failed to read hash %d: %v", i, err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if !bytes.Equal(gotHash, expectedHash) {
+				fm.t.Errorf("hash %d = %x, want %x", i, gotHash, expectedHash)
+			}
+		}
+
+		if fm.addEntriesStatus != http.StatusOK {
+			w.WriteHeader(fm.addEntriesStatus)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(fm.expectedCosigs)
+
+	case "/add-checkpoint":
+		if r.Method != http.MethodPost {
+			fm.t.Errorf("Method = %q, want %q", r.Method, http.MethodPost)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			fm.t.Errorf("failed to read body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		expectedBody := fmt.Sprintf("old 0\n\n%s", string(fm.targetCheckpoint))
+		if string(bodyBytes) != expectedBody {
+			fm.t.Errorf("body = %q, want %q", string(bodyBytes), expectedBody)
+		}
+		if fm.addCheckpointStatus != http.StatusOK {
+			w.WriteHeader(fm.addCheckpointStatus)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+
+	default:
+		fm.t.Errorf("Unexpected path: %q", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+// TestSync runs the happy path synchronization flow, verifying client options validation,
+// checkpoint updating, and entry streaming.
+func TestSync(t *testing.T) {
+	origin := "test-origin"
+	fm := newFakeMirror(t, origin)
+	server := httptest.NewServer(fm)
+	defer server.Close()
+
+	u, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatalf("failed to parse server URL: %v", err)
+	}
+
+	tileFetcher := func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
+		return nil, errors.New("tile fetcher should not be called")
+	}
+
+	bundleFetcher := func(ctx context.Context, bundleIndex uint64, p uint8) ([]byte, error) {
+		var buf bytes.Buffer
+		for i := range fm.numEntries {
+			entry := fmt.Appendf(nil, "entry-%d", i)
+			_ = binary.Write(&buf, binary.BigEndian, uint16(len(entry)))
+			buf.Write(entry)
+		}
+		return buf.Bytes(), nil
+	}
+
+	mirrorCheckpointFetcher := func(ctx context.Context) ([]byte, error) {
+		return nil, errors.New("mirror checkpoint fetcher should not be called")
+	}
+
+	packageProver := func(ctx context.Context, start, end uint64) ([][]byte, error) {
+		return fm.proofHashes, nil
+	}
+
+	opts := NewOptions().
+		WithMirrorURL(u).
+		WithLogOrigin(origin).
+		WithTileFetcher(tileFetcher).
+		WithBundleFetcher(bundleFetcher).
+		WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
+		WithPackageProver(packageProver)
+
+	c, err := NewClient(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	cosigs, err := c.Sync(context.Background(), fm.targetCheckpoint, uint64(fm.numEntries))
+	if err != nil {
+		t.Fatalf("Sync() failed: %v", err)
+	}
+
+	if !bytes.Equal(cosigs, fm.expectedCosigs) {
+		t.Errorf("Sync() returned cosigs = %q, want %q", string(cosigs), string(fm.expectedCosigs))
 	}
 }


### PR DESCRIPTION
Towards https://github.com/transparency-dev/tessera/issues/945.

This is the happy path unit test. More tests will be added. The fake server can be replaced with a tlog-mirror POSIX server later.