### PR TITLE
Handle unaligned uploadStart

### DIFF
--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -296,7 +296,7 @@ func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd u
 	}
 }
 
-// bundleIterator returns an interator which yields entry bundles after verifying their subtree consistency with the provided pending checkpoint.
+// bundleIterator returns an iterator which yields entry bundles after verifying their subtree consistency with the provided pending checkpoint.
 //
 // Yielded entry bundles are always aligned to bundle boundaries. Specifically, this means that if the provided start is _not_ bundle aligned, then we will
 // fetch entries from the bundle at start/256 and use those entries to left-pad the first yielded bundle.
@@ -316,6 +316,10 @@ func (mt *MirrorTarget) bundleIterator(ctx context.Context, next func() (*Mirror
 			b := &api.EntryBundle{}
 			if err := b.UnmarshalText(br); err != nil {
 				yield(nil, fmt.Errorf("failed to unmarshal bundle containing uploadStart (%d): %v", start, err))
+				return
+			}
+			if l := len(b.Entries); l < int(p) {
+				yield(nil, fmt.Errorf("POTENTIAL CORRUPTION: partial bundle at index %d.%d has only %d entries", start/layout.EntryBundleWidth, p, l))
 				return
 			}
 			padEntries = b.Entries[:p]

--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -111,10 +111,12 @@ func (o *MirrorOptions) valid() error {
 
 // mirrorWriter describes the contract for storage implementation required to support the mirroring lifecycle.
 type MirrorWriter interface {
-	// IntegrateBundles integrates bundles of log entries, starting at the given index, into the local tree.
+	// IntegrateBundles integrates bundles of log entries, starting at the given bundle index, into the local tree.
+	// Bundles are _always_ aligned on bundle boundaries.
+	//
 	// Returns the size of the tree and its new root hash if successful.
 	// If the provided iterator yields an error, the MirrorWriter MUST return it either directly, or wrapped so the caller can identify it.
-	IntegrateBundles(ctx context.Context, from uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error)
+	IntegrateBundles(ctx context.Context, fromBundleIdx uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error)
 	// IntegratedSize returns the size of the local integrated tree.
 	IntegratedSize(ctx context.Context) (uint64, error)
 
@@ -206,8 +208,6 @@ type MirrorPackage struct {
 // ticket for future invocations, and, optionally, a cosignature over a pending checkpoint
 // whose size matches uploadEnd if one exists.
 func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticketBytes []byte, next func() (*MirrorPackage, error)) (nextEntry uint64, pendingSize uint64, newTicket []byte, cosigs []byte, err error) {
-	// TODO(al) handle non-aligned uploadStart.
-
 	curIntegratedSize, err := mt.reader.IntegratedSize(ctx)
 	if err != nil {
 		return 0, 0, nil, nil, fmt.Errorf("failed to read integrated size: %w", err)
@@ -266,10 +266,8 @@ func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd u
 		return curIntegratedSize, pendingCP.Size, ticketBytes, nil, ErrConflict
 	}
 
-	curStart := uploadStart
 	bundleIdx := uploadStart / layout.EntryBundleWidth
-
-	nextEntry, newRoot, err := mt.writer.IntegrateBundles(ctx, bundleIdx, mt.bundleIterator(ctx, next, curStart, pendingCP))
+	nextEntry, newRoot, err := mt.writer.IntegrateBundles(ctx, bundleIdx, mt.bundleIterator(ctx, next, uploadStart, pendingCP))
 	switch {
 	case err != nil:
 		return 0, 0, nil, nil, err
@@ -298,21 +296,52 @@ func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd u
 	}
 }
 
-// bundleIterator returns an interator which yields MirrorPackages after verifying their subtree consistency with the provided pending checkpoint.
+// bundleIterator returns an interator which yields entry bundles after verifying their subtree consistency with the provided pending checkpoint.
+//
+// Yielded entry bundles are always aligned to bundle boundaries. Specifically, this means that if the provided start is _not_ bundle aligned, then we will
+// fetch entries from the bundle at start/256 and use those entries to left-pad the first yielded bundle.
 func (mt *MirrorTarget) bundleIterator(ctx context.Context, next func() (*MirrorPackage, error), start uint64, pendingCP *log.Checkpoint) func(func(*api.EntryBundle, error) bool) {
 	crf := compact.RangeFactory{Hash: rfc6962.DefaultHasher.HashChildren}
 	return func(yield func(*api.EntryBundle, error) bool) {
+		// Check for unaligned upload start, and fetch entries from the start of the bundle to use to pad.
+		var padEntries [][]byte
+		if p := start % layout.EntryBundleWidth; p != 0 {
+			// non-aligned starting bundle
+			br, err := mt.reader.ReadEntryBundle(ctx, start/layout.EntryBundleWidth, uint8(p))
+			if err != nil {
+				yield(nil, fmt.Errorf("failed to read bundle containing uploadStart (%d): %v", start, err))
+				return
+			}
+			// Parse and clip, just in case we were returned data from a full tile.
+			b := &api.EntryBundle{}
+			if err := b.UnmarshalText(br); err != nil {
+				yield(nil, fmt.Errorf("failed to unmarshal bundle containing uploadStart (%d): %v", start, err))
+				return
+			}
+			padEntries = b.Entries[:p]
+			// SPEC: The subtree consistency proof is computed from the subtree defined by [rounded_start + i * 256, end), and the log
+			//       checkpoint with tree size upload_end
+			start &= ^uint64(0xff) // floor to bundle boundary
+		}
+
 		for {
 			pkg, err := next()
 			if err != nil {
 				if err == io.EOF {
 					return
 				}
-				// TODO(al): handle this
 				slog.WarnContext(ctx, "NextPackage returned an error", slog.String("error", err.Error()))
+				yield(nil, fmt.Errorf("failed to get next package: %w", err)) // Wrap to preserve err from next().
 				return
 			}
 
+			// Handle the case where the first mirror package is not bundle-aligned.
+			if len(padEntries) > 0 {
+				pkg.Entries = append(padEntries, pkg.Entries...)
+				padEntries = nil
+			}
+
+			// Build the subtree root so that we can verify the package proof.
 			cr := crf.NewEmptyRange(0)
 			for _, e := range pkg.Entries {
 				if err := cr.Append(rfc6962.DefaultHasher.HashLeaf(e), nil); err != nil {
@@ -320,7 +349,6 @@ func (mt *MirrorTarget) bundleIterator(ctx context.Context, next func() (*Mirror
 					return
 				}
 			}
-
 			subRoot, err := cr.GetRootHash(nil)
 			if err != nil {
 				yield(nil, fmt.Errorf("failed to get root of compact range: %v", err))

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -59,7 +59,8 @@ func (f *fakeMirrorWriter) UpdateCheckpoint(ctx context.Context, g func(oldCP []
 }
 
 type fakeLogReader struct {
-	sizeFunc func(ctx context.Context) (uint64, error)
+	sizeFunc            func(ctx context.Context) (uint64, error)
+	readEntryBundleFunc func(ctx context.Context, index uint64, p uint8) ([]byte, error)
 }
 
 func (f *fakeLogReader) IntegratedSize(ctx context.Context) (uint64, error) {
@@ -73,6 +74,9 @@ func (f *fakeLogReader) ReadTile(ctx context.Context, level, index uint64, p uin
 	return nil, nil
 }
 func (f *fakeLogReader) ReadEntryBundle(ctx context.Context, index uint64, p uint8) ([]byte, error) {
+	if f.readEntryBundleFunc != nil {
+		return f.readEntryBundleFunc(ctx, index, p)
+	}
 	return nil, nil
 }
 func (f *fakeLogReader) NextIndex(ctx context.Context) (uint64, error) { return 0, nil }
@@ -357,5 +361,73 @@ func TestMirrorTarget_AddEntries_VerifySubtreeProof(t *testing.T) {
 				t.Errorf("verifySubtreeProof proof: got %x, want %x", gotProof, pkg.Proof)
 			}
 		})
+	}
+}
+
+func TestMirrorTarget_AddEntries_Unaligned_PadsFirstBundle(t *testing.T) {
+	const (
+		testIntegratedSize = uint64(270)
+		testUploadStart    = uint64(270) // not aligned: 270 % 256 = 14
+		testUploadEnd      = testPendingCPSize
+	)
+
+	var readEntryBundleCalled bool
+
+	padEntries := testUploadStart % layout.EntryBundleWidth
+	padBundleRaw := make([]byte, 2*padEntries)
+
+	mt := &MirrorTarget{
+		logVerifier: testLogVerifier,
+		signer:      testMirrorSigner,
+		writer: &fakeMirrorWriter{
+			integrateFunc: func(ctx context.Context, fromBundleIdx uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
+				if want := testUploadStart / layout.EntryBundleWidth; fromBundleIdx != want {
+					return 0, nil, fmt.Errorf("got fromBundleIdx %d want %d", fromBundleIdx, want)
+				}
+				for b, err := range bundles {
+					if err != nil {
+						return 0, nil, err
+					}
+					if got, want := uint64(len(b.Entries)), testUploadStart%layout.EntryBundleWidth; got != want {
+						return 0, nil, fmt.Errorf("got %d entries in bundle, want %d", got, want)
+					}
+				}
+				pendingCPRoot, err := base64.StdEncoding.DecodeString(testPendingCPRoot)
+				return testUploadEnd, pendingCPRoot, err
+			},
+			updateCheckpointFunc: func(ctx context.Context, f func(oldCP []byte) (newCP []byte, err error)) error {
+				_, err := f(nil)
+				return err
+			},
+		},
+		reader: &fakeLogReader{
+			sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
+			readEntryBundleFunc: func(ctx context.Context, index uint64, p uint8) ([]byte, error) {
+				readEntryBundleCalled = true
+				if got, want := index, testUploadStart/layout.EntryBundleWidth; got != want {
+					t.Errorf("ReadEntryBundle index: got %d, want %d", got, want)
+				}
+				if got, want := p, uint8(testUploadStart%layout.EntryBundleWidth); got != want {
+					t.Errorf("ReadEntryBundle p: got %d, want %d", got, want)
+				}
+				return padBundleRaw, nil
+			},
+		},
+		cpSource: func(ctx context.Context) ([]byte, error) { return []byte(testPendingCP), nil },
+	}
+
+	validTicket, err := mt.sealTicket([]byte(testPendingCP))
+	if err != nil {
+		t.Fatalf("sealTicket failed: %v", err)
+	}
+
+	_, _, _, _, err = mt.AddEntries(t.Context(), testUploadStart, testUploadEnd, validTicket, func() (*MirrorPackage, error) {
+		return nil, io.EOF
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !readEntryBundleCalled {
+		t.Errorf("ReadEntryBundle was not called")
 	}
 }

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -27,6 +27,7 @@ import (
 	fnote "github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/merkle"
 	"github.com/transparency-dev/tessera/api"
+	"github.com/transparency-dev/tessera/api/layout"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -178,7 +179,10 @@ func TestMirrorTarget_AddEntries_CompleteUpload(t *testing.T) {
 		logVerifier: testLogVerifier,
 		signer:      testMirrorSigner,
 		writer: &fakeMirrorWriter{
-			integrateFunc: func(ctx context.Context, from uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
+			integrateFunc: func(ctx context.Context, fromBundleIdx uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
+				if fromBundleIdx != testUploadStart/layout.EntryBundleWidth {
+					return 0, nil, fmt.Errorf("got from %d want %d", fromBundleIdx, testUploadStart/layout.EntryBundleWidth)
+				}
 				pendingCPRoot, err := base64.StdEncoding.DecodeString(testPendingCPRoot)
 				return testUploadEnd, pendingCPRoot, err
 			},

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -1212,18 +1212,19 @@ func (m *MirrorWriter) IntegrateBundles(ctx context.Context, bundleIdx uint64, b
 		}
 		if seenPartialBundle {
 			// Seeing a partial bundle means that there should not be any further bundles to be processed.
-			return 0, nil, fmt.Errorf("unexpected bundle after partial at index %d", bundleIdx)
+			return 0, nil, fmt.Errorf("bundle index %d follows a partial bundle", bundleIdx)
 		}
 
-		p := len(b.Entries)
-		switch p {
-		case 0:
+		var p int
+		switch le := len(b.Entries); {
+		case le == 0:
 			return 0, nil, fmt.Errorf("zero-length entry bundle at index %d", bundleIdx)
-		case layout.EntryBundleWidth:
-			p = 0
-		default:
+		case le > layout.EntryBundleWidth:
+			return 0, nil, fmt.Errorf("bundle index %d has too many entries (%d)", bundleIdx, le)
+		case le < layout.EntryBundleWidth:
 			// This is a partial bundle, so we do not expect to see any further bundles from the iterator.
 			seenPartialBundle = true
+			p = le
 		}
 
 		// Serialise the bundle...
@@ -1233,7 +1234,8 @@ func (m *MirrorWriter) IntegrateBundles(ctx context.Context, bundleIdx uint64, b
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed to marshal bundle at index %d: %v", bundleIdx, err)
 		}
-		// ...and then write it out.
+
+		// Now write the bundle out out.
 		if err := m.logStorage.writeBundle(ctx, bundleIdx, uint8(p), bundleData); err != nil {
 			return 0, nil, err
 		}

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -1235,7 +1235,7 @@ func (m *MirrorWriter) IntegrateBundles(ctx context.Context, bundleIdx uint64, b
 			return 0, nil, fmt.Errorf("failed to marshal bundle at index %d: %v", bundleIdx, err)
 		}
 
-		// Now write the bundle out out.
+		// Now write the bundle out.
 		if err := m.logStorage.writeBundle(ctx, bundleIdx, uint8(p), bundleData); err != nil {
 			return 0, nil, err
 		}


### PR DESCRIPTION
This PR adds support for mirror uploads which don't start on an entrybundle boundary.

Towards #945 