### PR TITLE
Add simple outline mirror config

### DIFF
--- a/cmd/mtc/mirror/internal/config/config.go
+++ b/cmd/mtc/mirror/internal/config/config.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config contains code and structs for configuring log sources for mirrors.
+package config
+
+// Config represents a collection of logs which are eligible for being mirrored.
+type Config struct {
+	Logs []LogConfig `json:"logs"`
+}
+
+// LogConfig represents the configuration for a single log.
+type LogConfig struct {
+	// VKey is the verification key of the log.
+	// The origin is the name of the key.
+	VKey string `json:"vkey"`
+}

--- a/cmd/mtc/mirror/posix/example_config.json
+++ b/cmd/mtc/mirror/posix/example_config.json
@@ -1,0 +1,34 @@
+{
+  "logs": [
+    {
+      "vkey": "example.com/inmemorylog/0+7fd3f320+AXX8yEKexoMqBPPwG4pGAhhjo5CyiHLiJZ7p3jg0aJZM"
+    },
+    {
+      "vkey": "example.com/inmemorylog/1+d6b76bb3+AS2t66Y8jqA6iglM+/cf9SK9to/kWF5ZOKQuzBizIkt0"
+    },
+    {
+      "vkey": "example.com/inmemorylog/2+6002fc9a+AZZB18AupYoobUi++orjEXTQXs5hADlr2qmWSEF1QF03"
+    },
+    {
+      "vkey": "example.com/inmemorylog/3+2e79c94b+Aeb/wrDMh+K6ePnsCa8tCZ1VGdZrekcn981a3lu8RTNz"
+    },
+    {
+      "vkey": "example.com/inmemorylog/4+077b5e25+AdENMJ7roiENzm8NZkJp2Ab/YgX03/S9nKqhtY5ziXz3"
+    },
+    {
+      "vkey": "example.com/inmemorylog/5+5a1a204b+AXhylT5b4WBj97QDCip0j2tyUfHoPCqRXLEhkV70RqdK"
+    },
+    {
+      "vkey": "example.com/inmemorylog/6+c70112ff+AdrqJRTIbtgTWs/dEMu76q62q4lSbf0O4Z9H61ijZYWm"
+    },
+    {
+      "vkey": "example.com/inmemorylog/7+12af122d+AZVD+MMfLq4VTUdAkaShpPhKCrYxZtkuDysOPBUWv41D"
+    },
+    {
+      "vkey": "example.com/inmemorylog/8+1e515327+AcoawYane0W5D4GbZEf4jPXEjzVFHAkgIhcMaOvzuQel"
+    },
+    {
+      "vkey": "example.com/inmemorylog/9+a7d1f7c9+AZ7IxhHbsA1DlJt6zfoY617Paib7gtkXRD2Tz9uWYiaI"
+    }
+  ]
+}

--- a/cmd/mtc/mirror/posix/main.go
+++ b/cmd/mtc/mirror/posix/main.go
@@ -16,16 +16,19 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
-	"log/slog"
 
 	fnote "github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/cmd/mtc/mirror/internal/config"
 	"github.com/transparency-dev/tessera/cmd/mtc/mirror/internal/handler"
+	"github.com/transparency-dev/witness/omniwitness"
 	"github.com/transparency-dev/witness/witness"
 	"github.com/transparency-dev/witness/persistence/sqlite"
 	"golang.org/x/mod/sumdb/note"
@@ -36,9 +39,10 @@ const (
 )
 
 var (
-	listenAddr      = flag.String("listen_addr", ":8080", "The address to listen on for HTTP requests.")
-	storageDir      = flag.String("storage_dir", "", "Directory to store mirror data.")
+	listenAddr        = flag.String("listen_addr", ":8080", "The address to listen on for HTTP requests.")
+	storageDir        = flag.String("storage_dir", "", "Directory to store mirror data.")
 	witnessSignerPath = flag.String("witness_signer_path", "", "The path to the note-formatted witness signer secret key.")
+	mirrorConfigPath  = flag.String("config_path", "", "The path to the mirror configuration file.")
 )
 
 func main() {
@@ -46,7 +50,7 @@ func main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, nil)))
 	ctx := context.Background()
 	
-	w, shutdown := witnessFromFlags(ctx)
+	w, wp, shutdown := witnessFromFlags(ctx)
 	defer func() {
 		if err := shutdown(); err != nil {
 			slog.ErrorContext(ctx, "Failed to shut down Witness", slog.Any("error", err))
@@ -54,9 +58,24 @@ func main() {
 	}()
 
 	mux := handler.NewMirrorMux()
-	if err := mux.AddTarget("example.com/log", &fakeTarget{}); err != nil {
-		slog.ErrorContext(ctx, "Failed to add target", slog.Any("error", err))
-		os.Exit(1)
+	cfg := mirrorConfigFromFlags(ctx)
+	for _, l := range cfg.Logs {
+		v, err := fnote.NewVerifier(l.VKey)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to create verifier", slog.String("vkey", l.VKey), slog.Any("error", err))
+			os.Exit(1)
+		}
+		origin := v.Name()
+		if err := mux.AddTarget(origin, &fakeTarget{}); err != nil {
+			slog.ErrorContext(ctx, "Failed to add target", slog.String("origin", origin), slog.Any("error", err))
+			os.Exit(1)
+		}
+		if err := wp.AddLogs(ctx, []omniwitness.Log{
+			{Origin: origin, VKey: l.VKey},
+		}); err != nil {
+			slog.ErrorContext(ctx, "Failed to add target log to witness", slog.String("origin", origin), slog.Any("error", err))
+			os.Exit(1)
+		}
 	}
 
 	h := handler.New(mux, w)
@@ -68,49 +87,64 @@ func main() {
 	}
 }
 
+func mirrorConfigFromFlags(ctx context.Context) config.Config {
+	if *mirrorConfigPath == "" {
+		slog.ErrorContext(ctx, "Mirror config path not specified")
+		os.Exit(1)
+	}
+	data, err := os.ReadFile(*mirrorConfigPath)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to read mirror config file", slog.String("path", *mirrorConfigPath), slog.Any("error", err))
+		os.Exit(1)
+	}
+	var cfg config.Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		slog.ErrorContext(ctx, "Failed to unmarshal mirror config", slog.Any("error", err))
+		os.Exit(1)
+	}
+	return cfg
+}
+
 // witnessFromFlags returns a witness instance configured from the provided flags.
 // Exits if the witness could not be created.
 //
 // The returned shutdown func should be called once the witness is no longer in use.
-func witnessFromFlags(ctx context.Context) (*witness.Witness, func() error) {
-	if *storageDir == "" {
-		slog.ErrorContext(ctx, "Storage directory not specified")
-		os.Exit(1)
-	}
-
-	wPath := filepath.Join(*storageDir, witnessDir)
-	if err := os.MkdirAll(wPath, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
-		slog.ErrorContext(ctx, "Failed to create witness directory", slog.String("path", wPath))
-		os.Exit(1)
-	}
-
-	// TODO(al): config.
-	v, err := fnote.NewVerifier("example.com/inmemorylog/0+7fd3f320+AXX8yEKexoMqBPPwG4pGAhhjo5CyiHLiJZ7p3jg0aJZM")
-	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create note verifier", slog.Any("error", err))
-		os.Exit(1)
-	}
-
+func witnessFromFlags(ctx context.Context) (*witness.Witness, *sqlite.Persistence, func() error) {
+ 	if *storageDir == "" {
+ 		slog.ErrorContext(ctx, "Storage directory not specified")
+ 		os.Exit(1)
+ 	}
+ 
+ 	wPath := filepath.Join(*storageDir, witnessDir)
+ 	if err := os.MkdirAll(wPath, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+ 		slog.ErrorContext(ctx, "Failed to create witness directory", slog.String("path", wPath))
+ 		os.Exit(1)
+ 	}
+ 
 	p, shutdown, err := sqlite.New(ctx, sqlite.Opts{
-		Path: filepath.Join(wPath, "witness.db"),
-	})
+ 		Path: filepath.Join(wPath, "witness.db"),
+ 	})
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create witness persistence", slog.String("path", wPath), slog.Any("error", err))
 		os.Exit(1)
 	}
 
-	w, err := witness.New(ctx, witness.Opts{
-		Persistence: p,
-		Signers:     witnessSignerFromFlags(ctx),
+ 	w, err := witness.New(ctx, witness.Opts{
+ 		Persistence: p,
+ 		Signers:     witnessSignerFromFlags(ctx),
 		VerifierForLog: func(ctx context.Context, origin string) (note.Verifier, bool, error) {
-			return v, true, nil
+			log, ok, err := p.Log(ctx, origin)
+			if err != nil || !ok {
+				return nil, false, err
+			}
+			return log.Verifier, true, nil
 		},
 	})
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create witness", slog.Any("error", err))
 		os.Exit(1)
 	}
-	return w, shutdown
+	return w, p, shutdown
 }
 
 // fakeTarget is a temporary mirror target impl, and will be removed in due course.


### PR DESCRIPTION
This PR adds a simple outline of a means to configure logs in the MTC mirror.

Towards #945