### PR TITLE
Fix aws antispam

### DIFF
--- a/storage/aws/antispam/aws.go
+++ b/storage/aws/antispam/aws.go
@@ -198,8 +198,11 @@ func (d *AntispamStorage) index(ctx context.Context, h []byte) (*uint64, error) 
 	row := d.dbPool.QueryRowContext(ctx, "SELECT idx FROM AntispamIDSeq WHERE h = ?", h)
 
 	var idx uint64
-	if err := row.Scan(&idx); err == sql.ErrNoRows {
-		return nil, nil
+	if err := row.Scan(&idx); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("error during scan: %v", err)
 	}
 	d.numHits.Add(1)
 	return &idx, nil

--- a/storage/aws/antispam/aws_test.go
+++ b/storage/aws/antispam/aws_test.go
@@ -163,6 +163,35 @@ func TestAntispamPushbackRecovers(t *testing.T) {
 	t.Fatalf("pushBack remains true after 5 seconds despite being caught up!")
 }
 
+func TestAntispamIndexError(t *testing.T) {
+	ctx := t.Context()
+	if canSkipMySQLTest(t, ctx) {
+		slog.WarnContext(ctx, "MySQL not available, skipping", slog.String("name", t.Name()))
+		t.Skip("MySQL not available, skipping test")
+	}
+	mustDropTables(t, ctx)
+	as, err := NewAntispam(ctx, *mySQLURI, AntispamOpts{
+		PushbackThreshold: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// DB should be empty, try to read an index and expect no index and no error.
+	i, err := as.index(t.Context(), []byte("hash"))
+	if i != nil || err != nil {
+		t.Fatalf("got %v, %v, want nil, nil", i, err)
+	}
+
+	// Close the DB, and try to read an index. Should see an error.
+	if err := as.dbPool.Close(); err != nil {
+		t.Fatalf("Failed to close DB: %v", err)
+	}
+	if _, err := as.index(t.Context(), []byte("hash")); err == nil {
+		t.Fatal("Got no error, want error")
+	}
+}
+
 // canSkipMySQLTest checks if the test MySQL db is available and, if not, if the test can be skipped.
 //
 // Use this method before every MySQL test, and if it returns true, skip the test.


### PR DESCRIPTION
This PR fixes the issue in #1018 where a failed DB read would be incorrectly treated as a successful miss in the antispam index.

Fixes #1018.