### PR TITLE
Copy hammer from tlog-tiles for tlog-mirror

### DIFF
--- a/internal/mirror/hammer/README.md
+++ b/internal/mirror/hammer/README.md
@@ -1,0 +1,45 @@
+# Hammer: A load testing tool for tlog-mirror servers
+
+This hammer sets up write traffic to a mirror to test correctness and performance under load.
+The write traffic is sent according to the [tlog-mirror](https://c2sp.org/tlog-mirror) spec, and thus could be used to load test any tlog-mirror server.
+
+The target log must support `POST` requests to both `/add-checkpoint` and `add-entries` paths.
+
+## UI
+
+The hammer runs using a text-based UI in the terminal that shows the current status, logs, and supports increasing/decreasing read and write traffic.
+The process can be killed with `<Ctrl-C>`.
+This TUI allows for a level of interactivity when probing a new configuration of a log in order to find any cliffs where performance degrades.
+
+For real load-testing applications, especially headless runs as part of a CI pipeline, it is recommended to run the tool with `show_ui=false` in order to disable the UI.
+
+## Usage
+
+Example usage to test a deployment of `cmd/conformance/posix`:
+
+```shell
+go run ./internal/mirror/hammer \
+  --log_public_key=transparency.dev/tessera/example+ae330e15+ASf4/L1zE859VqlfQgGzKy34l91Gl8W6wfwp+vKP62DW \
+  --log_url=http://localhost:2024 \
+  --max_read_ops=1024 \
+  --num_readers_random=128 \
+  --num_readers_full=128 \
+  --num_writers=256 \
+  --max_write_ops=42
+```
+
+For a headless write-only example that could be used for integration tests, this command attempts to write 2500 leaves within 1 minute.
+If the target number of leaves is reached then it exits successfully.
+If the timeout of 1 minute is reached first, then it exits with an exit code of 1.
+
+```shell
+go run ./internal/mirror/hammer \
+  --log_public_key=transparency.dev/tessera/example+ae330e15+ASf4/L1zE859VqlfQgGzKy34l91Gl8W6wfwp+vKP62DW \
+  --log_url=http://localhost:2024 \
+  --max_read_ops=0 \
+  --num_writers=512 \
+  --max_write_ops=512 \
+  --max_runtime=1m \
+  --leaf_write_goal=2500 \
+  --show_ui=false
+```

--- a/internal/mirror/hammer/hammer.go
+++ b/internal/mirror/hammer/hammer.go
@@ -1,0 +1,364 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// hammer is a tool to load test a Tessera log.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"net/http/httptrace"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/transparency-dev/tessera/client"
+	"github.com/transparency-dev/tessera/internal/hammer/loadtest"
+	"golang.org/x/mod/sumdb/note"
+	"golang.org/x/net/http2"
+
+	"log/slog"
+)
+
+func init() {
+	flag.Var(&logURL, "log_url", "Log storage root URL (can be specified multiple times), e.g. https://log.server/and/path/")
+	flag.Var(&writeLogURL, "write_log_url", "Root URL for writing to a log (can be specified multiple times), e.g. https://log.server/and/path/ (optional, defaults to log_url)")
+}
+
+var (
+	logURL      multiStringFlag
+	writeLogURL multiStringFlag
+
+	logPubKey = flag.String("log_public_key", os.Getenv("TILES_LOG_PUBLIC_KEY"), "Public key for the log. This is defaulted to the environment variable TILES_LOG_PUBLIC_KEY")
+
+	maxReadOpsPerSecond = flag.Int("max_read_ops", 20, "The maximum number of read operations per second")
+	numReadersRandom    = flag.Int("num_readers_random", 4, "The number of readers looking for random leaves")
+	numReadersFull      = flag.Int("num_readers_full", 4, "The number of readers downloading the whole log")
+
+	maxWriteOpsPerSecond = flag.Int("max_write_ops", 0, "The maximum number of write operations per second")
+	numWriters           = flag.Int("num_writers", 0, "The number of independent write tasks to run")
+
+	leafMinSize = flag.Int("leaf_min_size", 0, "Minimum size in bytes of individual leaves")
+	dupChance   = flag.Float64("dup_chance", 0.1, "The probability of a generated leaf being a duplicate of a previous value")
+
+	leafWriteGoal = flag.Int64("leaf_write_goal", 0, "Exit after writing this number of leaves, or 0 to keep going indefinitely")
+	maxRunTime    = flag.Duration("max_runtime", 0, "Fail after this amount of time has passed, or 0 to keep going indefinitely")
+
+	showUI = flag.Bool("show_ui", true, "Set to false to disable the text-based UI")
+
+	bearerToken      = flag.String("bearer_token", "", "The bearer token for auth. For GCP this is the result of `gcloud auth print-access-token`")
+	bearerTokenWrite = flag.String("bearer_token_write", "", "The bearer token for auth to write. For GCP this is the result of `gcloud auth print-identity-token`. If unset will default to --bearer_token.")
+
+	httpTimeout = flag.Duration("http_timeout", 30*time.Second, "Timeout for HTTP requests")
+	forceHTTP2  = flag.Bool("force_http2", false, "Use HTTP/2 connections *only*")
+	slogLevel   = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
+
+	hc *http.Client
+)
+
+func main() {
+	flag.Parse()
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
+
+	hc = &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:        *numWriters + *numReadersFull + *numReadersRandom,
+			MaxIdleConnsPerHost: *numWriters + *numReadersFull + *numReadersRandom,
+			DisableKeepAlives:   false,
+		},
+		Timeout: *httpTimeout,
+	}
+	if *forceHTTP2 {
+		hc.Transport = &http2.Transport{
+			// So http2.Transport doesn't complain the URL scheme isn't 'https'
+			AllowHTTP: true,
+			// Pretend we are dialing a TLS endpoint. (Note, we ignore the passed tls.Config)
+			DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, network, addr)
+			},
+		}
+	}
+
+	// If bearerTokenWrite is unset, default it to whatever bearerToken has (which may too be unset).
+	if *bearerTokenWrite == "" {
+		*bearerTokenWrite = *bearerToken
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	logSigV, err := note.NewVerifier(*logPubKey)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to create verifier", slog.Any("error", err))
+		os.Exit(1)
+	}
+
+	r := mustCreateReaders(ctx, logURL)
+	if len(writeLogURL) == 0 {
+		writeLogURL = logURL
+	}
+	w := mustCreateWriters(ctx, writeLogURL)
+
+	var cpRaw []byte
+	cons := client.UnilateralConsensus(r.ReadCheckpoint)
+	tracker, err := client.NewLogStateTracker(ctx, r.ReadTile, cpRaw, logSigV, logSigV.Name(), cons)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to create LogStateTracker", slog.Any("error", err))
+		os.Exit(1)
+	}
+	// Fetch initial state of log
+	_, _, _, err = tracker.Update(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to get initial state of the log", slog.Any("error", err))
+		os.Exit(1)
+	}
+
+	ha := loadtest.NewHammerAnalyser(func() uint64 { return tracker.Latest().Size })
+	ha.Run(ctx)
+
+	gen := newLeafGenerator(tracker.Latest().Size, *leafMinSize, *dupChance)
+	opts := loadtest.HammerOpts{
+		MaxReadOpsPerSecond:  *maxReadOpsPerSecond,
+		MaxWriteOpsPerSecond: *maxWriteOpsPerSecond,
+		NumReadersRandom:     *numReadersRandom,
+		NumReadersFull:       *numReadersFull,
+		NumWriters:           *numWriters,
+	}
+	hammer := loadtest.NewHammer(tracker, r.ReadEntryBundle, w, gen, ha.SeqLeafChan, ha.ErrChan, opts)
+
+	exitCode := 0
+	if *leafWriteGoal > 0 {
+		go func() {
+			startTime := time.Now()
+			goal := tracker.Latest().Size + uint64(*leafWriteGoal)
+			slog.InfoContext(ctx, "Waiting for target tree size", slog.Uint64("size", goal))
+			tick := time.NewTicker(1 * time.Second)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-tick.C:
+					if tracker.Latest().Size >= goal {
+						elapsed := time.Since(startTime)
+						slog.InfoContext(ctx, "Reached tree size goal; exiting", slog.Uint64("size", goal), slog.Duration("elapsed", elapsed))
+						cancel()
+						return
+					}
+				}
+			}
+		}()
+	}
+	if *maxRunTime > 0 {
+		go func() {
+			slog.InfoContext(ctx, "Configured max runtime", slog.Duration("duration", *maxRunTime))
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(*maxRunTime):
+					slog.InfoContext(ctx, "Max runtime reached; exiting")
+					exitCode = 1
+					cancel()
+					return
+				}
+			}
+		}()
+	}
+	hammer.Run(ctx)
+
+	if *showUI {
+		c := loadtest.NewController(hammer, ha)
+		c.Run(ctx)
+	} else {
+		<-ctx.Done()
+	}
+	os.Exit(exitCode)
+}
+
+// newLeafGenerator returns a function that generates values to append to a log.
+// The leaves are constructed to be at least minLeafSize bytes long.
+// The generator can be used by concurrent threads.
+//
+// dupChance provides the probability that a new leaf will be a duplicate of a previous entry.
+// Leaves will be unique if dupChance is 0, and if set to 1 then all values will be duplicates.
+// startSize should be set to the initial size of the log so that repeated runs of the
+// hammer can start seeding leaves to avoid duplicates with previous runs.
+func newLeafGenerator(startSize uint64, minLeafSize int, dupChance float64) func() []byte {
+	// genLeaf MUST be determinstic given n
+	genLeaf := func(n uint64) []byte {
+		// Make a slice with half the number of requested bytes since we'll
+		// hex-encode them below which gets us back up to the full amount.
+		filler := make([]byte, minLeafSize/2)
+		source := rand.New(rand.NewPCG(0, n))
+		for i := range filler {
+			// This throws away a lot of the generated data. An exercise to a future
+			// coder is to fill in multiple bytes at a time.
+			filler[i] = byte(source.Int())
+		}
+		return fmt.Appendf(nil, "%x %d", filler, n)
+	}
+
+	sizeLocked := startSize
+	var mu sync.Mutex
+	return func() []byte {
+		mu.Lock()
+		thisSize := sizeLocked
+
+		if thisSize > 0 && rand.Float64() <= dupChance {
+			thisSize = rand.Uint64N(thisSize)
+		} else {
+			sizeLocked++
+		}
+		mu.Unlock()
+
+		// Do this outside of the protected block so that writers don't block on leaf generation (especially for larger leaves).
+		return genLeaf(thisSize)
+	}
+}
+
+func mustCreateReaders(ctx context.Context, us []string) loadtest.LogReader {
+	r := []loadtest.LogReader{}
+	for _, u := range us {
+		if !strings.HasSuffix(u, "/") {
+			u += "/"
+		}
+		rURL, err := url.Parse(u)
+		if err != nil {
+			slog.ErrorContext(ctx, "Invalid log reader URL", slog.String("u", u), slog.Any("error", err))
+			os.Exit(1)
+		}
+
+		switch rURL.Scheme {
+		case "http", "https":
+			c, err := client.NewHTTPFetcher(rURL, hc)
+			if err != nil {
+				slog.ErrorContext(ctx, "Failed to create HTTP fetcher", slog.String("u", u), slog.Any("error", err))
+				os.Exit(1)
+			}
+			if *bearerToken != "" {
+				c.SetAuthorizationHeader(fmt.Sprintf("Bearer %s", *bearerToken))
+			}
+			r = append(r, c)
+		case "file":
+			r = append(r, client.FileFetcher{Root: rURL.Path})
+		default:
+			slog.ErrorContext(ctx, "Unsupported scheme on log URL", slog.String("scheme", rURL.Scheme))
+			os.Exit(1)
+		}
+	}
+	return loadtest.NewRoundRobinReader(r)
+}
+
+func mustCreateWriters(ctx context.Context, us []string) loadtest.LeafWriter {
+	w := []loadtest.LeafWriter{}
+	for _, u := range us {
+		if !strings.HasSuffix(u, "/") {
+			u += "/"
+		}
+		u += "add"
+		wURL, err := url.Parse(u)
+		if err != nil {
+			slog.ErrorContext(ctx, "Invalid log writer URL", slog.String("u", u), slog.Any("error", err))
+			os.Exit(1)
+		}
+		w = append(w, httpWriter(ctx, wURL, hc, *bearerTokenWrite))
+	}
+	return loadtest.NewRoundRobinWriter(w)
+}
+
+func httpWriter(ctx context.Context, u *url.URL, hc *http.Client, bearerToken string) loadtest.LeafWriter {
+	cTrace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) { slog.InfoContext(ctx, "connection established %#v") },
+	}
+	return func(ctx context.Context, newLeaf []byte) (uint64, error) {
+		req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(newLeaf))
+		if err != nil {
+			return 0, fmt.Errorf("failed to create request: %v", err)
+		}
+		if bearerToken != "" {
+			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", bearerToken))
+		}
+		reqCtx := req.Context()
+		if slog.Default().Enabled(ctx, slog.LevelDebug) {
+			reqCtx = httptrace.WithClientTrace(req.Context(), cTrace)
+		}
+		resp, err := hc.Do(req.WithContext(reqCtx))
+		if err != nil {
+			return 0, fmt.Errorf("failed to write leaf: %v", err)
+		}
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return 0, fmt.Errorf("failed to read body: %v", err)
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			if resp.Request.Method != http.MethodPost {
+				return 0, fmt.Errorf("write leaf was redirected to %s", resp.Request.URL)
+			}
+			// Continue below
+		case http.StatusServiceUnavailable, http.StatusBadGateway, http.StatusGatewayTimeout, http.StatusTooManyRequests:
+			// These status codes may indicate a delay before retrying, so handle that here:
+			time.Sleep(retryDelay(resp.Header.Get("Retry-After"), time.Second))
+
+			return 0, fmt.Errorf("log not available. Status code: %d. Body: %q %w", resp.StatusCode, body, loadtest.ErrRetry)
+		default:
+			return 0, fmt.Errorf("write leaf was not OK. Status code: %d. Body: %q", resp.StatusCode, body)
+		}
+		parts := bytes.Split(body, []byte("\n"))
+		index, err := strconv.ParseUint(string(parts[0]), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("write leaf failed to parse response: %v", body)
+		}
+		return index, nil
+	}
+}
+
+func retryDelay(retryAfter string, defaultDur time.Duration) time.Duration {
+	if retryAfter == "" {
+		return defaultDur
+	}
+	d, err := time.Parse(http.TimeFormat, retryAfter)
+	if err == nil {
+		return time.Until(d)
+	}
+	s, err := strconv.Atoi(retryAfter)
+	if err == nil {
+		return time.Duration(s) * time.Second
+	}
+	return defaultDur
+}
+
+// multiStringFlag allows a flag to be specified multiple times on the command
+// line, and stores all of these values.
+type multiStringFlag []string
+
+func (ms *multiStringFlag) String() string {
+	return strings.Join(*ms, ",")
+}
+
+func (ms *multiStringFlag) Set(w string) error {
+	*ms = append(*ms, w)
+	return nil
+}

--- a/internal/mirror/hammer/hammer_test.go
+++ b/internal/mirror/hammer/hammer_test.go
@@ -1,0 +1,37 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestLeafGenerator(t *testing.T) {
+	// Always generate new values
+	gN := newLeafGenerator(0, 100, 0)
+	vs := make(map[string]bool)
+	for range 256 {
+		v := string(gN())
+		vs[v] = true
+	}
+
+	// Always generate duplicate
+	gD := newLeafGenerator(256, 100, 1.0)
+	for range 256 {
+		if !vs[string(gD())] {
+			t.Error("Expected duplicate")
+		}
+	}
+}

--- a/internal/mirror/hammer/loadtest/analysis.go
+++ b/internal/mirror/hammer/loadtest/analysis.go
@@ -1,0 +1,144 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"log/slog"
+
+	movingaverage "github.com/RobinUS2/golang-moving-average"
+)
+
+func NewHammerAnalyser(treeSizeFn func() uint64) *HammerAnalyser {
+	leafSampleChan := make(chan LeafTime, 100)
+	errChan := make(chan error, 20)
+	return &HammerAnalyser{
+		treeSizeFn:      treeSizeFn,
+		SeqLeafChan:     leafSampleChan,
+		ErrChan:         errChan,
+		IntegrationTime: movingaverage.Concurrent(movingaverage.New(30)),
+		QueueTime:       movingaverage.Concurrent(movingaverage.New(30)),
+	}
+}
+
+// HammerAnalyser is responsible for measuring and interpreting the result of hammering.
+type HammerAnalyser struct {
+	treeSizeFn  func() uint64
+	SeqLeafChan chan LeafTime
+	ErrChan     chan error
+
+	QueueTime       *movingaverage.ConcurrentMovingAverage
+	IntegrationTime *movingaverage.ConcurrentMovingAverage
+}
+
+func (a *HammerAnalyser) Run(ctx context.Context) {
+	go a.updateStatsLoop(ctx)
+	go a.errorLoop(ctx)
+}
+
+func (a *HammerAnalyser) updateStatsLoop(ctx context.Context) {
+	tick := time.NewTicker(100 * time.Millisecond)
+	size := a.treeSizeFn()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+		}
+		newSize := a.treeSizeFn()
+		if newSize <= size {
+			continue
+		}
+		now := time.Now()
+		totalLatency := time.Duration(0)
+		queueLatency := time.Duration(0)
+		numLeaves := 0
+		var sample *LeafTime
+	ReadLoop:
+		for {
+			if sample == nil {
+				select {
+				case l, ok := <-a.SeqLeafChan:
+					if !ok {
+						break ReadLoop
+					}
+					sample = &l
+				default:
+					break ReadLoop
+				}
+			}
+			// Stop considering leaf times once we've caught up with that cross
+			// either the current checkpoint or "now":
+			// - leaves with indices beyond the tree size we're considering are not integrated yet, so we can't calculate their TTI
+			// - leaves which were queued before "now", but not assigned by "now" should also be ignored as they don't fall into this epoch (and would contribute a -ve latency if they were included).
+			if sample.Index >= newSize || sample.AssignedAt.After(now) {
+				break
+			}
+			queueLatency += sample.AssignedAt.Sub(sample.QueuedAt)
+			// totalLatency is skewed towards being higher than perhaps it may technically be by:
+			// - the tick interval of this goroutine,
+			// - the tick interval of the goroutine which updates the LogStateTracker,
+			// - any latency in writes to the log becoming visible for reads.
+			// But it's probably good enough for now.
+			totalLatency += now.Sub(sample.QueuedAt)
+
+			numLeaves++
+			sample = nil
+		}
+		if numLeaves > 0 {
+			a.IntegrationTime.Add(float64(totalLatency/time.Millisecond) / float64(numLeaves))
+			a.QueueTime.Add(float64(queueLatency/time.Millisecond) / float64(numLeaves))
+		}
+	}
+}
+
+func (a *HammerAnalyser) errorLoop(ctx context.Context) {
+	tick := time.NewTicker(time.Second)
+	pbCount := 0
+	lastErr := ""
+	lastErrCount := 0
+	for {
+		select {
+		case <-ctx.Done(): //context cancelled
+			return
+		case <-tick.C:
+			if pbCount > 0 {
+				slog.WarnContext(ctx, "received pushback from log", slog.Int("requests", pbCount))
+				pbCount = 0
+			}
+			if lastErrCount > 0 {
+				slog.WarnContext(ctx, "errors", slog.Int("count", lastErrCount), slog.String("lasterror", lastErr))
+				lastErrCount = 0
+			}
+		case err := <-a.ErrChan:
+			if errors.Is(err, ErrRetry) {
+				pbCount++
+				continue
+			}
+			es := err.Error()
+			if es != lastErr && lastErrCount > 0 {
+				slog.WarnContext(ctx, "errors", slog.Int("count", lastErrCount), slog.String("lasterror", lastErr))
+				lastErr = es
+				lastErrCount = 0
+				continue
+			}
+			lastErr = es
+			lastErrCount++
+		}
+	}
+}

--- a/internal/mirror/hammer/loadtest/analysis_test.go
+++ b/internal/mirror/hammer/loadtest/analysis_test.go
@@ -1,0 +1,65 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestHammerAnalyser_Stats(t *testing.T) {
+	ctx := t.Context()
+
+	var treeSize treeSizeState
+	ha := NewHammerAnalyser(treeSize.getSize)
+
+	go ha.updateStatsLoop(ctx)
+
+	time.Sleep(100 * time.Millisecond)
+
+	baseTime := time.Now().Add(-1 * time.Minute)
+	for i := range 10 {
+		ha.SeqLeafChan <- LeafTime{
+			Index:      uint64(i),
+			QueuedAt:   baseTime,
+			AssignedAt: baseTime.Add(time.Duration(i) * time.Second),
+		}
+	}
+	treeSize.setSize(10)
+	time.Sleep(500 * time.Millisecond)
+
+	avg := ha.QueueTime.Avg()
+	if want := float64(4500); avg != want {
+		t.Errorf("integration time avg: got != want (%f != %f)", avg, want)
+	}
+}
+
+type treeSizeState struct {
+	size uint64
+	mux  sync.RWMutex
+}
+
+func (s *treeSizeState) getSize() uint64 {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	return s.size
+}
+
+func (s *treeSizeState) setSize(size uint64) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.size = size
+}

--- a/internal/mirror/hammer/loadtest/client.go
+++ b/internal/mirror/hammer/loadtest/client.go
@@ -1,0 +1,89 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var ErrRetry = errors.New("retry")
+
+// NewRoundRobinReader creates a new LogReader which will spread read requests over the passed-in LogReaders.
+func NewRoundRobinReader(r []LogReader) LogReader {
+	return &roundRobinReader{r: r}
+}
+
+// NewRoundRobinWriter creates a new LeafWriter which will spread write requests over the passed-in LeafWriters.
+func NewRoundRobinWriter(w []LeafWriter) LeafWriter {
+	return (&roundRobinLeafWriter{ws: w}).Write
+}
+
+// roundRobinReader ensures that read requests are sent to all configured readers
+// using a round-robin strategy.
+type roundRobinReader struct {
+	sync.Mutex
+	idx int
+	r   []LogReader
+}
+
+func (rr *roundRobinReader) ReadCheckpoint(ctx context.Context) ([]byte, error) {
+	r := rr.next()
+	return r.ReadCheckpoint(ctx)
+}
+
+func (rr *roundRobinReader) ReadTile(ctx context.Context, l, i uint64, p uint8) ([]byte, error) {
+	r := rr.next()
+	return r.ReadTile(ctx, l, i, p)
+}
+
+func (rr *roundRobinReader) ReadEntryBundle(ctx context.Context, i uint64, p uint8) ([]byte, error) {
+	r := rr.next()
+	return r.ReadEntryBundle(ctx, i, p)
+}
+
+func (rr *roundRobinReader) next() LogReader {
+	rr.Lock()
+	defer rr.Unlock()
+
+	r := rr.r[rr.idx]
+	rr.idx = (rr.idx + 1) % len(rr.r)
+
+	return r
+}
+
+// roundRobinLeafWriter ensures that write requests are sent to all configured
+// LeafWriters using a round-robin strategy.
+type roundRobinLeafWriter struct {
+	sync.Mutex
+	idx int
+	ws  []LeafWriter
+}
+
+func (rr *roundRobinLeafWriter) Write(ctx context.Context, newLeaf []byte) (uint64, error) {
+	w := rr.next()
+	return w(ctx, newLeaf)
+}
+
+func (rr *roundRobinLeafWriter) next() LeafWriter {
+	rr.Lock()
+	defer rr.Unlock()
+
+	w := rr.ws[rr.idx]
+	rr.idx = (rr.idx + 1) % len(rr.ws)
+
+	return w
+}

--- a/internal/mirror/hammer/loadtest/hammer.go
+++ b/internal/mirror/hammer/loadtest/hammer.go
@@ -1,0 +1,119 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/transparency-dev/tessera/client"
+
+	"log/slog"
+)
+
+type HammerOpts struct {
+	MaxReadOpsPerSecond  int
+	MaxWriteOpsPerSecond int
+
+	NumReadersRandom int
+	NumReadersFull   int
+	NumWriters       int
+}
+
+func NewHammer(tracker *client.LogStateTracker, f client.EntryBundleFetcherFunc, w LeafWriter, gen func() []byte, seqLeafChan chan<- LeafTime, errChan chan<- error, opts HammerOpts) *Hammer {
+	readThrottle := NewThrottle(opts.MaxReadOpsPerSecond)
+	writeThrottle := NewThrottle(opts.MaxWriteOpsPerSecond)
+
+	randomReaders := NewWorkerPool(func() Worker {
+		return NewLeafReader(tracker, f, RandomNextLeaf(), readThrottle.TokenChan, errChan)
+	})
+	fullReaders := NewWorkerPool(func() Worker {
+		return NewLeafReader(tracker, f, MonotonicallyIncreasingNextLeaf(), readThrottle.TokenChan, errChan)
+	})
+	writers := NewWorkerPool(func() Worker {
+		return NewLogWriter(w, gen, writeThrottle.TokenChan, errChan, seqLeafChan)
+	})
+
+	return &Hammer{
+		opts:          opts,
+		randomReaders: randomReaders,
+		fullReaders:   fullReaders,
+		writers:       writers,
+		readThrottle:  readThrottle,
+		writeThrottle: writeThrottle,
+		tracker:       tracker,
+	}
+}
+
+// Hammer is responsible for coordinating the operations against the log in the form
+// of write and read operations. The work of analysing the results of hammering should
+// live outside of this class.
+type Hammer struct {
+	opts          HammerOpts
+	randomReaders WorkerPool
+	fullReaders   WorkerPool
+	writers       WorkerPool
+	readThrottle  *Throttle
+	writeThrottle *Throttle
+	tracker       *client.LogStateTracker
+}
+
+func (h *Hammer) Run(ctx context.Context) {
+	// Kick off readers & writers
+	for range h.opts.NumReadersRandom {
+		h.randomReaders.Grow(ctx)
+	}
+	for range h.opts.NumReadersFull {
+		h.fullReaders.Grow(ctx)
+	}
+	for range h.opts.NumWriters {
+		h.writers.Grow(ctx)
+	}
+
+	go h.readThrottle.Run(ctx)
+	go h.writeThrottle.Run(ctx)
+
+	go h.updateCheckpointLoop(ctx)
+}
+
+func (h *Hammer) updateCheckpointLoop(ctx context.Context) {
+	tick := time.NewTicker(500 * time.Millisecond)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			size := h.tracker.Latest().Size
+			_, _, _, err := h.tracker.Update(ctx)
+			if err != nil {
+				slog.WarnContext(ctx, "Failed to update LogStateTracker", slog.Any("error", err))
+				inconsistentErr := client.ErrInconsistency{}
+				if errors.As(err, &inconsistentErr) {
+					slog.ErrorContext(ctx, fmt.Sprintf("Last Good Checkpoint:\n%s\n\nFirst Bad Checkpoint:\n%s\n\n%v", string(inconsistentErr.SmallerRaw), string(inconsistentErr.LargerRaw), inconsistentErr), slog.Any("error", inconsistentErr))
+					os.Exit(1)
+				}
+			}
+			newSize := h.tracker.Latest().Size
+			if newSize > size {
+				slog.DebugContext(ctx, "Updated checkpoint", slog.Uint64("from", size), slog.Uint64("to", newSize))
+			} else {
+				slog.DebugContext(ctx, "Checkpoint size unchanged", slog.Uint64("size", newSize))
+			}
+		}
+	}
+}

--- a/internal/mirror/hammer/loadtest/throttle.go
+++ b/internal/mirror/hammer/loadtest/throttle.go
@@ -1,0 +1,91 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+func NewThrottle(opsPerSecond int) *Throttle {
+	return &Throttle{
+		opsPerSecond: opsPerSecond,
+		TokenChan:    make(chan bool, opsPerSecond),
+	}
+}
+
+type Throttle struct {
+	TokenChan    chan bool
+	mu           sync.Mutex
+	opsPerSecond int
+
+	oversupply int
+}
+
+func (t *Throttle) Increase() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	tokenCount := t.opsPerSecond
+	delta := max(float64(tokenCount)*0.1, 1)
+	t.opsPerSecond = tokenCount + int(delta)
+}
+
+func (t *Throttle) Decrease() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	tokenCount := t.opsPerSecond
+	if tokenCount <= 1 {
+		return
+	}
+	delta := max(float64(tokenCount)*0.1, 1)
+	t.opsPerSecond = tokenCount - int(delta)
+}
+
+func (t *Throttle) Run(ctx context.Context) {
+	interval := time.Second
+	ticker := time.NewTicker(interval)
+	for {
+		select {
+		case <-ctx.Done(): //context cancelled
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(ctx, interval)
+			t.supplyTokens(ctx)
+			cancel()
+		}
+	}
+}
+
+func (t *Throttle) supplyTokens(ctx context.Context) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	tokenCount := t.opsPerSecond
+	for range t.opsPerSecond {
+		select {
+		case t.TokenChan <- true:
+			tokenCount--
+		case <-ctx.Done():
+			t.oversupply = tokenCount
+			return
+		}
+	}
+	t.oversupply = 0
+}
+
+func (t *Throttle) String() string {
+	return fmt.Sprintf("Current max: %d/s. Oversupply in last second: %d", t.opsPerSecond, t.oversupply)
+}

--- a/internal/mirror/hammer/loadtest/tui.go
+++ b/internal/mirror/hammer/loadtest/tui.go
@@ -1,0 +1,145 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"log/slog"
+
+	movingaverage "github.com/RobinUS2/golang-moving-average"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type tuiController struct {
+	hammer     *Hammer
+	analyser   *HammerAnalyser
+	app        *tview.Application
+	statusView *tview.TextView
+	logView    *tview.TextView
+	helpView   *tview.TextView
+}
+
+func NewController(h *Hammer, a *HammerAnalyser) *tuiController {
+	c := tuiController{
+		hammer:   h,
+		analyser: a,
+		app:      tview.NewApplication(),
+	}
+	grid := tview.NewGrid()
+	grid.SetRows(5, 0, 10).SetColumns(0).SetBorders(true)
+
+	// Top: status box
+	statusView := tview.NewTextView()
+	grid.AddItem(statusView, 0, 0, 1, 1, 0, 0, false)
+	c.statusView = statusView
+
+	// Middle: log view box
+	logView := tview.NewTextView()
+	logView.ScrollToEnd()
+	logView.SetMaxLines(10000)
+	grid.AddItem(logView, 1, 0, 1, 1, 0, 0, false)
+	c.logView = logView
+
+	// Bottom: help text
+	helpView := tview.NewTextView()
+	helpView.SetText("+/- to increase/decrease read load\n>/< to increase/decrease write load\nw/W to increase/decrease workers")
+	grid.AddItem(helpView, 2, 0, 1, 1, 0, 0, false)
+	c.helpView = helpView
+
+	c.app.SetRoot(grid, true)
+	return &c
+}
+
+func (c *tuiController) Run(ctx context.Context) {
+	go c.updateStatsLoop(ctx, 500*time.Millisecond)
+
+	c.app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Rune() {
+		case '+':
+			slog.InfoContext(ctx, "Increasing the read operations per second")
+			c.hammer.readThrottle.Increase()
+		case '-':
+			slog.InfoContext(ctx, "Decreasing the read operations per second")
+			c.hammer.readThrottle.Decrease()
+		case '>':
+			slog.InfoContext(ctx, "Increasing the write operations per second")
+			c.hammer.writeThrottle.Increase()
+		case '<':
+			slog.InfoContext(ctx, "Decreasing the write operations per second")
+			c.hammer.writeThrottle.Decrease()
+		case 'w':
+			slog.InfoContext(ctx, "Increasing the number of workers")
+			c.hammer.randomReaders.Grow(ctx)
+			c.hammer.fullReaders.Grow(ctx)
+			c.hammer.writers.Grow(ctx)
+		case 'W':
+			slog.InfoContext(ctx, "Decreasing the number of workers")
+			c.hammer.randomReaders.Shrink(ctx)
+			c.hammer.fullReaders.Shrink(ctx)
+			c.hammer.writers.Shrink(ctx)
+		}
+		return event
+	})
+	if err := c.app.Run(); err != nil {
+		panic(err)
+	}
+}
+
+func (c *tuiController) updateStatsLoop(ctx context.Context, interval time.Duration) {
+	formatMovingAverage := func(ma *movingaverage.ConcurrentMovingAverage) string {
+		aMin, _ := ma.Min()
+		aMax, _ := ma.Max()
+		aAvg := ma.Avg()
+		return fmt.Sprintf("%.0fms/%.0fms/%.0fms (min/avg/max)", aMin, aAvg, aMax)
+	}
+
+	ticker := time.NewTicker(interval)
+	lastSize := c.hammer.tracker.Latest().Size
+	maSlots := int((30 * time.Second) / interval)
+	growth := movingaverage.New(maSlots)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s := c.hammer.tracker.Latest().Size
+			growth.Add(float64(s - lastSize))
+			lastSize = s
+			qps := growth.Avg() * float64(time.Second/interval)
+			readWorkersLine := fmt.Sprintf("Read (%d workers): %s",
+				c.hammer.fullReaders.Size()+c.hammer.randomReaders.Size(),
+				c.hammer.readThrottle.String())
+			writeWorkersLine := fmt.Sprintf("Write (%d workers): %s",
+				c.hammer.writers.Size(),
+				c.hammer.writeThrottle.String())
+			treeSizeLine := fmt.Sprintf("TreeSize: %d (Δ %.0fqps over %ds)",
+				s,
+				qps,
+				time.Duration(maSlots*int(interval))/time.Second)
+			queueLine := fmt.Sprintf("Time-in-queue: %s",
+				formatMovingAverage(c.analyser.QueueTime))
+			integrateLine := fmt.Sprintf("Observed-time-to-integrate: %s",
+				formatMovingAverage(c.analyser.IntegrationTime))
+			text := strings.Join([]string{readWorkersLine, writeWorkersLine, treeSizeLine, queueLine, integrateLine}, "\n")
+			c.statusView.SetText(text)
+			c.app.Draw()
+		}
+	}
+}

--- a/internal/mirror/hammer/loadtest/workerpool.go
+++ b/internal/mirror/hammer/loadtest/workerpool.go
@@ -1,0 +1,61 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import "context"
+
+type Worker interface {
+	Run(ctx context.Context)
+	Kill()
+}
+
+// NewWorkerPool creates a simple pool of workers.
+//
+// This works well enough for the simple task we ask of it at the moment.
+// If we find ourselves adding more features to this, consider swapping it
+// for a library such as https://github.com/alitto/pond.
+func NewWorkerPool(factory func() Worker) WorkerPool {
+	workers := make([]Worker, 0)
+	pool := WorkerPool{
+		workers: workers,
+		factory: factory,
+	}
+	return pool
+}
+
+// WorkerPool contains a collection of _running_ workers.
+type WorkerPool struct {
+	workers []Worker
+	factory func() Worker
+}
+
+func (p *WorkerPool) Grow(ctx context.Context) {
+	w := p.factory()
+	p.workers = append(p.workers, w)
+	go w.Run(ctx)
+}
+
+func (p *WorkerPool) Shrink(ctx context.Context) {
+	if len(p.workers) == 0 {
+		return
+	}
+	w := p.workers[len(p.workers)-1]
+	p.workers = p.workers[:len(p.workers)-1]
+	w.Kill()
+}
+
+func (p *WorkerPool) Size() int {
+	return len(p.workers)
+}

--- a/internal/mirror/hammer/loadtest/workers.go
+++ b/internal/mirror/hammer/loadtest/workers.go
@@ -1,0 +1,235 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadtest
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	"log/slog"
+
+	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/client"
+)
+
+// LeafWriter is the signature of a function which can write arbitrary data to a log.
+// The data to be written is provided, and the implementation must return the sequence
+// number at which this data will be found in the log, or an error.
+type LeafWriter func(ctx context.Context, data []byte) (uint64, error)
+
+type LogReader interface {
+	ReadCheckpoint(ctx context.Context) ([]byte, error)
+
+	ReadTile(ctx context.Context, l, i uint64, p uint8) ([]byte, error)
+
+	ReadEntryBundle(ctx context.Context, i uint64, p uint8) ([]byte, error)
+}
+
+// NewLeafReader creates a LeafReader.
+// The next function provides a strategy for which leaves will be read.
+// Custom implementations can be passed, or use RandomNextLeaf or MonotonicallyIncreasingNextLeaf.
+func NewLeafReader(tracker *client.LogStateTracker, f client.EntryBundleFetcherFunc, next func(uint64) uint64, throttle <-chan bool, errChan chan<- error) *LeafReader {
+	return &LeafReader{
+		tracker:  tracker,
+		f:        f,
+		next:     next,
+		throttle: throttle,
+		errChan:  errChan,
+	}
+}
+
+// LeafReader reads leaves from the tree.
+// This class is not thread safe.
+type LeafReader struct {
+	tracker  *client.LogStateTracker
+	f        client.EntryBundleFetcherFunc
+	next     func(uint64) uint64
+	throttle <-chan bool
+	errChan  chan<- error
+	cancel   func()
+	c        leafBundleCache
+}
+
+// Run runs the log reader. This should be called in a goroutine.
+func (r *LeafReader) Run(ctx context.Context) {
+	if r.cancel != nil {
+		panic("LeafReader was ran multiple times")
+	}
+	ctx, r.cancel = context.WithCancel(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.throttle:
+		}
+		size := r.tracker.Latest().Size
+		if size == 0 {
+			continue
+		}
+		i := r.next(size)
+		if i >= size {
+			continue
+		}
+		slog.DebugContext(ctx, "LeafReader: getting index", slog.Uint64("i", i))
+		_, err := r.getLeaf(ctx, i, size)
+		if err != nil {
+			r.errChan <- fmt.Errorf("failed to get leaf %d: %v", i, err)
+		}
+	}
+}
+
+// getLeaf fetches the raw contents committed to at a given leaf index.
+func (r *LeafReader) getLeaf(ctx context.Context, i uint64, logSize uint64) ([]byte, error) {
+	if i >= logSize {
+		return nil, fmt.Errorf("requested leaf %d >= log size %d", i, logSize)
+	}
+	if cached, _ := r.c.get(i); cached != nil {
+		slog.DebugContext(ctx, "Using cached result for index", slog.Uint64("i", i))
+		return cached, nil
+	}
+
+	bundle, err := client.GetEntryBundle(ctx, r.f, i/layout.EntryBundleWidth, logSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get entry bundle: %v", err)
+	}
+	ti := i % layout.EntryBundleWidth
+	r.c = leafBundleCache{
+		start:  i - ti,
+		leaves: bundle.Entries,
+	}
+	return r.c.leaves[ti], nil
+}
+
+// Kill kills this leaf reader at the next opportune moment.
+// This function may return before the reader is dead.
+func (r *LeafReader) Kill() {
+	if r.cancel != nil {
+		r.cancel()
+	}
+}
+
+// leafBundleCache stores the results of the last fetched tile. This allows
+// readers that read contiguous blocks of leaves to act more like real
+// clients and fetch a tile of 256 leaves once, instead of 256 times.
+type leafBundleCache struct {
+	start  uint64
+	leaves [][]byte
+}
+
+func (tc leafBundleCache) get(i uint64) ([]byte, error) {
+	end := tc.start + uint64(len(tc.leaves))
+	if i >= tc.start && i < end {
+		leaf := tc.leaves[i-tc.start]
+		return base64.StdEncoding.DecodeString(string(leaf))
+	}
+	return nil, errors.New("not found")
+}
+
+// RandomNextLeaf returns a function that fetches a random leaf available in the tree.
+func RandomNextLeaf() func(uint64) uint64 {
+	return func(size uint64) uint64 {
+		return rand.Uint64N(size)
+	}
+}
+
+// MonotonicallyIncreasingNextLeaf returns a function that always wants the next available
+// leaf after the one it previously fetched. It starts at leaf 0.
+func MonotonicallyIncreasingNextLeaf() func(uint64) uint64 {
+	var i uint64
+	return func(size uint64) uint64 {
+		if i < size {
+			r := i
+			i++
+			return r
+		}
+		return size
+	}
+}
+
+// LeafTime records the time at which a leaf was assigned the given index.
+//
+// This is used when sampling leaves which are added in order to later calculate
+// how long it took to for them to become integrated.
+type LeafTime struct {
+	Index      uint64
+	QueuedAt   time.Time
+	AssignedAt time.Time
+}
+
+// NewLogWriter creates a LogWriter.
+// u is the URL of the write endpoint for the log.
+// gen is a function that generates new leaves to add.
+func NewLogWriter(writer LeafWriter, gen func() []byte, throttle <-chan bool, errChan chan<- error, leafSampleChan chan<- LeafTime) *LogWriter {
+	return &LogWriter{
+		writer:   writer,
+		gen:      gen,
+		throttle: throttle,
+		errChan:  errChan,
+		leafChan: leafSampleChan,
+	}
+}
+
+// LogWriter writes new leaves to the log that are generated by `gen`.
+type LogWriter struct {
+	writer   LeafWriter
+	gen      func() []byte
+	throttle <-chan bool
+	errChan  chan<- error
+	leafChan chan<- LeafTime
+	cancel   func()
+}
+
+// Run runs the log writer. This should be called in a goroutine.
+func (w *LogWriter) Run(ctx context.Context) {
+	if w.cancel != nil {
+		panic("LogWriter was run multiple times")
+	}
+	ctx, w.cancel = context.WithCancel(ctx)
+	newLeaf := w.gen()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.throttle:
+		}
+		lt := LeafTime{QueuedAt: time.Now()}
+		index, err := w.writer(ctx, newLeaf)
+		if err != nil {
+			w.errChan <- fmt.Errorf("failed to create request: %w", err)
+			continue
+		}
+		lt.Index, lt.AssignedAt = index, time.Now()
+		// See if we can send a leaf sample
+		select {
+		// TODO: we might want to count dropped samples, and/or make sampling a bit more statistical.
+		case w.leafChan <- lt:
+		default:
+		}
+		slog.DebugContext(ctx, "Wrote leaf at index", slog.Uint64("i", index))
+		newLeaf = w.gen()
+	}
+}
+
+// Kill kills this writer at the next opportune moment.
+// This function may return before the writer is dead.
+func (w *LogWriter) Kill() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+}


### PR DESCRIPTION
Towards https://github.com/transparency-dev/tessera/issues/945 and https://github.com/transparency-dev/tessera/issues/1010.

This pull request simply copies the existing hammer for tlog-tiles to a new directory for tlog-mirror servers load testing.

The only change made is the `README.md`. `Dockerfile` is excluded from this pull request.