### PR TITLE
Verify subtree proofs in mirror AddEntries

### DIFF
--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -72,6 +72,7 @@ func addEntries(m *MirrorMux) http.HandlerFunc {
 				return
 			}
 			defer func() {
+				// Note that this only closes the gzip reader, it doesn't close the underlying HTTP body reader.
 				_ = reader.Close()
 			}()
 		default:
@@ -106,6 +107,12 @@ func addEntries(m *MirrorMux) http.HandlerFunc {
 
 		case errors.Is(err, tessera.ErrNoPendingCheckpoint):
 			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+
+		case errors.Is(err, tessera.ErrInvalidProof):
+			// SPEC: If this (subtree consistency proof) verification process fails, it MUST respond with a "422 Unprocessable Entity"
+			// HTTP status code and end processing.
+			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 			return
 
 		case err != nil:

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -244,6 +244,15 @@ func TestAddEntries_StatusCodes(t *testing.T) {
 			wantStatus: http.StatusConflict,
 			wantBody:   fmt.Sprintf("%d\n%d\n%s\n", testPendingSize, testNextIdx, base64.StdEncoding.EncodeToString([]byte(testNewTicket))),
 		}, {
+			name:   "422 unprocessable entity",
+			origin: testOrigin,
+			mockTarget: &mockTarget{
+				addEntriesFunc: func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
+					return testNextIdx, testPendingSize, []byte(testNewTicket), nil, tessera.ErrInvalidProof
+				},
+			},
+			wantStatus: http.StatusUnprocessableEntity,
+		}, {
 			name:   "500 internal server error",
 			origin: testOrigin,
 			mockTarget: &mockTarget{

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/rivo/tview v0.42.0
 	github.com/transparency-dev/formats v0.1.1
-	github.com/transparency-dev/merkle v0.0.3-0.20240919113952-3c979d16ee14
+	github.com/transparency-dev/merkle v0.0.3-0.20260629095233-a1adddb6323b
 	github.com/transparency-dev/witness v0.0.0-20260617164027-9332986a94a4
 	go.opentelemetry.io/contrib/detectors/aws/ec2/v2 v2.5.1
 	go.opentelemetry.io/contrib/detectors/aws/ecs v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/transparency-dev/formats v0.1.1 h1:4bVHJc+KdBgpA1OJD1yjI+g0i5Z1graCppTMH8lWKJI=
 github.com/transparency-dev/formats v0.1.1/go.mod h1:qtZ8goRuJ8FTBG9c9+Bj0rn2rUG7eG/AUTkr+Aw3jFw=
-github.com/transparency-dev/merkle v0.0.3-0.20240919113952-3c979d16ee14 h1:K8JqF1HyGDXfTdDHtHe7VsIzeuFEcfLhioOXaupKB+Q=
-github.com/transparency-dev/merkle v0.0.3-0.20240919113952-3c979d16ee14/go.mod h1:EoKPjljyIALg1rldsJwRQVKOJO7sLd6eUqki19ruI80=
+github.com/transparency-dev/merkle v0.0.3-0.20260629095233-a1adddb6323b h1:0nbx2whxWqEycj3JKCMezPXiV6z5Q+L2tdZjLDP6AbE=
+github.com/transparency-dev/merkle v0.0.3-0.20260629095233-a1adddb6323b/go.mod h1:E+iHk6bS+tIgIJGD4TMeAjSjhQ9wPfL/ST4pXyITjdU=
 github.com/transparency-dev/witness v0.0.0-20260617164027-9332986a94a4 h1:fcZnSVJlnE3GCiqoxvTaiHNfj7iBWMs09ow6edxIKFo=
 github.com/transparency-dev/witness v0.0.0-20260617164027-9332986a94a4/go.mod h1:x7LGvt50B3F6lTIg1/R3q5RjjVHkHiaKB5GFB2p3+ms=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -34,6 +34,10 @@ import (
 	"unicode/utf8"
 
 	"github.com/transparency-dev/formats/log"
+	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/compact"
+	"github.com/transparency-dev/merkle/proof"
+	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
 	"golang.org/x/mod/sumdb/note"
@@ -46,6 +50,8 @@ var (
 	// ErrNoPendingCheckpoint is returned when a pending checkpoint cannot be
 	// determined.
 	ErrNoPendingCheckpoint = errors.New("no pending checkpoint")
+	// ErrInvalidProof is returned when a proof fails to verify.
+	ErrInvalidProof = errors.New("invalid proof")
 )
 
 // MirrorOptions holds mirror lifecycle settings for all storage implementations.
@@ -107,7 +113,8 @@ func (o *MirrorOptions) valid() error {
 type MirrorWriter interface {
 	// IntegrateBundles integrates bundles of log entries, starting at the given index, into the local tree.
 	// Returns the size of the tree and its new root hash if successful.
-	IntegrateBundles(ctx context.Context, from uint64, bundles iter.Seq[api.EntryBundle]) (uint64, []byte, error)
+	// If the provided iterator yields an error, the MirrorWriter MUST return it either directly, or wrapped so the caller can identify it.
+	IntegrateBundles(ctx context.Context, from uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error)
 	// IntegratedSize returns the size of the local integrated tree.
 	IntegratedSize(ctx context.Context) (uint64, error)
 
@@ -121,12 +128,13 @@ type MirrorWriter interface {
 
 // MirrorTarget manages the process of mirroring a source log into a Tessera instance.
 type MirrorTarget struct {
-	writer      MirrorWriter
-	reader      LogReader
-	cpSource    func(context.Context) ([]byte, error)
-	signer      note.Signer
-	logVerifier note.Verifier
-	ticketKey   []byte
+	writer             MirrorWriter
+	reader             LogReader
+	cpSource           func(context.Context) ([]byte, error)
+	signer             note.Signer
+	logVerifier        note.Verifier
+	verifySubtreeProof func(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot []byte, root []byte) error
+	ticketKey          []byte
 }
 
 // NewMirrorTarget instantiates a new MirrorTarget for the given driver and options.
@@ -153,12 +161,13 @@ func NewMirrorTarget(ctx context.Context, d Driver, opts *MirrorOptions) (*Mirro
 		return nil, fmt.Errorf("failed to derive ticket key: %v", err)
 	}
 	return &MirrorTarget{
-		writer:      mw,
-		reader:      r,
-		cpSource:    opts.cpSource,
-		signer:      opts.signer,
-		logVerifier: opts.logVerifier,
-		ticketKey:   tK,
+		writer:             mw,
+		reader:             r,
+		cpSource:           opts.cpSource,
+		signer:             opts.signer,
+		logVerifier:        opts.logVerifier,
+		verifySubtreeProof: proof.VerifySubtreeConsistency,
+		ticketKey:          tK,
 	}, nil
 }
 
@@ -253,33 +262,14 @@ func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd u
 		(uploadEnd != pendingCP.Size || uploadEnd < curIntegratedSize) ||
 		(uploadStart > curIntegratedSize) {
 		// TODO(al): add flexibility about re-writing some entries
-		slog.ErrorContext(ctx, "Returning conflict", slog.Uint64("curIntegratedSize", curIntegratedSize), slog.Uint64("pendingSize", pendingSize), slog.Uint64("uploadStart", uploadStart), slog.Uint64("uploadEnd", uploadEnd))
+		slog.ErrorContext(ctx, "Returning conflict", slog.Uint64("curIntegratedSize", curIntegratedSize), slog.Uint64("pendingSize", pendingCP.Size), slog.Uint64("uploadStart", uploadStart), slog.Uint64("uploadEnd", uploadEnd))
 		return curIntegratedSize, pendingCP.Size, ticketBytes, nil, ErrConflict
 	}
 
-	bi := func(yield func(api.EntryBundle) bool) {
-		for {
-			pkg, err := next()
-			if err != nil {
-				if err == io.EOF {
-					return
-				}
-				// TODO(al): handle this
-				slog.WarnContext(ctx, "NextPackage returned an error", slog.String("error", err.Error()))
-				return
-			}
-
-			// TODO(al): verify entries+proof under checkpoint (Failure -> 422 Unprocessable Entity).
-
-			if !yield(api.EntryBundle{Entries: pkg.Entries}) {
-				return
-			}
-		}
-	}
-
+	curStart := uploadStart
 	bundleIdx := uploadStart / layout.EntryBundleWidth
 
-	nextEntry, newRoot, err := mt.writer.IntegrateBundles(ctx, bundleIdx, bi)
+	nextEntry, newRoot, err := mt.writer.IntegrateBundles(ctx, bundleIdx, mt.bundleIterator(ctx, next, curStart, pendingCP))
 	switch {
 	case err != nil:
 		return 0, 0, nil, nil, err
@@ -305,6 +295,53 @@ func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd u
 		slog.WarnContext(ctx, "Incomplete upload", slog.Uint64("nextEntry", nextEntry), slog.Uint64("pendingSize", pendingCP.Size))
 		// Incomplete upload, return an updated ticket with the current checkpoint.
 		return nextEntry, pendingCP.Size, ticketBytes, nil, nil
+	}
+}
+
+// bundleIterator returns an interator which yields MirrorPackages after verifying their subtree consistency with the provided pending checkpoint.
+func (mt *MirrorTarget) bundleIterator(ctx context.Context, next func() (*MirrorPackage, error), start uint64, pendingCP *log.Checkpoint) func(func(*api.EntryBundle, error) bool) {
+	crf := compact.RangeFactory{Hash: rfc6962.DefaultHasher.HashChildren}
+	return func(yield func(*api.EntryBundle, error) bool) {
+		for {
+			pkg, err := next()
+			if err != nil {
+				if err == io.EOF {
+					return
+				}
+				// TODO(al): handle this
+				slog.WarnContext(ctx, "NextPackage returned an error", slog.String("error", err.Error()))
+				return
+			}
+
+			cr := crf.NewEmptyRange(0)
+			for _, e := range pkg.Entries {
+				if err := cr.Append(rfc6962.DefaultHasher.HashLeaf(e), nil); err != nil {
+					yield(nil, fmt.Errorf("failed to append hash to compact range: %v", err))
+					return
+				}
+			}
+
+			subRoot, err := cr.GetRootHash(nil)
+			if err != nil {
+				yield(nil, fmt.Errorf("failed to get root of compact range: %v", err))
+				return
+			}
+
+			// SPEC: For each entry package, it MUST authenticate the entries by verifying the subtree consistency proof:
+			// 				- First, it reconstructs the subtree hash based on the received entries and entries already in the log.
+			// 				- It then verifies the subtree consistency proof using this hash and the checkpoint at upload_end.
+			//			If this verification process fails, it MUST respond with a "422 Unprocessable Entity" HTTP status code and end processing.
+			if err := mt.verifySubtreeProof(rfc6962.DefaultHasher, start, start+uint64(len(pkg.Entries)), pendingCP.Size, pkg.Proof, subRoot, pendingCP.Hash); err != nil {
+				// Return ErrInvalidProof which the handler can turn into a 422 status.
+				yield(nil, fmt.Errorf("failed to verify subtree consistency: %w", ErrInvalidProof))
+				return
+			}
+			start += uint64(len(pkg.Entries))
+
+			if !yield(&api.EntryBundle{Entries: pkg.Entries}, nil) {
+				return
+			}
+		}
 	}
 }
 

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	fnote "github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/merkle"
 	"github.com/transparency-dev/tessera/api"
 	"golang.org/x/mod/sumdb/note"
 )
@@ -239,4 +240,118 @@ func mustSignCP(origin string, size uint64, root string, s note.Signer) []byte {
 		panic(fmt.Errorf("Failed to sign note: %v", err))
 	}
 	return raw
+}
+
+func TestMirrorTarget_AddEntries_VerifySubtreeProof(t *testing.T) {
+	const (
+		testIntegratedSize = uint64(256)
+		testUploadStart    = uint64(256)
+		testUploadEnd      = testPendingCPSize
+	)
+
+	pkg := &MirrorPackage{
+		Entries: [][]byte{[]byte("entry1"), []byte("entry2")},
+		Proof:   [][]byte{[]byte("proof1")},
+	}
+
+	for _, tc := range []struct {
+		name      string
+		verifyErr error
+		wantErr   error
+	}{
+		{
+			name:      "success",
+			verifyErr: nil,
+			wantErr:   nil,
+		},
+		{
+			name:      "proof verification failure",
+			verifyErr: errors.New("oh noes, proof verification failed"),
+			wantErr:   ErrInvalidProof,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var verifyCalled bool
+			var gotStart, gotEnd, gotSize uint64
+			var gotProof [][]byte
+			var gotRoot []byte
+
+			mt := &MirrorTarget{
+				logVerifier: testLogVerifier,
+				signer:      testMirrorSigner,
+				writer: &fakeMirrorWriter{
+					integrateFunc: func(ctx context.Context, from uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
+						for _, err := range bundles {
+							if err != nil {
+								return 0, nil, err
+							}
+						}
+						pendingCPRoot, err := base64.StdEncoding.DecodeString(testPendingCPRoot)
+						return testUploadEnd, pendingCPRoot, err
+					},
+				},
+				reader: &fakeLogReader{
+					sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
+				},
+				cpSource: func(ctx context.Context) ([]byte, error) { return []byte(testPendingCP), nil },
+				verifySubtreeProof: func(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot, root []byte) error {
+					verifyCalled = true
+					gotStart = start
+					gotEnd = end
+					gotSize = size
+					gotProof = proof
+					gotRoot = root
+					return tc.verifyErr
+				},
+			}
+
+			validTicket, err := mt.sealTicket([]byte(testPendingCP))
+			if err != nil {
+				t.Fatalf("sealTicket failed: %v", err)
+			}
+
+			firstCall := true
+			nextFunc := func() (*MirrorPackage, error) {
+				if firstCall {
+					firstCall = false
+					return pkg, nil
+				}
+				return nil, io.EOF
+			}
+
+			_, _, _, _, err = mt.AddEntries(ctx, testUploadStart, testUploadEnd, validTicket, nextFunc)
+			if (err != nil) != (tc.wantErr != nil) {
+				t.Fatalf("got error: %v, want error: %v", err, tc.wantErr)
+			} else if err != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("unexpected error type: %v", err)
+			}
+
+			if !verifyCalled {
+				t.Errorf("verifySubtreeProof was not called")
+				return
+			}
+
+			if gotStart != testUploadStart {
+				t.Errorf("verifySubtreeProof start: got %d, want %d", gotStart, testUploadStart)
+			}
+			if want := testUploadStart + uint64(len(pkg.Entries)); gotEnd != want {
+				t.Errorf("verifySubtreeProof end: got %d, want %d", gotEnd, want)
+			}
+			if gotSize != testPendingCPSize {
+				t.Errorf("verifySubtreeProof size: got %d, want %d", gotSize, testPendingCPSize)
+			}
+			wantRoot, err := base64.StdEncoding.DecodeString(testPendingCPRoot)
+			if err != nil {
+				t.Fatalf("failed to decode root hash: %v", err)
+			}
+			if !bytes.Equal(gotRoot, wantRoot) {
+				t.Errorf("verifySubtreeProof root: got %x, want %x", gotRoot, wantRoot)
+			}
+			if len(gotProof) != 1 || !bytes.Equal(gotProof[0], pkg.Proof[0]) {
+				t.Errorf("verifySubtreeProof proof: got %x, want %x", gotProof, pkg.Proof)
+			}
+		})
+	}
 }

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -30,12 +30,12 @@ import (
 )
 
 type fakeMirrorWriter struct {
-	integrateFunc        func(ctx context.Context, from uint64, bundles iter.Seq[api.EntryBundle]) (uint64, []byte, error)
+	integrateFunc        func(ctx context.Context, from uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error)
 	sizeFunc             func(ctx context.Context) (uint64, error)
 	updateCheckpointFunc func(ctx context.Context, f func(oldCP []byte) (newCP []byte, err error)) error
 }
 
-func (f *fakeMirrorWriter) IntegrateBundles(ctx context.Context, from uint64, bundles iter.Seq[api.EntryBundle]) (uint64, []byte, error) {
+func (f *fakeMirrorWriter) IntegrateBundles(ctx context.Context, from uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
 	if f.integrateFunc != nil {
 		return f.integrateFunc(ctx, from, bundles)
 	}
@@ -177,7 +177,7 @@ func TestMirrorTarget_AddEntries_CompleteUpload(t *testing.T) {
 		logVerifier: testLogVerifier,
 		signer:      testMirrorSigner,
 		writer: &fakeMirrorWriter{
-			integrateFunc: func(ctx context.Context, from uint64, bundles iter.Seq[api.EntryBundle]) (uint64, []byte, error) {
+			integrateFunc: func(ctx context.Context, from uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
 				pendingCPRoot, err := base64.StdEncoding.DecodeString(testPendingCPRoot)
 				return testUploadEnd, pendingCPRoot, err
 			},

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -1185,7 +1185,7 @@ func (m *MirrorWriter) initialise(ctx context.Context) error {
 }
 
 // marshalTlogEntryBundle returns a tlog-tiles compatible serialization of the provided entrybundle.
-func marshalTlogEntryBundle(b api.EntryBundle) ([]byte, error) {
+func marshalTlogEntryBundle(b *api.EntryBundle) ([]byte, error) {
 	// Prealloc the max size we could possibly write out (about 16MB for a full bundle of max size entries).
 	// If this causes problems we may want to default this to some lower
 	// "reasonable" intermediate size, but not going to worry about that for now.
@@ -1203,10 +1203,13 @@ func marshalTlogEntryBundle(b api.EntryBundle) ([]byte, error) {
 
 // IntegrateBundles integrates a sequence of entry bundles into the tree, starting at the provided bundle index bundleIdx.
 // Returns the new size and root hash of the tree if successful.
-func (m *MirrorWriter) IntegrateBundles(ctx context.Context, bundleIdx uint64, bundles iter.Seq[api.EntryBundle]) (uint64, []byte, error) {
+func (m *MirrorWriter) IntegrateBundles(ctx context.Context, bundleIdx uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
 	targetSize := bundleIdx * layout.EntryBundleWidth
 	seenPartialBundle := false
-	for b := range bundles {
+	for b, err := range bundles {
+		if err != nil {
+			return 0, nil, err
+		}
 		if seenPartialBundle {
 			// Seeing a partial bundle means that there should not be any further bundles to be processed.
 			return 0, nil, fmt.Errorf("unexpected bundle after partial at index %d", bundleIdx)


### PR DESCRIPTION
This PR adds the missing check which asserts that the subtree proof provided with the mirror packages is valid before passing the entries on to be stored.

Towards #945 