### PR TITLE
Update the MirrorTarget API to return info we'll need at the handler level.

### DIFF
--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -76,20 +76,23 @@ func addEntries(m *MirrorMux) http.HandlerFunc {
 		default:
 			// Log unknown encodings and treat as malformed request
 			slog.WarnContext(r.Context(), "Unknown Content-Encoding", slog.String("encoding", ce))
-			http.Error(w, fmt.Sprintf("unsupported content encoding %q", ce), http.StatusBadRequest)
+			http.Error(w, "Unsupported content encoding", http.StatusBadRequest)
 			return
 		}
 		req, err := parseAddEntriesPreamble(reader)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("failed to parse header: %v", err), http.StatusBadRequest)
+			http.Error(w, "Failed to parse request preamble", http.StatusBadRequest)
 			return
 		}
 
-		cosigs, err := m.AddEntries(r.Context(), req.logOrigin, req.uploadStart, req.uploadEnd, req.ticket, req.NextPackage)
-		if err != nil {
-			// TODO(al): Handle various errors and respond accordingly.
-			slog.ErrorContext(r.Context(), "AddEntries failed", slog.Any("error", err))
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		_, _, _, cosigs, err := m.AddEntries(r.Context(), req.logOrigin, req.uploadStart, req.uploadEnd, req.ticket, req.NextPackage)
+		switch {
+		case errors.Is(err, ErrUnknownLog):
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		case err != nil:
+			slog.ErrorContext(r.Context(), "Failed to add entries", slog.String("origin", req.logOrigin), slog.Any("err", err))
+			http.Error(w, "Failed to add entries", http.StatusInternalServerError)
 			return
 		}
 

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -38,27 +38,27 @@ func TestAddEntries(t *testing.T) {
 	)
 
 	mock := &mockTarget{
-		addEntriesFunc: func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error) {
+		addEntriesFunc: func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, newSize uint64, newTicket []byte, cosigs []byte, err error) {
 			if uploadStart != testUploadStart || uploadEnd != testUploadEnd {
-				return nil, fmt.Errorf("want range %d-%d, got %d-%d", testUploadStart, testUploadEnd, uploadStart, uploadEnd)
+				return 0, 0, nil, nil, fmt.Errorf("want range %d-%d, got %d-%d", testUploadStart, testUploadEnd, uploadStart, uploadEnd)
 			}
 
 			pkg, err := next()
 			if err != nil {
-				return nil, fmt.Errorf("failed to read next package: %v", err)
+				return 0, 0, nil, nil, fmt.Errorf("failed to read next package: %v", err)
 			}
 			wantNumEntries := testUploadEnd - testUploadStart
 			if len(pkg.Entries) != wantNumEntries {
-				return nil, fmt.Errorf("want %d entries in first package, got %d", wantNumEntries, len(pkg.Entries))
+				return 0, 0, nil, nil, fmt.Errorf("want %d entries in first package, got %d", wantNumEntries, len(pkg.Entries))
 			}
 
 			// Try to read one more, expecting EOF
 			_, err = next()
 			if err == nil {
-				return nil, fmt.Errorf("expected EOF, got nil")
+				return 0, 0, nil, nil, fmt.Errorf("expected EOF, got nil")
 			}
 
-			return []byte("— test-cosig\n"), nil
+			return testUploadEnd, testUploadEnd, nil, []byte("— test-cosig\n"), nil
 		},
 	}
 	mux := NewMirrorMux()
@@ -160,12 +160,12 @@ func TestAddEntries(t *testing.T) {
 }
 
 type mockTarget struct {
-	addEntriesFunc    func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error)
+	addEntriesFunc func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error)
 }
 
-func (m *mockTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error) {
+func (m *mockTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error) {
 	if m.addEntriesFunc != nil {
 		return m.addEntriesFunc(ctx, uploadStart, uploadEnd, ticket, next)
 	}
-	return []byte("— dummy-cosig\n"), nil
+	return uploadEnd, 0, nil, nil, nil
 }

--- a/cmd/mtc/mirror/internal/handler/mirror_mux.go
+++ b/cmd/mtc/mirror/internal/handler/mirror_mux.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	// ErrUnknownLog is returned when a requested log is unknown to the mirror.
+	// ErrUnknownLog is returned when a request is made for an unknown log origin.
 	ErrUnknownLog = errors.New("unknown log origin")
 )
 
@@ -55,10 +55,10 @@ type MirrorMux struct {
 	targets map[string]MirrorTarget // keyed by log origin.
 }
 
-func (m *MirrorMux) AddEntries(ctx context.Context, origin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error) {
+func (m *MirrorMux) AddEntries(ctx context.Context, origin string, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error) {
 	t, err := m.target(origin)
 	if err != nil {
-		return nil, err
+		return 0, 0, nil, nil, err
 	}
 	slog.InfoContext(ctx, "AddEntries", slog.String("origin", origin), slog.Uint64("start", uploadStart), slog.Uint64("end", uploadEnd))
 	return t.AddEntries(ctx, uploadStart, uploadEnd, ticket, next)
@@ -77,6 +77,6 @@ func (m *MirrorMux) target(origin string) (MirrorTarget, error) {
 
 // MirrorTarget describes the contract that a mirror target must satisfy.
 type MirrorTarget interface {
-	// AddEntries adds verified consistent entries to the mirror.
-	AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error)
+	// AddEntries adds provided entries into its tree after verifying subtree consistency proofs.
+	AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error)
 }

--- a/cmd/mtc/mirror/posix/main.go
+++ b/cmd/mtc/mirror/posix/main.go
@@ -150,9 +150,9 @@ func witnessFromFlags(ctx context.Context) (*witness.Witness, *sqlite.Persistenc
 // fakeTarget is a temporary mirror target impl, and will be removed in due course.
 type fakeTarget struct {}
 
-func (f fakeTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) ([]byte, error) {
+func (f fakeTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error) {
 	slog.InfoContext(ctx, "fake target: AddEntries", slog.Uint64("uploadStart", uploadStart), slog.Uint64("uploadEnd", uploadEnd))
-	return nil, nil
+	return uploadEnd, 0, nil, nil, nil
 }
 
 func witnessSignerFromFlags(ctx context.Context) []note.Signer {

--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -22,14 +22,13 @@ import (
 
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
-	"github.com/transparency-dev/witness/witness"
 	"golang.org/x/mod/sumdb/note"
 )
 
 // MirrorOptions holds mirror lifecycle settings for all storage implementations.
 type MirrorOptions struct {
-	signer      note.Signer
-	witness     *witness.Witness
+	signer   note.Signer
+	cpSource func(context.Context) ([]byte, error)
 }
 
 // NewMirrorOptions creates a new options struct with defaults.
@@ -43,8 +42,8 @@ func (o *MirrorOptions) WithSigner(s note.Signer) *MirrorOptions {
 	return o
 }
 
-func (o *MirrorOptions) WithWitness(w *witness.Witness) *MirrorOptions {
-	o.witness = w
+func (o *MirrorOptions) WithCheckpointSource(f func(context.Context) ([]byte, error)) *MirrorOptions {
+	o.cpSource = f
 	return o
 }
 
@@ -65,8 +64,8 @@ func (o *MirrorOptions) valid() error {
 	if o.signer == nil {
 		return errors.New("invalid MirrorOptions: WithSigner must be set")
 	}
-	if o.witness == nil {
-		return errors.New("invalid MirrorOptions: WithWitness must be set")
+	if o.cpSource == nil {
+		return errors.New("invalid MirrorOptions: WithCheckpointSource must be set")
 	}
 	return nil
 }
@@ -83,9 +82,10 @@ type MirrorWriter interface {
 // MirrorTarget is a high-level wrapper that manages the process of mirroring
 // a source log into a Tessera instance.
 type MirrorTarget struct {
-	witness *witness.Witness
-	writer  MirrorWriter
-	reader  LogReader
+	writer   MirrorWriter
+	reader   LogReader
+	cpSource func(context.Context) ([]byte, error)
+	signer   note.Signer
 }
 
 // NewMirrorTarget instantiates a new MirrorTarget for the given driver and options.
@@ -108,9 +108,10 @@ func NewMirrorTarget(ctx context.Context, d Driver, opts *MirrorOptions) (*Mirro
 		return nil, fmt.Errorf("failed to init MirrorTarget lifecycle: %v", err)
 	}
 	return &MirrorTarget{
-		witness: opts.witness,
-		writer:  mw,
-		reader:  r,
+		writer:   mw,
+		reader:   r,
+		cpSource: opts.cpSource,
+		signer:   opts.signer,
 	}, nil
 }
 
@@ -123,9 +124,9 @@ type MirrorPackage struct {
 // AddEntries processes a stream of entry packages, verifies subtree consistency proofs,
 // and durably commits entries to the log.
 //
-// TODO(al): Need to have integrated provided entries when we return so we can produce a signature.
-func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*MirrorPackage, error)) ([]byte, error) {
-	return nil, errors.New("unimplemented")
+// Returns the next required entry index, a recent pending checkpoint size, an opaque ticket for future invocations, and, optionally, a cosignature over a pending checkpoint whose size matches uploadEnd if one exists.
+func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
+	return 0, 0, nil, nil, errors.New("unimplemented")
 }
 
 // IntegratedSize returns the size of the current integrated log.


### PR DESCRIPTION
Update the MirrorTarget API to return info we'll need at the handler level.

Towards #945