### PR TITLE
Multi sig witness

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -1005,7 +1005,7 @@ func (o *AppendOptions) LogValue() slog.Value {
 	}
 
 	if len(o.witnesses.Components) > 0 {
-		endpoints := o.witnesses.Endpoints()
+		endpoints := o.witnesses.WitnessEndpoints()
 		urls := make([]string, 0, len(endpoints))
 		for u := range endpoints {
 			urls = append(urls, u)

--- a/internal/witness/client.go
+++ b/internal/witness/client.go
@@ -23,8 +23,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -287,7 +290,7 @@ func (pf *sharedConsistencyProofFetcher) ConsistencyProof(ctx context.Context, s
 // It also has the size of the checkpoint that the log thinks that the witness last signed.
 // This is important for sending update proofs.
 // This is defaulted to zero on startup and calibrated after the first request, which is expected by the spec:
-// `If a client doesn't have information on the latest cosigned checkpoint, it MAY initially make a request with a old size of zero to obtain it`
+// `If a client doesn't have information on the latest cosigned checkpoint, it MAY initially make a request with an old size of zero to obtain it`
 type witnessClient struct {
 	client    *http.Client
 	url       string
@@ -295,14 +298,26 @@ type witnessClient struct {
 	size      uint64
 }
 
+// names returns a string with unique names of the verifiers, sorted.
+func names(w []note.Verifier) []string {
+	m := make(map[string]struct{}, len(w))
+	for _, v := range w {
+		m[v.Name()] = struct{}{}
+	}
+	s := slices.Collect(maps.Keys(m))
+	sort.Strings(s)
+	return s
+}
+
 func (w *witnessClient) update(ctx context.Context, cp []byte, size uint64, fetchProof func(ctx context.Context, from, to uint64) ([][]byte, error)) ([]byte, error) {
 	return otel.Trace(ctx, "tessera.witness.update", tracer, func(ctx context.Context, span trace.Span) ([]byte, error) {
+		witNames := names(w.verifiers)
 		var recursed uint
 		if v := ctx.Value(antiRecursionCtxKey); v != nil {
 			recursed = v.(uint)
 		}
 		if recursed >= maxUpdateRecursion {
-			return nil, fmt.Errorf("too many consecutive requests to witness %s", w.verifiers[0].Name())
+			return nil, fmt.Errorf("too many consecutive requests to witness %v", witNames)
 		}
 
 		var proof [][]byte
@@ -315,7 +330,7 @@ func (w *witnessClient) update(ctx context.Context, cp []byte, size uint64, fetc
 		}
 
 		start := time.Now()
-		nameAttr := witnessNameKey.String(w.verifiers[0].Name())
+		nameAttr := witnessNameKey.String(strings.Join(witNames, ","))
 		witnessClientReqsTotal.Add(ctx, 1, metric.WithAttributes(nameAttr))
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.url, w.buildRequestBody(proof, cp))
@@ -348,7 +363,7 @@ func (w *witnessClient) update(ctx context.Context, cp []byte, size uint64, fetc
 			copy(signed, cp)
 			copy(signed[len(cp):], rb)
 			if n, err := note.Open(signed, note.VerifierList(w.verifiers...)); err != nil {
-				return nil, fmt.Errorf("witness %q at %q replied with invalid signature: %q\nconstructed note: %q\nerror: %v", w.verifiers[0].Name(), w.url, rb, string(signed), err)
+				return nil, fmt.Errorf("witnesses %v at %q replied with no valid signature(s): %q\nconstructed note: %q\nerror: %v", witNames, w.url, rb, string(signed), err)
 			} else {
 				w.size = uint64(size)
 				var sigs []byte

--- a/internal/witness/client.go
+++ b/internal/witness/client.go
@@ -105,9 +105,9 @@ type WitnessGroup interface {
 
 	// Endpoints returns the details required for updating a witness and checking the
 	// response. The returned result is a map from the URL that should be used to update
-	// the witness with a new checkpoint, to the value which is the verifier to check
+	// the witness with a new checkpoint, to the values which are the verifiers to check
 	// the response is well formed.
-	Endpoints() map[string]note.Verifier
+	Endpoints() map[string][]note.Verifier
 }
 
 // NewWitnessGateway returns a WitnessGateway that will send out new checkpoints to witnesses
@@ -117,19 +117,42 @@ type WitnessGroup interface {
 func NewWitnessGateway(group WitnessGroup, client *http.Client, oldSize uint64, fetchTiles client.TileFetcherFunc) WitnessGateway {
 	endpoints := group.Endpoints()
 	witnesses := make([]*witnessClient, 0, len(endpoints))
-	for u, v := range endpoints {
-		witnesses = append(witnesses, &witnessClient{
-			client:   client,
-			url:      u,
-			verifier: v,
-			size:     oldSize,
-		})
+	for u, vs := range endpoints {
+		vs := dedupVerifiers(vs)
+		if len(vs) > 0 {
+			witnesses = append(witnesses, &witnessClient{
+				client:    client,
+				url:       u,
+				verifiers: vs,
+				size:      oldSize,
+			})
+		}
 	}
 	return WitnessGateway{
 		group:     group,
 		witnesses: witnesses,
 		fetchTile: fetchTiles,
 	}
+}
+
+// dedupVerifiers removes duplicate verifiers (identified by name and keyhash) from the given slice.
+// Returns a new slice containing the unique verifiers, the passed in slice isn't modified.
+func dedupVerifiers(vs []note.Verifier) []note.Verifier {
+	type verifierKey struct {
+		name string
+		hash uint32
+	}
+
+	seen := make(map[verifierKey]bool)
+	var dedup []note.Verifier
+	for _, v := range vs {
+		k := verifierKey{name: v.Name(), hash: v.KeyHash()}
+		if !seen[k] {
+			seen[k] = true
+			dedup = append(dedup, v)
+		}
+	}
+	return dedup
 }
 
 // WitnessGateway allows a log implementation to send out a checkpoint to witnesses.
@@ -266,10 +289,10 @@ func (pf *sharedConsistencyProofFetcher) ConsistencyProof(ctx context.Context, s
 // This is defaulted to zero on startup and calibrated after the first request, which is expected by the spec:
 // `If a client doesn't have information on the latest cosigned checkpoint, it MAY initially make a request with a old size of zero to obtain it`
 type witnessClient struct {
-	client   *http.Client
-	url      string
-	verifier note.Verifier
-	size     uint64
+	client    *http.Client
+	url       string
+	verifiers []note.Verifier
+	size      uint64
 }
 
 func (w *witnessClient) update(ctx context.Context, cp []byte, size uint64, fetchProof func(ctx context.Context, from, to uint64) ([][]byte, error)) ([]byte, error) {
@@ -279,7 +302,7 @@ func (w *witnessClient) update(ctx context.Context, cp []byte, size uint64, fetc
 			recursed = v.(uint)
 		}
 		if recursed >= maxUpdateRecursion {
-			return nil, fmt.Errorf("too many consecutive requests to witness %s", w.verifier.Name())
+			return nil, fmt.Errorf("too many consecutive requests to witness %s", w.verifiers[0].Name())
 		}
 
 		var proof [][]byte
@@ -292,7 +315,7 @@ func (w *witnessClient) update(ctx context.Context, cp []byte, size uint64, fetc
 		}
 
 		start := time.Now()
-		nameAttr := witnessNameKey.String(w.verifier.Name())
+		nameAttr := witnessNameKey.String(w.verifiers[0].Name())
 		witnessClientReqsTotal.Add(ctx, 1, metric.WithAttributes(nameAttr))
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.url, w.buildRequestBody(proof, cp))
@@ -324,11 +347,15 @@ func (w *witnessClient) update(ctx context.Context, cp []byte, size uint64, fetc
 			signed := make([]byte, len(cp)+len(rb))
 			copy(signed, cp)
 			copy(signed[len(cp):], rb)
-			if n, err := note.Open(signed, note.VerifierList(w.verifier)); err != nil {
-				return nil, fmt.Errorf("witness %q at %q replied with invalid signature: %q\nconstructed note: %q\nerror: %v", w.verifier.Name(), w.url, rb, string(signed), err)
+			if n, err := note.Open(signed, note.VerifierList(w.verifiers...)); err != nil {
+				return nil, fmt.Errorf("witness %q at %q replied with invalid signature: %q\nconstructed note: %q\nerror: %v", w.verifiers[0].Name(), w.url, rb, string(signed), err)
 			} else {
 				w.size = uint64(size)
-				return fmt.Appendf(nil, "— %s %s\n", n.Sigs[0].Name, n.Sigs[0].Base64), nil
+				var sigs []byte
+				for _, sig := range n.Sigs {
+					sigs = fmt.Appendf(sigs, "— %s %s\n", sig.Name, sig.Base64)
+				}
+				return sigs, nil
 			}
 		case http.StatusConflict:
 			// Two cases here: the first is a situation we can recover from, the second isn't.

--- a/internal/witness/client.go
+++ b/internal/witness/client.go
@@ -103,11 +103,11 @@ type WitnessGroup interface {
 	// that the input value represents a valid note.
 	Satisfied(cp []byte) bool
 
-	// Endpoints returns the details required for updating a witness and checking the
+	// WitnessEndpoints returns the details required for updating a witness and checking the
 	// response. The returned result is a map from the URL that should be used to update
 	// the witness with a new checkpoint, to the values which are the verifiers to check
 	// the response is well formed.
-	Endpoints() map[string][]note.Verifier
+	WitnessEndpoints() map[string][]note.Verifier
 }
 
 // NewWitnessGateway returns a WitnessGateway that will send out new checkpoints to witnesses
@@ -115,7 +115,7 @@ type WitnessGroup interface {
 // requests will be done using the given client. The tile fetcher is used for constructing
 // consistency proofs for the witnesses.
 func NewWitnessGateway(group WitnessGroup, client *http.Client, oldSize uint64, fetchTiles client.TileFetcherFunc) WitnessGateway {
-	endpoints := group.Endpoints()
+	endpoints := group.WitnessEndpoints()
 	witnesses := make([]*witnessClient, 0, len(endpoints))
 	for u, vs := range endpoints {
 		vs := dedupVerifiers(vs)

--- a/internal/witness/client_test.go
+++ b/internal/witness/client_test.go
@@ -39,13 +39,15 @@ import (
 )
 
 const (
-	logVkey    = "example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
-	wit1Vkey   = "Wit1+55ee4561+AVhZSmQj9+SoL+p/nN0Hh76xXmF7QcHfytUrI1XfSClk"
-	wit1Skey   = "PRIVATE+KEY+Wit1+55ee4561+AeadRiG7XM4XiieCHzD8lxysXMwcViy5nYsoXURWGrlE"
-	wit2Vkey   = "Wit2+85ecc407+AWVbwFJte9wMQIPSnEnj4KibeO6vSIOEDUTDp3o63c2x"
-	wit2Skey   = "PRIVATE+KEY+Wit2+85ecc407+AfPTvxw5eUcqSgivo2vaiC7JPOMUZ/9baHPSDrWqgdGm"
-	witBadVkey = "WitBad+b82b4b16+AY5FLOcqxs5lD+OpC6cVTrxsyNJktaCGYHNfnE5vKBQX"
-	witBadSkey = "PRIVATE+KEY+WitBad+b82b4b16+AYSil2PKfSN1a0LhdbzmK1uXqDFZbp+P1OyR54k3gdJY"
+	logVkey     = "example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
+	wit1Vkey    = "Wit1+55ee4561+AVhZSmQj9+SoL+p/nN0Hh76xXmF7QcHfytUrI1XfSClk"
+	wit1Skey    = "PRIVATE+KEY+Wit1+55ee4561+AeadRiG7XM4XiieCHzD8lxysXMwcViy5nYsoXURWGrlE"
+	wit2Vkey    = "Wit2+85ecc407+AWVbwFJte9wMQIPSnEnj4KibeO6vSIOEDUTDp3o63c2x"
+	wit2Skey    = "PRIVATE+KEY+Wit2+85ecc407+AfPTvxw5eUcqSgivo2vaiC7JPOMUZ/9baHPSDrWqgdGm"
+	wit2AltSKey = "PRIVATE+KEY+Wit2+36009101+ASWI6XB1l1/fPORsXVxCbMvxfrvh7bXtYkNNlD1NYe2H"
+	wit2AltVKey = "Wit2+112f0455+BCy8NYvyk7N1dkxNxgrI3YAJzQDc0FIfs0q7q8U/cwOF"
+	witBadVkey  = "WitBad+b82b4b16+AY5FLOcqxs5lD+OpC6cVTrxsyNJktaCGYHNfnE5vKBQX"
+	witBadSkey  = "PRIVATE+KEY+WitBad+b82b4b16+AYSil2PKfSN1a0LhdbzmK1uXqDFZbp+P1OyR54k3gdJY"
 )
 
 var (
@@ -59,9 +61,8 @@ func TestWitnessGateway_Update(t *testing.T) {
 	// The witnesses just sign the checkpoint with whatever key is requested, they don't check the body at all.
 	// An improvement on this would be to make the fake witnesses more realistic, but it's a non-trivial
 	// amount of code to add to this already long test!
-	var wit1 tessera.Witness
-	var wit2 tessera.Witness
-	var witBad tessera.Witness
+	var wit1, wit2, witBad, witMulti1, witMulti2 tessera.Witness
+	var witCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w1u, err := url.Parse(wit1.URL)
 		if err != nil {
@@ -78,11 +79,18 @@ func TestWitnessGateway_Update(t *testing.T) {
 
 		switch r.URL.String() {
 		case w1u.Path:
+			witCalls.Add(1)
 			_, _ = w.Write(sigForSigner(t, cp, wit1Skey))
 		case w2u.Path:
+			witCalls.Add(1)
 			_, _ = w.Write(sigForSigner(t, cp, wit2Skey))
 		case wbu.Path:
+			witCalls.Add(1)
 			_, _ = w.Write([]byte("this is not a signature\n"))
+		case "/wit_multi/add-checkpoint":
+			witCalls.Add(1)
+			res := append(sigForSigner(t, cp, wit1Skey), sigForSigner(t, cp, wit2Skey)...)
+			_, _ = w.Write(res)
 		default:
 			t.Fatalf("Unknown case: %s", r.URL.String())
 		}
@@ -99,21 +107,31 @@ func TestWitnessGateway_Update(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	witMulti1, err = tessera.NewWitness(wit1Vkey, baseURL.JoinPath("wit_multi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	witMulti2, err = tessera.NewWitness(wit2Vkey, baseURL.JoinPath("wit_multi"))
+	if err != nil {
+		t.Fatal(err)
+	}
 	witBad, err = tessera.NewWitness(witBadVkey, baseURL)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	testCases := []struct {
-		desc     string
-		group    tessera.WitnessGroup
-		wantSigs int
-		wantErr  bool
+		desc             string
+		group            tessera.WitnessGroup
+		wantSigs         int
+		wantErr          bool
+		wantWitnessCalls func(actual int32) error
 	}{
 		{
-			desc:     "no witnesses",
-			group:    tessera.WitnessGroup{},
-			wantSigs: 0,
+			desc:             "no witnesses",
+			group:            tessera.WitnessGroup{},
+			wantSigs:         0,
+			wantWitnessCalls: exactly(0),
 		},
 		{
 			desc:     "one optional witness",
@@ -126,24 +144,34 @@ func TestWitnessGateway_Update(t *testing.T) {
 			wantSigs: 0,
 		},
 		{
-			desc:     "one required witness",
-			group:    tessera.NewWitnessGroup(1, wit1),
-			wantSigs: 1,
+			desc:             "one required witness",
+			group:            tessera.NewWitnessGroup(1, wit1),
+			wantSigs:         1,
+			wantWitnessCalls: exactly(1),
 		},
 		{
-			desc:     "one required witness out of 2",
-			group:    tessera.NewWitnessGroup(1, wit1, wit2),
-			wantSigs: 1,
+			desc:             "one required witness out of 2",
+			group:            tessera.NewWitnessGroup(1, wit1, wit2),
+			wantSigs:         1,
+			wantWitnessCalls: atLeast(1),
 		},
 		{
-			desc:     "two required witnesses",
-			group:    tessera.NewWitnessGroup(2, wit1, wit2),
-			wantSigs: 2,
+			desc:             "two required witnesses",
+			group:            tessera.NewWitnessGroup(2, wit1, wit2),
+			wantSigs:         2,
+			wantWitnessCalls: exactly(2),
 		},
 		{
-			desc:     "one required witness twice",
-			group:    tessera.NewWitnessGroup(2, wit1, wit1),
-			wantSigs: 1,
+			desc:             "one required witness twice",
+			group:            tessera.NewWitnessGroup(2, wit1, wit1),
+			wantSigs:         1,
+			wantWitnessCalls: exactly(1),
+		},
+		{
+			desc:             "two witnesses with same URL but different keys",
+			group:            tessera.NewWitnessGroup(2, witMulti1, witMulti2),
+			wantSigs:         2,
+			wantWitnessCalls: exactly(1),
 		},
 		{
 			desc:    "bad witness",
@@ -154,6 +182,7 @@ func TestWitnessGateway_Update(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			ctx := t.Context()
+			witCalls.Store(0)
 
 			g := witness.NewWitnessGateway(tC.group, ts.Client(), 0, testLogTileFetcher)
 
@@ -171,7 +200,30 @@ func TestWitnessGateway_Update(t *testing.T) {
 			if len(n.Sigs)-1 < tC.wantSigs {
 				t.Errorf("wanted %d sigs but got %d", tC.wantSigs, len(n.Sigs)-1)
 			}
+			if tC.wantWitnessCalls != nil {
+				if err := tC.wantWitnessCalls(witCalls.Load()); err != nil {
+					t.Error(err)
+				}
+			}
 		})
+	}
+}
+
+func exactly(x int32) func(actual int32) error {
+	return func(actual int32) error {
+		if actual != x {
+			return fmt.Errorf("got %d calls, want %d", actual, x)
+		}
+		return nil
+	}
+}
+
+func atLeast(x int32) func(actual int32) error {
+	return func(actual int32) error {
+		if actual < x {
+			return fmt.Errorf("got %d calls, want at least %d", actual, x)
+		}
+		return nil
 	}
 }
 

--- a/witness.go
+++ b/witness.go
@@ -22,8 +22,6 @@ import (
 	"strconv"
 	"strings"
 
-	"maps"
-
 	f_note "github.com/transparency-dev/formats/note"
 	"golang.org/x/mod/sumdb/note"
 )
@@ -37,9 +35,9 @@ type policyComponent interface {
 
 	// Endpoints returns the details required for updating a witness and checking the
 	// response. The returned result is a map from the URL that should be used to update
-	// the witness with a new checkpoint, to the value which is the verifier to check
+	// the witness with a new checkpoint, to the values which are the verifiers to check
 	// the response is well formed.
-	Endpoints() map[string]note.Verifier
+	Endpoints() map[string][]note.Verifier
 }
 
 // NewWitnessGroupFromPolicy creates a graph of witness objects that represents the
@@ -220,10 +218,10 @@ func (w Witness) Satisfied(cp []byte) bool {
 
 // Endpoints returns the details required for updating a witness and checking the
 // response. The returned result is a map from the URL that should be used to update
-// the witness with a new checkpoint, to the value which is the verifier to check
+// the witness with a new checkpoint, to the values which are the verifiers to check
 // the response is well formed.
-func (w Witness) Endpoints() map[string]note.Verifier {
-	return map[string]note.Verifier{w.URL: w.Key}
+func (w Witness) Endpoints() map[string][]note.Verifier {
+	return map[string][]note.Verifier{w.URL: {w.Key}}
 }
 
 // NewWitnessGroup creates a grouping of Witness or WitnessGroup with a configurable threshold
@@ -281,12 +279,14 @@ func (wg WitnessGroup) Satisfied(cp []byte) bool {
 
 // Endpoints returns the details required for updating a witness and checking the
 // response. The returned result is a map from the URL that should be used to update
-// the witness with a new checkpoint, to the value which is the verifier to check
+// the witness with a new checkpoint, to the values which are the verifiers to check
 // the response is well formed.
-func (wg WitnessGroup) Endpoints() map[string]note.Verifier {
-	endpoints := make(map[string]note.Verifier)
+func (wg WitnessGroup) Endpoints() map[string][]note.Verifier {
+	endpoints := make(map[string][]note.Verifier)
 	for _, c := range wg.Components {
-		maps.Copy(endpoints, c.Endpoints())
+		for u, vs := range c.Endpoints() {
+			endpoints[u] = append(endpoints[u], vs...)
+		}
 	}
 	return endpoints
 }

--- a/witness.go
+++ b/witness.go
@@ -33,11 +33,11 @@ type policyComponent interface {
 	// witnesses involved in this policy component.
 	Satisfied(cp []byte) bool
 
-	// Endpoints returns the details required for updating a witness and checking the
+	// WitnessEndpoints returns the details required for updating a witness and checking the
 	// response. The returned result is a map from the URL that should be used to update
 	// the witness with a new checkpoint, to the values which are the verifiers to check
 	// the response is well formed.
-	Endpoints() map[string][]note.Verifier
+	WitnessEndpoints() map[string][]note.Verifier
 }
 
 // NewWitnessGroupFromPolicy creates a graph of witness objects that represents the
@@ -217,10 +217,18 @@ func (w Witness) Satisfied(cp []byte) bool {
 }
 
 // Endpoints returns the details required for updating a witness and checking the
+// response.
+//
+// Deprecated: Endpoints is deprecated, use WitnessEndpoints instead.
+func (w Witness) Endpoints() map[string]note.Verifier {
+	return map[string]note.Verifier{w.URL: w.Key}
+}
+
+// WitnessEndpoints returns the details required for updating a witness and checking the
 // response. The returned result is a map from the URL that should be used to update
 // the witness with a new checkpoint, to the values which are the verifiers to check
 // the response is well formed.
-func (w Witness) Endpoints() map[string][]note.Verifier {
+func (w Witness) WitnessEndpoints() map[string][]note.Verifier {
 	return map[string][]note.Verifier{w.URL: {w.Key}}
 }
 
@@ -278,13 +286,37 @@ func (wg WitnessGroup) Satisfied(cp []byte) bool {
 }
 
 // Endpoints returns the details required for updating a witness and checking the
+// response.
+//
+// Deprecated: Endpoints is deprecated because it cannot handle policies with
+// multiple verifiers per endpoint (e.g. witnesses which return multiple signatures).
+// Use [WitnessEndpoints] instead.
+func (wg WitnessGroup) Endpoints() map[string]note.Verifier {
+	endpoints := make(map[string]note.Verifier)
+	for _, c := range wg.Components {
+		for u, v := range c.WitnessEndpoints() {
+			if _, ok := endpoints[u]; ok {
+				panic(fmt.Errorf("the Endpoints func cannot safely handle witnesses which return multiple signatures, use WitnessEndpoints instead"))
+			}
+			switch l := len(v); {
+			case l > 1:
+				panic(fmt.Errorf("the Endpoints func cannot safely handle witnesses which return multiple signatures, use WitnessEndpoints instead"))
+			case l == 1:
+				endpoints[u] = v[0]
+			}
+		}
+	}
+	return endpoints
+}
+
+// WitnessEndpoints returns the details required for updating a witness and checking the
 // response. The returned result is a map from the URL that should be used to update
 // the witness with a new checkpoint, to the values which are the verifiers to check
 // the response is well formed.
-func (wg WitnessGroup) Endpoints() map[string][]note.Verifier {
+func (wg WitnessGroup) WitnessEndpoints() map[string][]note.Verifier {
 	endpoints := make(map[string][]note.Verifier)
 	for _, c := range wg.Components {
-		for u, vs := range c.Endpoints() {
+		for u, vs := range c.WitnessEndpoints() {
 			endpoints[u] = append(endpoints[u], vs...)
 		}
 	}

--- a/witness.go
+++ b/witness.go
@@ -51,6 +51,8 @@ func NewWitnessGroupFromPolicy(p []byte) (WitnessGroup, error) {
 	scanner := bufio.NewScanner(bytes.NewBuffer(p))
 	components := make(map[string]policyComponent)
 
+	urlToWitnessName := make(map[string]string)
+
 	var quorumName string
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -88,6 +90,11 @@ func NewWitnessGroupFromPolicy(p []byte) (WitnessGroup, error) {
 				return WitnessGroup{}, fmt.Errorf("invalid witness config %q: %w", line, err)
 			}
 			components[name] = w
+			if wName, ok := urlToWitnessName[witnessURLStr]; !ok {
+				urlToWitnessName[witnessURLStr] = w.Key.Name()
+			} else if wName != w.Key.Name() {
+				return WitnessGroup{}, fmt.Errorf("witness URL %q has multiple witness signer names assigned %q and %q", witnessURLStr, wName, w.Key.Name())
+			}
 		case "group":
 			if len(fields) < 3 {
 				return WitnessGroup{}, fmt.Errorf("invalid group definition: %q", line)

--- a/witness_policy_test.go
+++ b/witness_policy_test.go
@@ -159,8 +159,15 @@ func TestNewWitnessGroupFromPolicy_Errors(t *testing.T) {
 			desc:   "witness name is keyword",
 			policy: `group none 1 witness`,
 			errStr: "invalid group name",
-		},
-	}
+		}, {
+			desc: "witness URL has multiple signer names",
+			policy: `
+				witness w1 sigsum.org+e4ade967+AZuUY6B08pW3QVHu8uvsrxWPcAv9nykap2Nb4oxCee+r https://sigsum.org/witness/
+				witness w2 example.com+3753d3de+AebBhMcghIUoavZpjuDofa4sW6fYHyVn7gvwDBfvkvuM https://sigsum.org/witness/
+				group g1 1 w1 w2
+				quorum g1`,
+			errStr: "has multiple witness signer names assigned",
+		}}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/witness_test.go
+++ b/witness_test.go
@@ -35,7 +35,7 @@ func TestWitnessGroup_Empty(t *testing.T) {
 	if !group.Satisfied([]byte("definitely a checkpoint\n")) {
 		t.Error("empty group should be satisfied")
 	}
-	if len(group.Endpoints()) != 0 {
+	if len(group.WitnessEndpoints()) != 0 {
 		t.Error("empty group should have no URLs")
 	}
 }
@@ -180,7 +180,7 @@ func TestWitnessGroup_URLs(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			gotURLs := make([]string, 0)
-			for u := range tC.group.Endpoints() {
+			for u := range tC.group.WitnessEndpoints() {
 				gotURLs = append(gotURLs, u)
 			}
 			slices.Sort(gotURLs)


### PR DESCRIPTION
This PR improves the way the Tessera witness client handles policies which require multiple cosignatures from the same URL (e.g. a witness which is returning both `ed25519` and `MLDSA cosignatures`).

Previously, such a policy would have caused multiple `add-checkpoint` requests to be sent to the witness, one for each `vkey` in the policy, and all but the first of those would be guaranteed to receive a `409` in response causing more requests to be sent.

With the changes in this PR, Tessera should make at most a single call to each witness URL present in the policy (conflicts not withstanding).

I've added a new `WitnessEndpoint` func on the witness policy interface so as to avoid breaking semver by changing the func signature. In practice, I doubt anyone uses the old `Endpoints` func directly (as opposed to just creating the policy structure and passing it directly to `WithWitnesses`), but...