### PR TITLE
Improve add-entries http handler

### DIFF
--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -16,6 +16,7 @@ package handler
 
 import (
 	"compress/gzip"
+	"encoding/base64"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -85,19 +86,59 @@ func addEntries(m *MirrorMux) http.HandlerFunc {
 			return
 		}
 
-		_, _, _, cosigs, err := m.AddEntries(r.Context(), req.logOrigin, req.uploadStart, req.uploadEnd, req.ticket, req.NextPackage)
+		nextEntry, pendingSize, ticket, cosigs, err := m.AddEntries(r.Context(), req.logOrigin, req.uploadStart, req.uploadEnd, req.ticket, req.NextPackage)
 		switch {
 		case errors.Is(err, ErrUnknownLog):
+			// SPEC: If log_origin is not a known log, the mirror MUST respond with a "404 Not Found" HTTP status code.
 			http.Error(w, err.Error(), http.StatusNotFound)
 			return
+
+		case errors.Is(err, tessera.ErrConflict):
+			// SPEC: When sending a "409 Conflict" or "202 Accepted" response, the response body MUST have a Content-Type of text/x.tlog.mirror-info and consist of three lines, each followed by a newline (U+000A):
+			// The tree size of a valid pending checkpoint, in decimal
+			// The next entry, in decimal
+			// An opaque, possibly zero length, ticket value, encoded in base64
+			w.Header().Set("Content-Type", "text/x.tlog.mirror-info")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = fmt.Fprintf(w, "%d\n%d\n%s\n", pendingSize, nextEntry, base64.StdEncoding.EncodeToString(ticket))
+			return
+
+		case errors.Is(err, tessera.ErrNoPendingCheckpoint):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+
 		case err != nil:
 			slog.ErrorContext(r.Context(), "Failed to add entries", slog.String("origin", req.logOrigin), slog.Any("err", err))
 			http.Error(w, "Failed to add entries", http.StatusInternalServerError)
 			return
-		}
 
-		w.Header().Set("Content-Type", "text/plain")
-		_, _ = w.Write(cosigs)
+		case nextEntry == pendingSize:
+			// SPEC: If next_entry == upload_end, and no cosignatures are provided by the mirror, 
+			// the mirror MUST respond with a "200 OK" status code and an empty response body.
+			// If next_entry == upload_end, and cosignatures are provided by the mirror, 
+			// the mirror MUST respond with a "200 OK" status code and the cosignatures.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(cosigs) // We don't care about failures here.
+			return
+
+		case nextEntry == req.uploadStart:
+			// SPEC: If no entry package was authenticated and saved before the body ended (for example, the request header itself was malformed, or the first package's bytes were truncated mid-package), the mirror MUST respond with a "400 Bad Request" HTTP status code.
+			http.Error(w, "truncated or malformed body: no entry packages saved", http.StatusBadRequest)
+			return
+
+		case nextEntry > req.uploadStart:
+			// SPEC: If at least one entry package was authenticated and saved, but the mirror has not yet received all packages covering [upload_start, upload_end), the mirror MUST respond with a "202 Accepted" response carrying the advanced next entry.
+			w.Header().Set("Content-Type", "text/x.tlog.mirror-info")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = fmt.Fprintf(w, "%d\n%d\n%s\n", pendingSize, nextEntry, base64.StdEncoding.EncodeToString(ticket)) // We don't care about failures here.
+			return
+
+		default:
+			// This should never happen.
+			slog.ErrorContext(r.Context(), "LOGIC ERROR: invalid state", slog.Uint64("nextEntry", nextEntry), slog.Uint64("uploadStart", req.uploadStart), slog.Uint64("pendingSize", pendingSize))
+			http.Error(w, "invalid state", http.StatusInternalServerError)
+			return
+		}
 	}
 }
 

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -18,7 +18,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -169,3 +171,120 @@ func (m *mockTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint
 	}
 	return uploadEnd, 0, nil, nil, nil
 }
+
+func TestAddEntries_StatusCodes(t *testing.T) {
+	const (
+		testOrigin = "example-log"
+		testUploadStart = 10
+		testUploadEnd = 20
+		testNextIdx = 100
+		testPendingSize = 200
+		testNewTicket = "ticket-bytes"
+		testCosig = "— test-cosig\n"
+	)
+
+	for _, test := range []struct {
+		name       string
+		origin     string
+		mockTarget *mockTarget
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:   "200 ok",
+			origin: testOrigin,
+			mockTarget: &mockTarget{
+				addEntriesFunc: func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
+					return testPendingSize, testPendingSize, []byte(testNewTicket), []byte(testCosig), nil
+				},
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   testCosig,
+		}, {
+			name:   "202 partial upload",
+			origin: testOrigin,
+			mockTarget: &mockTarget{
+				addEntriesFunc: func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
+					return testUploadStart + 5, testPendingSize, []byte(testNewTicket), nil, nil
+				},
+			},
+			wantStatus: http.StatusAccepted,
+			wantBody:   fmt.Sprintf("%d\n%d\n%s\n", testPendingSize, testUploadStart+5, base64.StdEncoding.EncodeToString([]byte(testNewTicket))),
+		}, {
+			name:   "400 no pending checkpoint",
+			origin: testOrigin,
+			mockTarget: &mockTarget{
+				addEntriesFunc: func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
+					return 0, 0, nil, nil, tessera.ErrNoPendingCheckpoint
+				},
+			},
+			wantStatus: http.StatusBadRequest,
+		}, {
+			name:   "400 truncated body (no entries saved)",
+			origin: testOrigin,
+			mockTarget: &mockTarget{
+				addEntriesFunc: func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
+					return uploadStart, testPendingSize, nil, nil, nil
+				},
+			},
+			wantStatus: http.StatusBadRequest,
+		}, {
+			name:       "404 unknown log",
+			origin:     "unknown-origin",
+			mockTarget: &mockTarget{},
+			wantStatus: http.StatusNotFound,
+		}, {
+			name:   "409 conflict",
+			origin: testOrigin,
+			mockTarget: &mockTarget{
+				addEntriesFunc: func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
+					return testNextIdx, testPendingSize, []byte(testNewTicket), nil, tessera.ErrConflict
+				},
+			},
+			wantStatus: http.StatusConflict,
+			wantBody:   fmt.Sprintf("%d\n%d\n%s\n", testPendingSize, testNextIdx, base64.StdEncoding.EncodeToString([]byte(testNewTicket))),
+		}, {
+			name:   "500 internal server error",
+			origin: testOrigin,
+			mockTarget: &mockTarget{
+				addEntriesFunc: func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
+					return 0, 0, nil, nil, errors.New("db explosion")
+				},
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+	}{
+		t.Run(test.name, func(t *testing.T) {
+			mux := NewMirrorMux()
+			_ = mux.AddTarget(testOrigin, test.mockTarget)
+			h := New(mux, nil)
+
+			var rawBody bytes.Buffer
+			_ = binary.Write(&rawBody, binary.BigEndian, uint16(len(test.origin)))
+			_, _ = rawBody.WriteString(test.origin)
+			_ = binary.Write(&rawBody, binary.BigEndian, uint64(testUploadStart))
+			_ = binary.Write(&rawBody, binary.BigEndian, uint64(testUploadEnd))
+			_ = binary.Write(&rawBody, binary.BigEndian, uint16(0))
+
+			req := httptest.NewRequest(http.MethodPost, "/add-entries", &rawBody)
+			req.Header.Add("Content-Type", "application/octet-stream")
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != test.wantStatus {
+				t.Errorf("want status %d, got %d: %s", test.wantStatus, w.Code, w.Body.String())
+			}
+			if test.wantStatus == http.StatusConflict || test.wantStatus == http.StatusAccepted {
+				if got := w.Header().Get("Content-Type"); got != "text/x.tlog.mirror-info" {
+					t.Errorf("want Content-Type text/x.tlog.mirror-info, got %q", got)
+				}
+			}
+			if test.wantBody != "" {
+				if got := w.Body.String(); got != test.wantBody {
+					t.Errorf("want body %q, got %q", test.wantBody, got)
+				}
+			}
+		})
+	}
+}
+

--- a/cmd/mtc/mirror/internal/handler/mirror_mux.go
+++ b/cmd/mtc/mirror/internal/handler/mirror_mux.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	// ErrUnknownLog is returned when a request is made for an unknown log origin.
+	// ErrUnknownLog is returned when a requested log is unknown to the mirror
 	ErrUnknownLog = errors.New("unknown log origin")
 )
 
@@ -61,6 +61,7 @@ func (m *MirrorMux) AddEntries(ctx context.Context, origin string, uploadStart, 
 		return 0, 0, nil, nil, err
 	}
 	slog.InfoContext(ctx, "AddEntries", slog.String("origin", origin), slog.Uint64("start", uploadStart), slog.Uint64("end", uploadEnd))
+
 	return t.AddEntries(ctx, uploadStart, uploadEnd, ticket, next)
 }
 
@@ -77,6 +78,6 @@ func (m *MirrorMux) target(origin string) (MirrorTarget, error) {
 
 // MirrorTarget describes the contract that a mirror target must satisfy.
 type MirrorTarget interface {
-	// AddEntries adds provided entries into its tree after verifying subtree consistency proofs.
+	// AddEntries adds verified consistent entries to the mirror.
 	AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error)
 }

--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -25,6 +25,15 @@ import (
 	"golang.org/x/mod/sumdb/note"
 )
 
+var (
+	// ErrConflict is returned when the requested upload range conflicts with the
+	// current state of the log.
+	ErrConflict          = errors.New("tree size conflict")
+	// ErrNoPendingCheckpoint is returned when a pending checkpoint cannot be
+	// determined.
+	ErrNoPendingCheckpoint = errors.New("no pending checkpoint")
+)
+
 // MirrorOptions holds mirror lifecycle settings for all storage implementations.
 type MirrorOptions struct {
 	signer   note.Signer


### PR DESCRIPTION
This PR fleshes-out the HTTP handler for `add-entries`.

Towards #945 