### PR TITLE
Support gzip encoding in add-entries requests

### DIFF
--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -15,6 +15,7 @@
 package handler
 
 import (
+	"compress/gzip"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -45,12 +46,40 @@ func New(m *MirrorMux, w *witness.Witness) http.Handler {
 
 func addEntries(m *MirrorMux) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// SPEC: When sending responses, mirrors SHOULD send an Accept-Encoding header that includes gzip
+		w.Header().Add("Accept-Encoding", "gzip")
+
 		// SPEC: The request body MUST have Content-Type of application/octet-stream ...
 		if t := strings.ToLower(r.Header.Get("Content-Type")); t != "application/octet-stream" {
 			http.Error(w, fmt.Sprintf("invalid Content-Type %q", t), http.StatusBadRequest)
 			return
 		}
-		req, err := parseAddEntriesPreamble(r.Body)
+		defer func() {
+			_ = r.Body.Close()
+		}()
+		// SPEC: Mirrors MUST support receiving Content-Encoding: gzip in add-entries requests
+		reader := r.Body
+		switch ce := strings.ToLower(r.Header.Get("Content-Encoding")); ce {
+		case "":
+			// No Content-Encoding header, nothing to do.
+			break
+		case "gzip":
+			var err error
+			reader, err = gzip.NewReader(reader)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("invalid gzip request body: %v", err), http.StatusBadRequest)
+				return
+			}
+			defer func() {
+				_ = reader.Close()
+			}()
+		default:
+			// Log unknown encodings and treat as malformed request
+			slog.WarnContext(r.Context(), "Unknown Content-Encoding", slog.String("encoding", ce))
+			http.Error(w, fmt.Sprintf("unsupported content encoding %q", ce), http.StatusBadRequest)
+			return
+		}
+		req, err := parseAddEntriesPreamble(reader)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to parse header: %v", err), http.StatusBadRequest)
 			return

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -16,11 +16,14 @@ package handler
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/transparency-dev/tessera"
@@ -64,35 +67,95 @@ func TestAddEntries(t *testing.T) {
 	}
 	h := New(mux, nil)
 
-	var body bytes.Buffer
+	var rawBody bytes.Buffer
 
 	// Write preamble
-	_ = binary.Write(&body, binary.BigEndian, uint16(len(testOrigin)))
-	_, _ = body.WriteString(testOrigin)
-	_ = binary.Write(&body, binary.BigEndian, uint64(testUploadStart))
-	_ = binary.Write(&body, binary.BigEndian, uint64(testUploadEnd))
-	_ = binary.Write(&body, binary.BigEndian, uint16(len(testTicket)))
-	_, _ = body.WriteString(testTicket)
+	_ = binary.Write(&rawBody, binary.BigEndian, uint16(len(testOrigin)))
+	_, _ = rawBody.WriteString(testOrigin)
+	_ = binary.Write(&rawBody, binary.BigEndian, uint64(testUploadStart))
+	_ = binary.Write(&rawBody, binary.BigEndian, uint64(testUploadEnd))
+	_ = binary.Write(&rawBody, binary.BigEndian, uint16(len(testTicket)))
+	_, _ = rawBody.WriteString(testTicket)
 
 	// Write entry package
 	for i := range testUploadEnd - testUploadStart {
 		entry := fmt.Appendf(nil, "entry-%d", i)
-		_ = binary.Write(&body, binary.BigEndian, uint16(len(entry)))
-		_, _ = body.Write(entry)
+		_ = binary.Write(&rawBody, binary.BigEndian, uint16(len(entry)))
+		_, _ = rawBody.Write(entry)
 	}
-	_ = body.WriteByte(1)               // num proof hashes
-	_, _ = body.Write(make([]byte, 32)) // 1 hash
+	_ = rawBody.WriteByte(1)               // num proof hashes
+	_, _ = rawBody.Write(make([]byte, 32)) // 1 hash
+	validPayload := rawBody.Bytes()
 
-	req := httptest.NewRequest(http.MethodPost, "/add-entries", &body)
-	req.Header.Add("Content-Type", "application/octet-stream")
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Errorf("want status 200, got %d: %s", w.Code, w.Body.String())
+	tests := []struct {
+		name       string
+		encoding   string
+		body       func() io.Reader
+		wantStatus int
+		wantCosig  bool
+	}{
+		{
+			name:     "uncompressed",
+			encoding: "",
+			body: func() io.Reader {
+				return bytes.NewReader(validPayload)
+			},
+			wantStatus: http.StatusOK,
+			wantCosig:  true,
+		},
+		{
+			name:     "gzip",
+			encoding: "gzip",
+			body: func() io.Reader {
+				var b bytes.Buffer
+				zw := gzip.NewWriter(&b)
+				_, _ = zw.Write(validPayload)
+				_ = zw.Close()
+				return &b
+			},
+			wantStatus: http.StatusOK,
+			wantCosig:  true,
+		},
+		{
+			name:     "invalid gzip",
+			encoding: "gzip",
+			body: func() io.Reader {
+				return strings.NewReader("not-a-gzip-stream")
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:     "unsupported encoding",
+			encoding: "br",
+			body: func() io.Reader {
+				return strings.NewReader("dummy")
+			},
+			wantStatus: http.StatusBadRequest,
+		},
 	}
-	if !bytes.Contains(w.Body.Bytes(), []byte("— test-cosig\n")) {
-		t.Errorf("response does not contain expected cosignature: %s", w.Body.String())
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/add-entries", tc.body())
+			req.Header.Add("Content-Type", "application/octet-stream")
+			if tc.encoding != "" {
+				req.Header.Add("Content-Encoding", tc.encoding)
+			}
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Errorf("want status %d, got %d: %s", tc.wantStatus, w.Code, w.Body.String())
+			}
+			if tc.wantCosig {
+				if !bytes.Contains(w.Body.Bytes(), []byte("— test-cosig\n")) {
+					t.Errorf("response does not contain expected cosignature: %s", w.Body.String())
+				}
+				if got := w.Header().Get("Accept-Encoding"); got != "gzip" {
+					t.Errorf("want Accept-Encoding gzip, got %q", got)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This PR adds support for reading `add-entries` requests with `gzip` encoded bodies.