### PR TITLE
storage/gcp: add optional SpannerTablePrefix to Config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,5 +8,6 @@
 #
 # Please keep the list sorted.
 
+Anthropic PBC
 Google LLC
 Internet Security Research Group

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,5 +23,6 @@
 # Please keep the list sorted.
 
 Al Cutter <al@google.com> <al@9600.org>
+Erin Perrine <eperrine@anthropic.com>
 Martin Hutchinson <mhutchinson@google.com> <mhutchinson@gmail.com>
 Roger Ng <rogerng@google.com> <roger2hk@gmail.com>

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	"iter"
 	"os"
+	"regexp"
 	"sync/atomic"
 	"time"
 
@@ -72,7 +73,18 @@ type AntispamOpts struct {
 	// When the antispam follower is at least this many entries behind the size of the locally integrated tree,
 	// the antispam decorator will return a wrapped tessera.ErrPushback for every Add request.
 	PushbackThreshold uint
+
+	// SpannerTablePrefix is an optional prefix to prepend to the names of all Spanner tables.
+	// This can be used e.g. to store the antispam state for multiple logs in the same Spanner database.
+	// If set, it must start with a letter, contain only letters, digits, or underscores
+	// (e.g. "log1_"), and be at most 64 characters long, so that prefixed table names
+	// remain valid Spanner identifiers.
+	SpannerTablePrefix string
 }
+
+// tablePrefixRE matches valid values for a Spanner table prefix: empty, or a leading
+// letter followed by up to 63 letters, digits, or underscores.
+var tablePrefixRE = regexp.MustCompile(`^([A-Za-z][A-Za-z0-9_]{0,63})?$`)
 
 // NewAntispam returns an antispam driver which uses Spanner to maintain a mapping of
 // previously seen entries and their assigned indices.
@@ -88,14 +100,17 @@ func NewAntispam(ctx context.Context, spannerDB string, opts AntispamOpts) (*Ant
 	if opts.PushbackThreshold == 0 {
 		opts.PushbackThreshold = DefaultPushbackThreshold
 	}
+	if !tablePrefixRE.MatchString(opts.SpannerTablePrefix) {
+		return nil, fmt.Errorf("invalid SpannerTablePrefix %q: must start with a letter, contain only letters, digits, or underscores, and be at most 64 characters long", opts.SpannerTablePrefix)
+	}
 	if err := createAndPrepareTables(
 		ctx, spannerDB,
 		[]string{
-			"CREATE TABLE IF NOT EXISTS FollowCoord (id INT64 NOT NULL, nextIdx INT64 NOT NULL) PRIMARY KEY (id)",
-			"CREATE TABLE IF NOT EXISTS IDSeq (h BYTES(32) NOT NULL, idx INT64 NOT NULL) PRIMARY KEY (h)",
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sFollowCoord (id INT64 NOT NULL, nextIdx INT64 NOT NULL) PRIMARY KEY (id)", opts.SpannerTablePrefix),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sIDSeq (h BYTES(32) NOT NULL, idx INT64 NOT NULL) PRIMARY KEY (h)", opts.SpannerTablePrefix),
 		},
 		[][]*spanner.Mutation{
-			{spanner.Insert("FollowCoord", []string{"id", "nextIdx"}, []any{0, 0})},
+			{spanner.Insert(opts.SpannerTablePrefix+"FollowCoord", []string{"id", "nextIdx"}, []any{0, 0})},
 		},
 	); err != nil {
 		return nil, fmt.Errorf("failed to create tables: %v", err)
@@ -107,17 +122,26 @@ func NewAntispam(ctx context.Context, spannerDB string, opts AntispamOpts) (*Ant
 	}
 
 	r := &AntispamStorage{
-		opts:   opts,
-		dbPool: db,
+		opts:        opts,
+		dbPool:      db,
+		tablePrefix: opts.SpannerTablePrefix,
 	}
 
 	return r, nil
+}
+
+// tbl returns the provided table name with the configured table prefix, if any, prepended.
+func (d *AntispamStorage) tbl(name string) string {
+	return d.tablePrefix + name
 }
 
 type AntispamStorage struct {
 	opts AntispamOpts
 
 	dbPool *spanner.Client
+
+	// tablePrefix is prepended to the names of all Spanner tables, see AntispamOpts.SpannerTablePrefix.
+	tablePrefix string
 
 	// pushBack is used to prevent the follower from getting too far underwater.
 	// Populate dynamically will set this to true/false based on how far behind the follower is from the
@@ -135,7 +159,7 @@ func (d *AntispamStorage) index(ctx context.Context, h []byte) (*uint64, error) 
 	return otel.Trace(ctx, "tessera.antispam.gcp.index", tracer, func(ctx context.Context, span trace.Span) (*uint64, error) {
 		d.numLookups.Add(1)
 		var idx int64
-		if row, err := d.dbPool.Single().ReadRowWithOptions(ctx, "IDSeq", spanner.Key{h}, []string{"idx"}, &spanner.ReadOptions{RequestTag: "tessera.op=antispam.index"}); err != nil {
+		if row, err := d.dbPool.Single().ReadRowWithOptions(ctx, d.tbl("IDSeq"), spanner.Key{h}, []string{"idx"}, &spanner.ReadOptions{RequestTag: "tessera.op=antispam.index"}); err != nil {
 			if c := spanner.ErrCode(err); c == codes.NotFound {
 				span.AddEvent("tessera.miss")
 				return nil, nil
@@ -267,7 +291,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 				_, err := f.as.dbPool.ReadWriteTransactionWithOptions(ctx, func(txctx context.Context, txn *spanner.ReadWriteTransaction) error {
 					return otel.TraceErr(txctx, "tessera.antispam.gcp.FollowTxn", tracer, func(txctx context.Context, span trace.Span) error {
 						// Figure out the last entry we used to populate our antispam storage.
-						row, err := txn.ReadRowWithOptions(txctx, "FollowCoord", spanner.Key{0}, []string{"nextIdx"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+						row, err := txn.ReadRowWithOptions(txctx, f.as.tbl("FollowCoord"), spanner.Key{0}, []string{"nextIdx"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 						if err != nil {
 							return err
 						}
@@ -357,7 +381,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 						{
 							ms := make([]*spanner.Mutation, 0, len(curEntries))
 							for i, e := range curEntries {
-								ms = append(ms, spanner.Insert("IDSeq", []string{"h", "idx"}, []any{e, int64(curIndex + uint64(i))}))
+								ms = append(ms, spanner.Insert(f.as.tbl("IDSeq"), []string{"h", "idx"}, []any{e, int64(curIndex + uint64(i))}))
 							}
 							if err := f.updateIndex(txctx, txn, ms); err != nil {
 								return err
@@ -369,7 +393,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 
 						// Insertion of dupe entries was successful, so update our follow coordination row:
 						m := make([]*spanner.Mutation, 0)
-						m = append(m, spanner.Update("FollowCoord", []string{"id", "nextIdx"}, []any{0, int64(followFrom + numAdded)}))
+						m = append(m, spanner.Update(f.as.tbl("FollowCoord"), []string{"id", "nextIdx"}, []any{0, int64(followFrom + numAdded)}))
 
 						return txn.BufferWrite(m)
 					})
@@ -433,7 +457,7 @@ func (f *follower) batchUpdateIndex(ctx context.Context, _ *spanner.ReadWriteTra
 
 // EntriesProcessed returns the total number of log entries processed.
 func (f *follower) EntriesProcessed(ctx context.Context) (uint64, error) {
-	row, err := f.as.dbPool.Single().ReadRowWithOptions(ctx, "FollowCoord", spanner.Key{0}, []string{"nextIdx"}, &spanner.ReadOptions{RequestTag: "tessera.op=antispam.EntriesProcessed"})
+	row, err := f.as.dbPool.Single().ReadRowWithOptions(ctx, f.as.tbl("FollowCoord"), spanner.Key{0}, []string{"nextIdx"}, &spanner.ReadOptions{RequestTag: "tessera.op=antispam.EntriesProcessed"})
 	if err != nil {
 		return 0, err
 	}

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -79,6 +79,10 @@ type AntispamOpts struct {
 	// If set, it must start with a letter, contain only letters, digits, or underscores
 	// (e.g. "log1_"), and be at most 64 characters long, so that prefixed table names
 	// remain valid Spanner identifiers.
+	// It's recommended to derive this prefix from the log's origin string (e.g. by
+	// replacing any characters other than letters, digits, or underscores with
+	// underscores, and prepending a letter if the origin doesn't start with one), to
+	// make it easy to associate tables with specific logs.
 	SpannerTablePrefix string
 }
 
@@ -103,14 +107,17 @@ func NewAntispam(ctx context.Context, spannerDB string, opts AntispamOpts) (*Ant
 	if !tablePrefixRE.MatchString(opts.SpannerTablePrefix) {
 		return nil, fmt.Errorf("invalid SpannerTablePrefix %q: must start with a letter, contain only letters, digits, or underscores, and be at most 64 characters long", opts.SpannerTablePrefix)
 	}
+	table := func(t string) string {
+		return opts.SpannerTablePrefix + t
+	}
 	if err := createAndPrepareTables(
 		ctx, spannerDB,
 		[]string{
-			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sFollowCoord (id INT64 NOT NULL, nextIdx INT64 NOT NULL) PRIMARY KEY (id)", opts.SpannerTablePrefix),
-			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sIDSeq (h BYTES(32) NOT NULL, idx INT64 NOT NULL) PRIMARY KEY (h)", opts.SpannerTablePrefix),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id INT64 NOT NULL, nextIdx INT64 NOT NULL) PRIMARY KEY (id)", table("FollowCoord")),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (h BYTES(32) NOT NULL, idx INT64 NOT NULL) PRIMARY KEY (h)", table("IDSeq")),
 		},
 		[][]*spanner.Mutation{
-			{spanner.Insert(opts.SpannerTablePrefix+"FollowCoord", []string{"id", "nextIdx"}, []any{0, 0})},
+			{spanner.Insert(table("FollowCoord"), []string{"id", "nextIdx"}, []any{0, 0})},
 		},
 	); err != nil {
 		return nil, fmt.Errorf("failed to create tables: %v", err)
@@ -122,17 +129,12 @@ func NewAntispam(ctx context.Context, spannerDB string, opts AntispamOpts) (*Ant
 	}
 
 	r := &AntispamStorage{
-		opts:        opts,
-		dbPool:      db,
-		tablePrefix: opts.SpannerTablePrefix,
+		opts:   opts,
+		dbPool: db,
+		table:  table,
 	}
 
 	return r, nil
-}
-
-// tbl returns the provided table name with the configured table prefix, if any, prepended.
-func (d *AntispamStorage) tbl(name string) string {
-	return d.tablePrefix + name
 }
 
 type AntispamStorage struct {
@@ -140,8 +142,9 @@ type AntispamStorage struct {
 
 	dbPool *spanner.Client
 
-	// tablePrefix is prepended to the names of all Spanner tables, see AntispamOpts.SpannerTablePrefix.
-	tablePrefix string
+	// table returns the provided table name with the configured table prefix, if any,
+	// prepended - see AntispamOpts.SpannerTablePrefix.
+	table func(string) string
 
 	// pushBack is used to prevent the follower from getting too far underwater.
 	// Populate dynamically will set this to true/false based on how far behind the follower is from the
@@ -159,7 +162,7 @@ func (d *AntispamStorage) index(ctx context.Context, h []byte) (*uint64, error) 
 	return otel.Trace(ctx, "tessera.antispam.gcp.index", tracer, func(ctx context.Context, span trace.Span) (*uint64, error) {
 		d.numLookups.Add(1)
 		var idx int64
-		if row, err := d.dbPool.Single().ReadRowWithOptions(ctx, d.tbl("IDSeq"), spanner.Key{h}, []string{"idx"}, &spanner.ReadOptions{RequestTag: "tessera.op=antispam.index"}); err != nil {
+		if row, err := d.dbPool.Single().ReadRowWithOptions(ctx, d.table("IDSeq"), spanner.Key{h}, []string{"idx"}, &spanner.ReadOptions{RequestTag: "tessera.op=antispam.index"}); err != nil {
 			if c := spanner.ErrCode(err); c == codes.NotFound {
 				span.AddEvent("tessera.miss")
 				return nil, nil
@@ -291,7 +294,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 				_, err := f.as.dbPool.ReadWriteTransactionWithOptions(ctx, func(txctx context.Context, txn *spanner.ReadWriteTransaction) error {
 					return otel.TraceErr(txctx, "tessera.antispam.gcp.FollowTxn", tracer, func(txctx context.Context, span trace.Span) error {
 						// Figure out the last entry we used to populate our antispam storage.
-						row, err := txn.ReadRowWithOptions(txctx, f.as.tbl("FollowCoord"), spanner.Key{0}, []string{"nextIdx"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+						row, err := txn.ReadRowWithOptions(txctx, f.as.table("FollowCoord"), spanner.Key{0}, []string{"nextIdx"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 						if err != nil {
 							return err
 						}
@@ -381,7 +384,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 						{
 							ms := make([]*spanner.Mutation, 0, len(curEntries))
 							for i, e := range curEntries {
-								ms = append(ms, spanner.Insert(f.as.tbl("IDSeq"), []string{"h", "idx"}, []any{e, int64(curIndex + uint64(i))}))
+								ms = append(ms, spanner.Insert(f.as.table("IDSeq"), []string{"h", "idx"}, []any{e, int64(curIndex + uint64(i))}))
 							}
 							if err := f.updateIndex(txctx, txn, ms); err != nil {
 								return err
@@ -393,7 +396,7 @@ func (f *follower) Follow(ctx context.Context, lr tessera.LogReader) {
 
 						// Insertion of dupe entries was successful, so update our follow coordination row:
 						m := make([]*spanner.Mutation, 0)
-						m = append(m, spanner.Update(f.as.tbl("FollowCoord"), []string{"id", "nextIdx"}, []any{0, int64(followFrom + numAdded)}))
+						m = append(m, spanner.Update(f.as.table("FollowCoord"), []string{"id", "nextIdx"}, []any{0, int64(followFrom + numAdded)}))
 
 						return txn.BufferWrite(m)
 					})
@@ -457,7 +460,7 @@ func (f *follower) batchUpdateIndex(ctx context.Context, _ *spanner.ReadWriteTra
 
 // EntriesProcessed returns the total number of log entries processed.
 func (f *follower) EntriesProcessed(ctx context.Context) (uint64, error) {
-	row, err := f.as.dbPool.Single().ReadRowWithOptions(ctx, f.as.tbl("FollowCoord"), spanner.Key{0}, []string{"nextIdx"}, &spanner.ReadOptions{RequestTag: "tessera.op=antispam.EntriesProcessed"})
+	row, err := f.as.dbPool.Single().ReadRowWithOptions(ctx, f.as.table("FollowCoord"), spanner.Key{0}, []string{"nextIdx"}, &spanner.ReadOptions{RequestTag: "tessera.op=antispam.EntriesProcessed"})
 	if err != nil {
 		return 0, err
 	}

--- a/storage/gcp/antispam/gcp_test.go
+++ b/storage/gcp/antispam/gcp_test.go
@@ -62,6 +62,24 @@ func TestAntispamStorage(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "roundtrip with table prefix",
+			opts: AntispamOpts{SpannerTablePrefix: "Tenant1_"},
+			logEntries: [][]byte{
+				[]byte("one"),
+				[]byte("two"),
+			},
+			lookupEntries: []testLookup{
+				{
+					entryHash: testIDHash([]byte("one")),
+				}, {
+					entryHash: testIDHash([]byte("two")),
+				}, {
+					entryHash:    testIDHash([]byte("nowhere to be found")),
+					wantNotFound: true,
+				},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			closeDB := newSpannerDB(t)

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -39,6 +39,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"time"
 
@@ -157,10 +158,26 @@ type Config struct {
 	BucketPrefix string
 	// Spanner is the GCP resource URI of the spanner database instance to use.
 	Spanner string
+	// SpannerTablePrefix is an optional prefix to prepend to the names of all Spanner tables.
+	// This can be used e.g. to store multiple logs in the same Spanner database.
+	// Note that this only namespaces the Spanner state; logs sharing a database must still
+	// each use a distinct Bucket and/or BucketPrefix, since GCS object paths are unaffected
+	// by this prefix.
+	// If set, it must start with a letter, contain only letters, digits, or underscores
+	// (e.g. "log1_"), and be at most 64 characters long, so that prefixed table names
+	// remain valid Spanner identifiers.
+	SpannerTablePrefix string
 }
+
+// tablePrefixRE matches valid values for a Spanner table prefix: empty, or a leading
+// letter followed by up to 63 letters, digits, or underscores.
+var tablePrefixRE = regexp.MustCompile(`^([A-Za-z][A-Za-z0-9_]{0,63})?$`)
 
 // New creates a new instance of the GCP based Storage.
 func New(ctx context.Context, cfg Config) (tessera.Driver, error) {
+	if !tablePrefixRE.MatchString(cfg.SpannerTablePrefix) {
+		return nil, fmt.Errorf("invalid SpannerTablePrefix %q: must start with a letter, contain only letters, digits, or underscores, and be at most 64 characters long", cfg.SpannerTablePrefix)
+	}
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = http.DefaultClient
 	}
@@ -237,11 +254,11 @@ func (s *Storage) Appender(ctx context.Context, opts *tessera.AppendOptions) (*t
 			return nil, nil, fmt.Errorf("failed to connect to Spanner: %v", err)
 		}
 	}
-	if err := initDB(ctx, s.cfg.Spanner); err != nil {
+	if err := initDB(ctx, s.cfg.Spanner, s.cfg.SpannerTablePrefix); err != nil {
 		return nil, nil, fmt.Errorf("failed to verify/init Spanner schema: %v", err)
 	}
 
-	seq, err := newSpannerCoordinator(ctx, s.cfg.SpannerClient, uint64(opts.PushbackMaxOutstanding()))
+	seq, err := newSpannerCoordinator(ctx, s.cfg.SpannerClient, s.cfg.SpannerTablePrefix, uint64(opts.PushbackMaxOutstanding()))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create Spanner coordinator: %v", err)
 	}
@@ -756,6 +773,7 @@ func (a *Appender) updateEntryBundles(ctx context.Context, fromSeq uint64, entri
 // a durable and thread/multi-process safe sequencer.
 type spannerCoordinator struct {
 	dbPool         *spanner.Client
+	tablePrefix    string
 	maxOutstanding uint64
 
 	// seqTableMaxBatchByteSize is the maximum byte size of a batch of entries to be written to the "V" field in the "Seq" table.
@@ -764,9 +782,10 @@ type spannerCoordinator struct {
 
 // newSpannerCoordinator returns a new spannerSequencer struct which uses the provided
 // spanner resource name for its spanner connection.
-func newSpannerCoordinator(ctx context.Context, dbPool *spanner.Client, maxOutstanding uint64) (*spannerCoordinator, error) {
+func newSpannerCoordinator(ctx context.Context, dbPool *spanner.Client, tablePrefix string, maxOutstanding uint64) (*spannerCoordinator, error) {
 	r := &spannerCoordinator{
 		dbPool:                   dbPool,
+		tablePrefix:              tablePrefix,
 		maxOutstanding:           maxOutstanding,
 		seqTableMaxBatchByteSize: defaultSeqTableMaxBatchByteSize,
 	}
@@ -774,6 +793,11 @@ func newSpannerCoordinator(ctx context.Context, dbPool *spanner.Client, maxOutst
 		return nil, fmt.Errorf("schema is not compatible with this version of the Tessera library: %v", err)
 	}
 	return r, nil
+}
+
+// tbl returns the provided table name with the configured table prefix, if any, prepended.
+func (s *spannerCoordinator) tbl(name string) string {
+	return s.tablePrefix + name
 }
 
 // initDB ensures that the coordination DB is initialised correctly.
@@ -795,32 +819,32 @@ func newSpannerCoordinator(ctx context.Context, dbPool *spanner.Client, maxOutst
 //   - GCCoord
 //     This table coordinates garbage collection of unneeded partial tiles
 //     and entry bundles.
-func initDB(ctx context.Context, spannerDB string) error {
+func initDB(ctx context.Context, spannerDB string, tablePrefix string) error {
 	return createAndPrepareTables(ctx, spannerDB,
 		[]string{
-			"CREATE TABLE IF NOT EXISTS Tessera (id INT64 NOT NULL, compatibilityVersion INT64 NOT NULL) PRIMARY KEY (id)",
-			"CREATE TABLE IF NOT EXISTS SeqCoord (id INT64 NOT NULL, next INT64 NOT NULL,) PRIMARY KEY (id)",
-			"CREATE TABLE IF NOT EXISTS Seq (id INT64 NOT NULL, seq INT64 NOT NULL, v BYTES(MAX),) PRIMARY KEY (id, seq)",
-			"CREATE TABLE IF NOT EXISTS IntCoord (id INT64 NOT NULL, seq INT64 NOT NULL, rootHash BYTES(32)) PRIMARY KEY (id)",
-			"CREATE TABLE IF NOT EXISTS PubCoord (id INT64 NOT NULL, publishedAt TIMESTAMP NOT NULL, size INT64) PRIMARY KEY (id)",
-			"CREATE TABLE IF NOT EXISTS GCCoord (id INT64 NOT NULL, fromSize INT64 NOT NULL) PRIMARY KEY (id)",
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sTessera (id INT64 NOT NULL, compatibilityVersion INT64 NOT NULL) PRIMARY KEY (id)", tablePrefix),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sSeqCoord (id INT64 NOT NULL, next INT64 NOT NULL,) PRIMARY KEY (id)", tablePrefix),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sSeq (id INT64 NOT NULL, seq INT64 NOT NULL, v BYTES(MAX),) PRIMARY KEY (id, seq)", tablePrefix),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sIntCoord (id INT64 NOT NULL, seq INT64 NOT NULL, rootHash BYTES(32)) PRIMARY KEY (id)", tablePrefix),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sPubCoord (id INT64 NOT NULL, publishedAt TIMESTAMP NOT NULL, size INT64) PRIMARY KEY (id)", tablePrefix),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sGCCoord (id INT64 NOT NULL, fromSize INT64 NOT NULL) PRIMARY KEY (id)", tablePrefix),
 		},
 		[]string{
-			"ALTER TABLE PubCoord ADD COLUMN IF NOT EXISTS size INT64",
+			fmt.Sprintf("ALTER TABLE %sPubCoord ADD COLUMN IF NOT EXISTS size INT64", tablePrefix),
 		},
 		[][]*spanner.Mutation{
-			{spanner.Insert("Tessera", []string{"id", "compatibilityVersion"}, []any{0, SchemaCompatibilityVersion})},
-			{spanner.Insert("SeqCoord", []string{"id", "next"}, []any{0, 0})},
-			{spanner.Insert("IntCoord", []string{"id", "seq", "rootHash"}, []any{0, 0, rfc6962.DefaultHasher.EmptyRoot()})},
-			{spanner.Insert("PubCoord", []string{"id", "publishedAt", "size"}, []any{0, time.Unix(0, 0), 0})},
-			{spanner.Insert("GCCoord", []string{"id", "fromSize"}, []any{0, 0})},
+			{spanner.Insert(tablePrefix+"Tessera", []string{"id", "compatibilityVersion"}, []any{0, SchemaCompatibilityVersion})},
+			{spanner.Insert(tablePrefix+"SeqCoord", []string{"id", "next"}, []any{0, 0})},
+			{spanner.Insert(tablePrefix+"IntCoord", []string{"id", "seq", "rootHash"}, []any{0, 0, rfc6962.DefaultHasher.EmptyRoot()})},
+			{spanner.Insert(tablePrefix+"PubCoord", []string{"id", "publishedAt", "size"}, []any{0, time.Unix(0, 0), 0})},
+			{spanner.Insert(tablePrefix+"GCCoord", []string{"id", "fromSize"}, []any{0, 0})},
 		})
 }
 
 // checkDataCompatibility compares the Tessera library SchemaCompatibilityVersion with the one stored in the
 // database, and returns an error if they are not identical.
 func (s *spannerCoordinator) checkDataCompatibility(ctx context.Context) error {
-	row, err := s.dbPool.Single().ReadRow(ctx, "Tessera", spanner.Key{0}, []string{"compatibilityVersion"})
+	row, err := s.dbPool.Single().ReadRow(ctx, s.tbl("Tessera"), spanner.Key{0}, []string{"compatibilityVersion"})
 	if err != nil {
 		return fmt.Errorf("failed to read schema compatibilityVersion: %v", err)
 	}
@@ -853,7 +877,7 @@ func (s *spannerCoordinator) assignEntries(ctx context.Context, entries []*tesse
 		// First grab the treeSize in a non-locking read-only fashion (we don't want to block/collide with integration).
 		// We'll use this value to determine whether we need to apply back-pressure.
 		var treeSize int64
-		if row, err := s.dbPool.Single().ReadRowWithOptions(ctx, "IntCoord", spanner.Key{0}, []string{"seq"}, &spanner.ReadOptions{RequestTag: "tessera.op=assignEntries.treeSize"}); err != nil {
+		if row, err := s.dbPool.Single().ReadRowWithOptions(ctx, s.tbl("IntCoord"), spanner.Key{0}, []string{"seq"}, &spanner.ReadOptions{RequestTag: "tessera.op=assignEntries.treeSize"}); err != nil {
 			return err
 		} else {
 			if err := row.Column(0, &treeSize); err != nil {
@@ -868,7 +892,7 @@ func (s *spannerCoordinator) assignEntries(ctx context.Context, entries []*tesse
 		_, err := s.dbPool.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 			span.AddEvent("Reading SeqCoord:next")
 			// First we need to grab the next available sequence number from the SeqCoord table.
-			row, err := txn.ReadRowWithOptions(ctx, "SeqCoord", spanner.Key{0}, []string{"next"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+			row, err := txn.ReadRowWithOptions(ctx, s.tbl("SeqCoord"), spanner.Key{0}, []string{"next"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 			if err != nil {
 				return fmt.Errorf("failed to read SeqCoord: %w", err)
 			}
@@ -927,7 +951,7 @@ func (s *spannerCoordinator) assignEntries(ctx context.Context, entries []*tesse
 			}
 
 			// and update the next-available sequence number row in SeqCoord.
-			mutations = append(mutations, spanner.Update("SeqCoord", []string{"id", "next"}, []any{0, int64(next)}))
+			mutations = append(mutations, spanner.Update(s.tbl("SeqCoord"), []string{"id", "next"}, []any{0, int64(next)}))
 
 			span.AddEvent("Writing mutations")
 			if err := txn.BufferWrite(mutations); err != nil {
@@ -958,7 +982,7 @@ func (s *spannerCoordinator) addSeqMutation(seq uint64, entries []storage.Sequen
 		return nil, fmt.Errorf("failed to serialise batch: %v", err)
 	}
 	// Insert our newly sequenced batch of entries into Seq.
-	return spanner.Insert("Seq", []string{"id", "seq", "v"}, []any{0, int64(seq), b.Bytes()}), nil
+	return spanner.Insert(s.tbl("Seq"), []string{"id", "seq", "v"}, []any{0, int64(seq), b.Bytes()}), nil
 }
 
 // consumeEntries calls f with previously sequenced entries.
@@ -981,7 +1005,7 @@ func (s *spannerCoordinator) consumeEntries(ctx context.Context, limit uint64, f
 		_, err := s.dbPool.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 			span.AddEvent("Reading IntCoord:seq")
 			// Figure out which is the starting index of sequenced entries to start consuming from.
-			row, err := txn.ReadRowWithOptions(ctx, "IntCoord", spanner.Key{0}, []string{"seq"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+			row, err := txn.ReadRowWithOptions(ctx, s.tbl("IntCoord"), spanner.Key{0}, []string{"seq"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 			if err != nil {
 				return err
 			}
@@ -997,7 +1021,7 @@ func (s *spannerCoordinator) consumeEntries(ctx context.Context, limit uint64, f
 			slog.DebugContext(ctx, "Consuming bundles", slog.Int64("fromSeq", fromSeq), slog.Uint64("toSeq", seqLimit-1))
 			span.AddEvent("Reading entries from sequence table")
 			// Now read the sequenced starting at the index we got above.
-			rows := txn.Read(ctx, "Seq",
+			rows := txn.Read(ctx, s.tbl("Seq"),
 				spanner.KeyRange{Start: spanner.Key{0, fromSeq}, End: spanner.Key{0, int64(seqLimit)}, Kind: spanner.ClosedOpen},
 				[]string{"seq", "v"})
 			defer rows.Stop()
@@ -1049,9 +1073,9 @@ func (s *spannerCoordinator) consumeEntries(ctx context.Context, limit uint64, f
 			// consumeFunc was successful, so we can update our coordination row, and delete the row(s) for
 			// the then consumed entries.
 			m := make([]*spanner.Mutation, 0)
-			m = append(m, spanner.Update("IntCoord", []string{"id", "seq", "rootHash"}, []any{0, int64(orderCheck), newRoot}))
+			m = append(m, spanner.Update(s.tbl("IntCoord"), []string{"id", "seq", "rootHash"}, []any{0, int64(orderCheck), newRoot}))
 			for _, c := range seqsConsumed {
-				m = append(m, spanner.Delete("Seq", spanner.Key{0, c}))
+				m = append(m, spanner.Delete(s.tbl("Seq"), spanner.Key{0, c}))
 			}
 
 			span.AddEvent("Writing mutations")
@@ -1074,7 +1098,7 @@ func (s *spannerCoordinator) consumeEntries(ctx context.Context, limit uint64, f
 
 // currentTree returns the size and root hash of the currently integrated tree.
 func (s *spannerCoordinator) currentTree(ctx context.Context) (uint64, []byte, error) {
-	row, err := s.dbPool.Single().ReadRowWithOptions(ctx, "IntCoord", spanner.Key{0}, []string{"seq", "rootHash"}, &spanner.ReadOptions{RequestTag: "tessera.op=currentTree"})
+	row, err := s.dbPool.Single().ReadRowWithOptions(ctx, s.tbl("IntCoord"), spanner.Key{0}, []string{"seq", "rootHash"}, &spanner.ReadOptions{RequestTag: "tessera.op=currentTree"})
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to read IntCoord: %v", err)
 	}
@@ -1089,7 +1113,7 @@ func (s *spannerCoordinator) currentTree(ctx context.Context) (uint64, []byte, e
 
 // nextIndex returns the next available index in the log.
 func (s *spannerCoordinator) nextIndex(ctx context.Context) (uint64, error) {
-	row, err := s.dbPool.Single().ReadRowWithOptions(ctx, "SeqCoord", spanner.Key{0}, []string{"next"}, &spanner.ReadOptions{RequestTag: "tessera.op=nextIndex"})
+	row, err := s.dbPool.Single().ReadRowWithOptions(ctx, s.tbl("SeqCoord"), spanner.Key{0}, []string{"next"}, &spanner.ReadOptions{RequestTag: "tessera.op=nextIndex"})
 	if err != nil {
 		return 0, fmt.Errorf("failed to read SeqCoord: %v", err)
 	}
@@ -1131,7 +1155,7 @@ func (s *spannerCoordinator) publishCheckpoint(ctx context.Context, minStaleActi
 			outcomeAttr = outcomeTypeKey.String("success")
 
 			span.AddEvent("Reading PubCoord")
-			pRow, err := txn.ReadRowWithOptions(ctx, "PubCoord", spanner.Key{0}, []string{"publishedAt", "size"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+			pRow, err := txn.ReadRowWithOptions(ctx, s.tbl("PubCoord"), spanner.Key{0}, []string{"publishedAt", "size"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 			if err != nil {
 				return fmt.Errorf("failed to read PubCoord: %w", err)
 			}
@@ -1184,7 +1208,7 @@ func (s *spannerCoordinator) publishCheckpoint(ctx context.Context, minStaleActi
 			span.AddEvent("Updating PubCoord")
 			pubAt = time.Now()
 			nextPubAt = pubAt.Add(minStaleActive)
-			if err := txn.BufferWrite([]*spanner.Mutation{spanner.Update("PubCoord", []string{"id", "publishedAt", "size"}, []any{0, pubAt, int64(currentSize)})}); err != nil {
+			if err := txn.BufferWrite([]*spanner.Mutation{spanner.Update(s.tbl("PubCoord"), []string{"id", "publishedAt", "size"}, []any{0, pubAt, int64(currentSize)})}); err != nil {
 				return err
 			}
 
@@ -1211,7 +1235,7 @@ func (s *spannerCoordinator) garbageCollect(ctx context.Context, treeSize uint64
 	const numWorkers = 1
 
 	_, err := s.dbPool.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
-		row, err := txn.ReadRowWithOptions(ctx, "GCCoord", spanner.Key{0}, []string{"fromSize"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+		row, err := txn.ReadRowWithOptions(ctx, s.tbl("GCCoord"), spanner.Key{0}, []string{"fromSize"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 		if err != nil {
 			return fmt.Errorf("failed to read GCCoord: %w", err)
 		}
@@ -1276,7 +1300,7 @@ func (s *spannerCoordinator) garbageCollect(ctx context.Context, treeSize uint64
 			return fmt.Errorf("failed to delete one or more objects: %v", err)
 		}
 
-		if err := txn.BufferWrite([]*spanner.Mutation{spanner.Update("GCCoord", []string{"id", "fromSize"}, []any{0, int64(fromSize)})}); err != nil {
+		if err := txn.BufferWrite([]*spanner.Mutation{spanner.Update(s.tbl("GCCoord"), []string{"id", "fromSize"}, []any{0, int64(fromSize)})}); err != nil {
 			return err
 		}
 
@@ -1442,17 +1466,18 @@ func (s *Storage) MigrationWriter(ctx context.Context, opts *tessera.MigrationOp
 			return nil, nil, fmt.Errorf("failed to connect to Spanner: %v", err)
 		}
 	}
-	if err := initDB(ctx, s.cfg.Spanner); err != nil {
+	if err := initDB(ctx, s.cfg.Spanner, s.cfg.SpannerTablePrefix); err != nil {
 		return nil, nil, fmt.Errorf("failed to verify/init Spanner schema: %v", err)
 	}
 
-	seq, err := newSpannerCoordinator(ctx, s.cfg.SpannerClient, 0)
+	seq, err := newSpannerCoordinator(ctx, s.cfg.SpannerClient, s.cfg.SpannerTablePrefix, 0)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create Spanner sequencer: %v", err)
 	}
 	m := &MigrationStorage{
 		s:            s,
 		dbPool:       seq.dbPool,
+		tablePrefix:  s.cfg.SpannerTablePrefix,
 		bundleHasher: opts.LeafHasher(),
 		sequencer:    seq,
 		logStore: &logResourceStore{
@@ -1482,9 +1507,15 @@ func (s *Storage) MigrationWriter(ctx context.Context, opts *tessera.MigrationOp
 type MigrationStorage struct {
 	s            *Storage
 	dbPool       *spanner.Client
+	tablePrefix  string
 	bundleHasher func([]byte) ([][]byte, error)
 	sequencer    sequencer
 	logStore     *logResourceStore
+}
+
+// tbl returns the provided table name with the configured table prefix, if any, prepended.
+func (m *MigrationStorage) tbl(name string) string {
+	return m.tablePrefix + name
 }
 
 var _ migrate.MigrationWriter = &MigrationStorage{}
@@ -1576,7 +1607,7 @@ func (m *MigrationStorage) buildTree(ctx context.Context, sourceSize uint64) (ui
 
 	_, err := m.dbPool.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 		// Figure out which is the starting index of sequenced entries to start consuming from.
-		row, err := txn.ReadRowWithOptions(ctx, "IntCoord", spanner.Key{0}, []string{"seq", "rootHash"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+		row, err := txn.ReadRowWithOptions(ctx, m.tbl("IntCoord"), spanner.Key{0}, []string{"seq", "rootHash"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 		if err != nil {
 			return err
 		}
@@ -1611,9 +1642,8 @@ func (m *MigrationStorage) buildTree(ctx context.Context, sourceSize uint64) (ui
 		slog.InfoContext(ctx, "Integrate: added entries", slog.Uint64("added", added))
 
 		// integration was successful, so we can update our coordination row
-		m := make([]*spanner.Mutation, 0)
-		m = append(m, spanner.Update("IntCoord", []string{"id", "seq", "rootHash"}, []any{0, int64(from + added), newRoot}))
-		return txn.BufferWrite(m)
+		muts := []*spanner.Mutation{spanner.Update(m.tbl("IntCoord"), []string{"id", "seq", "rootHash"}, []any{0, int64(from + added), newRoot})}
+		return txn.BufferWrite(muts)
 	})
 
 	if err != nil {

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -166,6 +166,14 @@ type Config struct {
 	// If set, it must start with a letter, contain only letters, digits, or underscores
 	// (e.g. "log1_"), and be at most 64 characters long, so that prefixed table names
 	// remain valid Spanner identifiers.
+	// It's recommended to derive this prefix from the log's origin string (e.g. by
+	// replacing any characters other than letters, digits, or underscores with
+	// underscores, and prepending a letter if the origin doesn't start with one), to
+	// make it easy to associate tables with specific logs.
+	//
+	// TODO: consider providing a mechanism to set both BucketPrefix and SpannerTablePrefix
+	// from a single string to avoid misconfiguration foot-guns; decide based on how these
+	// options end up being used.
 	SpannerTablePrefix string
 }
 
@@ -254,11 +262,14 @@ func (s *Storage) Appender(ctx context.Context, opts *tessera.AppendOptions) (*t
 			return nil, nil, fmt.Errorf("failed to connect to Spanner: %v", err)
 		}
 	}
-	if err := initDB(ctx, s.cfg.Spanner, s.cfg.SpannerTablePrefix); err != nil {
+	table := func(t string) string {
+		return s.cfg.SpannerTablePrefix + t
+	}
+	if err := initDB(ctx, s.cfg.Spanner, table); err != nil {
 		return nil, nil, fmt.Errorf("failed to verify/init Spanner schema: %v", err)
 	}
 
-	seq, err := newSpannerCoordinator(ctx, s.cfg.SpannerClient, s.cfg.SpannerTablePrefix, uint64(opts.PushbackMaxOutstanding()))
+	seq, err := newSpannerCoordinator(ctx, s.cfg.SpannerClient, table, uint64(opts.PushbackMaxOutstanding()))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create Spanner coordinator: %v", err)
 	}
@@ -772,8 +783,9 @@ func (a *Appender) updateEntryBundles(ctx context.Context, fromSeq uint64, entri
 // spannerCoordinator uses Cloud Spanner to provide
 // a durable and thread/multi-process safe sequencer.
 type spannerCoordinator struct {
-	dbPool         *spanner.Client
-	tablePrefix    string
+	dbPool *spanner.Client
+	// table returns the provided table name with the configured table prefix, if any, prepended.
+	table          func(string) string
 	maxOutstanding uint64
 
 	// seqTableMaxBatchByteSize is the maximum byte size of a batch of entries to be written to the "V" field in the "Seq" table.
@@ -782,10 +794,10 @@ type spannerCoordinator struct {
 
 // newSpannerCoordinator returns a new spannerSequencer struct which uses the provided
 // spanner resource name for its spanner connection.
-func newSpannerCoordinator(ctx context.Context, dbPool *spanner.Client, tablePrefix string, maxOutstanding uint64) (*spannerCoordinator, error) {
+func newSpannerCoordinator(ctx context.Context, dbPool *spanner.Client, table func(string) string, maxOutstanding uint64) (*spannerCoordinator, error) {
 	r := &spannerCoordinator{
 		dbPool:                   dbPool,
-		tablePrefix:              tablePrefix,
+		table:                    table,
 		maxOutstanding:           maxOutstanding,
 		seqTableMaxBatchByteSize: defaultSeqTableMaxBatchByteSize,
 	}
@@ -793,11 +805,6 @@ func newSpannerCoordinator(ctx context.Context, dbPool *spanner.Client, tablePre
 		return nil, fmt.Errorf("schema is not compatible with this version of the Tessera library: %v", err)
 	}
 	return r, nil
-}
-
-// tbl returns the provided table name with the configured table prefix, if any, prepended.
-func (s *spannerCoordinator) tbl(name string) string {
-	return s.tablePrefix + name
 }
 
 // initDB ensures that the coordination DB is initialised correctly.
@@ -819,32 +826,32 @@ func (s *spannerCoordinator) tbl(name string) string {
 //   - GCCoord
 //     This table coordinates garbage collection of unneeded partial tiles
 //     and entry bundles.
-func initDB(ctx context.Context, spannerDB string, tablePrefix string) error {
+func initDB(ctx context.Context, spannerDB string, table func(string) string) error {
 	return createAndPrepareTables(ctx, spannerDB,
 		[]string{
-			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sTessera (id INT64 NOT NULL, compatibilityVersion INT64 NOT NULL) PRIMARY KEY (id)", tablePrefix),
-			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sSeqCoord (id INT64 NOT NULL, next INT64 NOT NULL,) PRIMARY KEY (id)", tablePrefix),
-			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sSeq (id INT64 NOT NULL, seq INT64 NOT NULL, v BYTES(MAX),) PRIMARY KEY (id, seq)", tablePrefix),
-			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sIntCoord (id INT64 NOT NULL, seq INT64 NOT NULL, rootHash BYTES(32)) PRIMARY KEY (id)", tablePrefix),
-			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sPubCoord (id INT64 NOT NULL, publishedAt TIMESTAMP NOT NULL, size INT64) PRIMARY KEY (id)", tablePrefix),
-			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %sGCCoord (id INT64 NOT NULL, fromSize INT64 NOT NULL) PRIMARY KEY (id)", tablePrefix),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id INT64 NOT NULL, compatibilityVersion INT64 NOT NULL) PRIMARY KEY (id)", table("Tessera")),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id INT64 NOT NULL, next INT64 NOT NULL,) PRIMARY KEY (id)", table("SeqCoord")),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id INT64 NOT NULL, seq INT64 NOT NULL, v BYTES(MAX),) PRIMARY KEY (id, seq)", table("Seq")),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id INT64 NOT NULL, seq INT64 NOT NULL, rootHash BYTES(32)) PRIMARY KEY (id)", table("IntCoord")),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id INT64 NOT NULL, publishedAt TIMESTAMP NOT NULL, size INT64) PRIMARY KEY (id)", table("PubCoord")),
+			fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id INT64 NOT NULL, fromSize INT64 NOT NULL) PRIMARY KEY (id)", table("GCCoord")),
 		},
 		[]string{
-			fmt.Sprintf("ALTER TABLE %sPubCoord ADD COLUMN IF NOT EXISTS size INT64", tablePrefix),
+			fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS size INT64", table("PubCoord")),
 		},
 		[][]*spanner.Mutation{
-			{spanner.Insert(tablePrefix+"Tessera", []string{"id", "compatibilityVersion"}, []any{0, SchemaCompatibilityVersion})},
-			{spanner.Insert(tablePrefix+"SeqCoord", []string{"id", "next"}, []any{0, 0})},
-			{spanner.Insert(tablePrefix+"IntCoord", []string{"id", "seq", "rootHash"}, []any{0, 0, rfc6962.DefaultHasher.EmptyRoot()})},
-			{spanner.Insert(tablePrefix+"PubCoord", []string{"id", "publishedAt", "size"}, []any{0, time.Unix(0, 0), 0})},
-			{spanner.Insert(tablePrefix+"GCCoord", []string{"id", "fromSize"}, []any{0, 0})},
+			{spanner.Insert(table("Tessera"), []string{"id", "compatibilityVersion"}, []any{0, SchemaCompatibilityVersion})},
+			{spanner.Insert(table("SeqCoord"), []string{"id", "next"}, []any{0, 0})},
+			{spanner.Insert(table("IntCoord"), []string{"id", "seq", "rootHash"}, []any{0, 0, rfc6962.DefaultHasher.EmptyRoot()})},
+			{spanner.Insert(table("PubCoord"), []string{"id", "publishedAt", "size"}, []any{0, time.Unix(0, 0), 0})},
+			{spanner.Insert(table("GCCoord"), []string{"id", "fromSize"}, []any{0, 0})},
 		})
 }
 
 // checkDataCompatibility compares the Tessera library SchemaCompatibilityVersion with the one stored in the
 // database, and returns an error if they are not identical.
 func (s *spannerCoordinator) checkDataCompatibility(ctx context.Context) error {
-	row, err := s.dbPool.Single().ReadRow(ctx, s.tbl("Tessera"), spanner.Key{0}, []string{"compatibilityVersion"})
+	row, err := s.dbPool.Single().ReadRow(ctx, s.table("Tessera"), spanner.Key{0}, []string{"compatibilityVersion"})
 	if err != nil {
 		return fmt.Errorf("failed to read schema compatibilityVersion: %v", err)
 	}
@@ -877,7 +884,7 @@ func (s *spannerCoordinator) assignEntries(ctx context.Context, entries []*tesse
 		// First grab the treeSize in a non-locking read-only fashion (we don't want to block/collide with integration).
 		// We'll use this value to determine whether we need to apply back-pressure.
 		var treeSize int64
-		if row, err := s.dbPool.Single().ReadRowWithOptions(ctx, s.tbl("IntCoord"), spanner.Key{0}, []string{"seq"}, &spanner.ReadOptions{RequestTag: "tessera.op=assignEntries.treeSize"}); err != nil {
+		if row, err := s.dbPool.Single().ReadRowWithOptions(ctx, s.table("IntCoord"), spanner.Key{0}, []string{"seq"}, &spanner.ReadOptions{RequestTag: "tessera.op=assignEntries.treeSize"}); err != nil {
 			return err
 		} else {
 			if err := row.Column(0, &treeSize); err != nil {
@@ -892,7 +899,7 @@ func (s *spannerCoordinator) assignEntries(ctx context.Context, entries []*tesse
 		_, err := s.dbPool.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 			span.AddEvent("Reading SeqCoord:next")
 			// First we need to grab the next available sequence number from the SeqCoord table.
-			row, err := txn.ReadRowWithOptions(ctx, s.tbl("SeqCoord"), spanner.Key{0}, []string{"next"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+			row, err := txn.ReadRowWithOptions(ctx, s.table("SeqCoord"), spanner.Key{0}, []string{"next"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 			if err != nil {
 				return fmt.Errorf("failed to read SeqCoord: %w", err)
 			}
@@ -951,7 +958,7 @@ func (s *spannerCoordinator) assignEntries(ctx context.Context, entries []*tesse
 			}
 
 			// and update the next-available sequence number row in SeqCoord.
-			mutations = append(mutations, spanner.Update(s.tbl("SeqCoord"), []string{"id", "next"}, []any{0, int64(next)}))
+			mutations = append(mutations, spanner.Update(s.table("SeqCoord"), []string{"id", "next"}, []any{0, int64(next)}))
 
 			span.AddEvent("Writing mutations")
 			if err := txn.BufferWrite(mutations); err != nil {
@@ -982,7 +989,7 @@ func (s *spannerCoordinator) addSeqMutation(seq uint64, entries []storage.Sequen
 		return nil, fmt.Errorf("failed to serialise batch: %v", err)
 	}
 	// Insert our newly sequenced batch of entries into Seq.
-	return spanner.Insert(s.tbl("Seq"), []string{"id", "seq", "v"}, []any{0, int64(seq), b.Bytes()}), nil
+	return spanner.Insert(s.table("Seq"), []string{"id", "seq", "v"}, []any{0, int64(seq), b.Bytes()}), nil
 }
 
 // consumeEntries calls f with previously sequenced entries.
@@ -1005,7 +1012,7 @@ func (s *spannerCoordinator) consumeEntries(ctx context.Context, limit uint64, f
 		_, err := s.dbPool.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 			span.AddEvent("Reading IntCoord:seq")
 			// Figure out which is the starting index of sequenced entries to start consuming from.
-			row, err := txn.ReadRowWithOptions(ctx, s.tbl("IntCoord"), spanner.Key{0}, []string{"seq"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+			row, err := txn.ReadRowWithOptions(ctx, s.table("IntCoord"), spanner.Key{0}, []string{"seq"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 			if err != nil {
 				return err
 			}
@@ -1021,7 +1028,7 @@ func (s *spannerCoordinator) consumeEntries(ctx context.Context, limit uint64, f
 			slog.DebugContext(ctx, "Consuming bundles", slog.Int64("fromSeq", fromSeq), slog.Uint64("toSeq", seqLimit-1))
 			span.AddEvent("Reading entries from sequence table")
 			// Now read the sequenced starting at the index we got above.
-			rows := txn.Read(ctx, s.tbl("Seq"),
+			rows := txn.Read(ctx, s.table("Seq"),
 				spanner.KeyRange{Start: spanner.Key{0, fromSeq}, End: spanner.Key{0, int64(seqLimit)}, Kind: spanner.ClosedOpen},
 				[]string{"seq", "v"})
 			defer rows.Stop()
@@ -1073,9 +1080,9 @@ func (s *spannerCoordinator) consumeEntries(ctx context.Context, limit uint64, f
 			// consumeFunc was successful, so we can update our coordination row, and delete the row(s) for
 			// the then consumed entries.
 			m := make([]*spanner.Mutation, 0)
-			m = append(m, spanner.Update(s.tbl("IntCoord"), []string{"id", "seq", "rootHash"}, []any{0, int64(orderCheck), newRoot}))
+			m = append(m, spanner.Update(s.table("IntCoord"), []string{"id", "seq", "rootHash"}, []any{0, int64(orderCheck), newRoot}))
 			for _, c := range seqsConsumed {
-				m = append(m, spanner.Delete(s.tbl("Seq"), spanner.Key{0, c}))
+				m = append(m, spanner.Delete(s.table("Seq"), spanner.Key{0, c}))
 			}
 
 			span.AddEvent("Writing mutations")
@@ -1098,7 +1105,7 @@ func (s *spannerCoordinator) consumeEntries(ctx context.Context, limit uint64, f
 
 // currentTree returns the size and root hash of the currently integrated tree.
 func (s *spannerCoordinator) currentTree(ctx context.Context) (uint64, []byte, error) {
-	row, err := s.dbPool.Single().ReadRowWithOptions(ctx, s.tbl("IntCoord"), spanner.Key{0}, []string{"seq", "rootHash"}, &spanner.ReadOptions{RequestTag: "tessera.op=currentTree"})
+	row, err := s.dbPool.Single().ReadRowWithOptions(ctx, s.table("IntCoord"), spanner.Key{0}, []string{"seq", "rootHash"}, &spanner.ReadOptions{RequestTag: "tessera.op=currentTree"})
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to read IntCoord: %v", err)
 	}
@@ -1113,7 +1120,7 @@ func (s *spannerCoordinator) currentTree(ctx context.Context) (uint64, []byte, e
 
 // nextIndex returns the next available index in the log.
 func (s *spannerCoordinator) nextIndex(ctx context.Context) (uint64, error) {
-	row, err := s.dbPool.Single().ReadRowWithOptions(ctx, s.tbl("SeqCoord"), spanner.Key{0}, []string{"next"}, &spanner.ReadOptions{RequestTag: "tessera.op=nextIndex"})
+	row, err := s.dbPool.Single().ReadRowWithOptions(ctx, s.table("SeqCoord"), spanner.Key{0}, []string{"next"}, &spanner.ReadOptions{RequestTag: "tessera.op=nextIndex"})
 	if err != nil {
 		return 0, fmt.Errorf("failed to read SeqCoord: %v", err)
 	}
@@ -1155,7 +1162,7 @@ func (s *spannerCoordinator) publishCheckpoint(ctx context.Context, minStaleActi
 			outcomeAttr = outcomeTypeKey.String("success")
 
 			span.AddEvent("Reading PubCoord")
-			pRow, err := txn.ReadRowWithOptions(ctx, s.tbl("PubCoord"), spanner.Key{0}, []string{"publishedAt", "size"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+			pRow, err := txn.ReadRowWithOptions(ctx, s.table("PubCoord"), spanner.Key{0}, []string{"publishedAt", "size"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 			if err != nil {
 				return fmt.Errorf("failed to read PubCoord: %w", err)
 			}
@@ -1208,7 +1215,7 @@ func (s *spannerCoordinator) publishCheckpoint(ctx context.Context, minStaleActi
 			span.AddEvent("Updating PubCoord")
 			pubAt = time.Now()
 			nextPubAt = pubAt.Add(minStaleActive)
-			if err := txn.BufferWrite([]*spanner.Mutation{spanner.Update(s.tbl("PubCoord"), []string{"id", "publishedAt", "size"}, []any{0, pubAt, int64(currentSize)})}); err != nil {
+			if err := txn.BufferWrite([]*spanner.Mutation{spanner.Update(s.table("PubCoord"), []string{"id", "publishedAt", "size"}, []any{0, pubAt, int64(currentSize)})}); err != nil {
 				return err
 			}
 
@@ -1235,7 +1242,7 @@ func (s *spannerCoordinator) garbageCollect(ctx context.Context, treeSize uint64
 	const numWorkers = 1
 
 	_, err := s.dbPool.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
-		row, err := txn.ReadRowWithOptions(ctx, s.tbl("GCCoord"), spanner.Key{0}, []string{"fromSize"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+		row, err := txn.ReadRowWithOptions(ctx, s.table("GCCoord"), spanner.Key{0}, []string{"fromSize"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 		if err != nil {
 			return fmt.Errorf("failed to read GCCoord: %w", err)
 		}
@@ -1300,7 +1307,7 @@ func (s *spannerCoordinator) garbageCollect(ctx context.Context, treeSize uint64
 			return fmt.Errorf("failed to delete one or more objects: %v", err)
 		}
 
-		if err := txn.BufferWrite([]*spanner.Mutation{spanner.Update(s.tbl("GCCoord"), []string{"id", "fromSize"}, []any{0, int64(fromSize)})}); err != nil {
+		if err := txn.BufferWrite([]*spanner.Mutation{spanner.Update(s.table("GCCoord"), []string{"id", "fromSize"}, []any{0, int64(fromSize)})}); err != nil {
 			return err
 		}
 
@@ -1466,18 +1473,21 @@ func (s *Storage) MigrationWriter(ctx context.Context, opts *tessera.MigrationOp
 			return nil, nil, fmt.Errorf("failed to connect to Spanner: %v", err)
 		}
 	}
-	if err := initDB(ctx, s.cfg.Spanner, s.cfg.SpannerTablePrefix); err != nil {
+	table := func(t string) string {
+		return s.cfg.SpannerTablePrefix + t
+	}
+	if err := initDB(ctx, s.cfg.Spanner, table); err != nil {
 		return nil, nil, fmt.Errorf("failed to verify/init Spanner schema: %v", err)
 	}
 
-	seq, err := newSpannerCoordinator(ctx, s.cfg.SpannerClient, s.cfg.SpannerTablePrefix, 0)
+	seq, err := newSpannerCoordinator(ctx, s.cfg.SpannerClient, table, 0)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create Spanner sequencer: %v", err)
 	}
 	m := &MigrationStorage{
 		s:            s,
 		dbPool:       seq.dbPool,
-		tablePrefix:  s.cfg.SpannerTablePrefix,
+		table:        table,
 		bundleHasher: opts.LeafHasher(),
 		sequencer:    seq,
 		logStore: &logResourceStore{
@@ -1505,17 +1515,13 @@ func (s *Storage) MigrationWriter(ctx context.Context, opts *tessera.MigrationOp
 
 // MigrationStorgage implements the tessera.MigrationTarget lifecycle contract.
 type MigrationStorage struct {
-	s            *Storage
-	dbPool       *spanner.Client
-	tablePrefix  string
+	s      *Storage
+	dbPool *spanner.Client
+	// table returns the provided table name with the configured table prefix, if any, prepended.
+	table        func(string) string
 	bundleHasher func([]byte) ([][]byte, error)
 	sequencer    sequencer
 	logStore     *logResourceStore
-}
-
-// tbl returns the provided table name with the configured table prefix, if any, prepended.
-func (m *MigrationStorage) tbl(name string) string {
-	return m.tablePrefix + name
 }
 
 var _ migrate.MigrationWriter = &MigrationStorage{}
@@ -1607,7 +1613,7 @@ func (m *MigrationStorage) buildTree(ctx context.Context, sourceSize uint64) (ui
 
 	_, err := m.dbPool.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 		// Figure out which is the starting index of sequenced entries to start consuming from.
-		row, err := txn.ReadRowWithOptions(ctx, m.tbl("IntCoord"), spanner.Key{0}, []string{"seq", "rootHash"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
+		row, err := txn.ReadRowWithOptions(ctx, m.table("IntCoord"), spanner.Key{0}, []string{"seq", "rootHash"}, &spanner.ReadOptions{LockHint: spannerpb.ReadRequest_LOCK_HINT_EXCLUSIVE})
 		if err != nil {
 			return err
 		}
@@ -1642,7 +1648,7 @@ func (m *MigrationStorage) buildTree(ctx context.Context, sourceSize uint64) (ui
 		slog.InfoContext(ctx, "Integrate: added entries", slog.Uint64("added", added))
 
 		// integration was successful, so we can update our coordination row
-		muts := []*spanner.Mutation{spanner.Update(m.tbl("IntCoord"), []string{"id", "seq", "rootHash"}, []any{0, int64(from + added), newRoot})}
+		muts := []*spanner.Mutation{spanner.Update(m.table("IntCoord"), []string{"id", "seq", "rootHash"}, []any{0, int64(from + added), newRoot})}
 		return txn.BufferWrite(muts)
 	})
 

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -159,21 +159,13 @@ type Config struct {
 	// Spanner is the GCP resource URI of the spanner database instance to use.
 	Spanner string
 	// SpannerTablePrefix is an optional prefix to prepend to the names of all Spanner tables.
-	// This can be used e.g. to store multiple logs in the same Spanner database.
-	// Note that this only namespaces the Spanner state; logs sharing a database must still
-	// each use a distinct Bucket and/or BucketPrefix, since GCS object paths are unaffected
-	// by this prefix.
 	// If set, it must start with a letter, contain only letters, digits, or underscores
-	// (e.g. "log1_"), and be at most 64 characters long, so that prefixed table names
-	// remain valid Spanner identifiers.
-	// It's recommended to derive this prefix from the log's origin string (e.g. by
-	// replacing any characters other than letters, digits, or underscores with
-	// underscores, and prepending a letter if the origin doesn't start with one), to
+	// (e.g. "log1_"), and be at most 64 characters long.
+	// It's recommended to derive this prefix from the log's origin string, to
 	// make it easy to associate tables with specific logs.
 	//
 	// TODO: consider providing a mechanism to set both BucketPrefix and SpannerTablePrefix
-	// from a single string to avoid misconfiguration foot-guns; decide based on how these
-	// options end up being used.
+	// from a single string to avoid misconfiguration foot-guns.
 	SpannerTablePrefix string
 }
 

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -51,6 +51,13 @@ func newSpannerDB(t *testing.T) (*spanner.Client, func()) {
 	return newSpannerDBWithPrefix(t, "")
 }
 
+// prefixTable returns a function which returns the provided table name with prefix prepended.
+func prefixTable(prefix string) func(string) string {
+	return func(table string) string {
+		return prefix + table
+	}
+}
+
 func newSpannerDBWithPrefix(t *testing.T, tablePrefix string) (*spanner.Client, func()) {
 	t.Helper()
 	srv, err := spannertest.NewServer("localhost:0")
@@ -62,7 +69,7 @@ func newSpannerDBWithPrefix(t *testing.T, tablePrefix string) (*spanner.Client, 
 	}
 
 	id := "projects/p/instances/i/databases/d"
-	if err := initDB(t.Context(), id, tablePrefix); err != nil {
+	if err := initDB(t.Context(), id, prefixTable(tablePrefix)); err != nil {
 		t.Fatalf("initDB: %v", err)
 	}
 
@@ -79,7 +86,7 @@ func TestSpannerSequencerAssignEntries(t *testing.T) {
 	db, close := newSpannerDB(t)
 	defer close()
 
-	seq, err := newSpannerCoordinator(ctx, db, "", 1000)
+	seq, err := newSpannerCoordinator(ctx, db, prefixTable(""), 1000)
 	if err != nil {
 		t.Fatalf("newSpannerCoordinator: %v", err)
 	}
@@ -108,7 +115,7 @@ func TestSpannerTablePrefix(t *testing.T) {
 	db, close := newSpannerDBWithPrefix(t, prefix)
 	defer close()
 
-	seq, err := newSpannerCoordinator(ctx, db, prefix, 1000)
+	seq, err := newSpannerCoordinator(ctx, db, prefixTable(prefix), 1000)
 	if err != nil {
 		t.Fatalf("newSpannerCoordinator: %v", err)
 	}
@@ -198,7 +205,7 @@ func TestSpannerSequencerPushback(t *testing.T) {
 			db, close := newSpannerDB(t)
 			defer close()
 
-			seq, err := newSpannerCoordinator(ctx, db, "", test.threshold)
+			seq, err := newSpannerCoordinator(ctx, db, prefixTable(""), test.threshold)
 			if err != nil {
 				t.Fatalf("newSpannerCoordinator: %v", err)
 			}
@@ -228,7 +235,7 @@ func TestSpannerSequencerRoundTrip(t *testing.T) {
 	db, close := newSpannerDB(t)
 	defer close()
 
-	s, err := newSpannerCoordinator(ctx, db, "", 1000)
+	s, err := newSpannerCoordinator(ctx, db, prefixTable(""), 1000)
 	if err != nil {
 		t.Fatalf("newSpannerCoordinator: %v", err)
 	}
@@ -280,7 +287,7 @@ func TestCheckDataCompatibility(t *testing.T) {
 	db, close := newSpannerDB(t)
 	defer close()
 
-	s, err := newSpannerCoordinator(ctx, db, "", 1000)
+	s, err := newSpannerCoordinator(ctx, db, prefixTable(""), 1000)
 	if err != nil {
 		t.Fatalf("newSpannerCoordinator: %v", err)
 	}
@@ -447,7 +454,7 @@ func TestSpannerSequencerAssignEntriesBatchSplitting(t *testing.T) {
 		entrySize  = 10 * 1024
 	)
 
-	seq, err := newSpannerCoordinator(ctx, db, "", uint64(numEntries+1))
+	seq, err := newSpannerCoordinator(ctx, db, prefixTable(""), uint64(numEntries+1))
 	if err != nil {
 		t.Fatalf("newSpannerCoordinator: %v", err)
 	}
@@ -573,7 +580,7 @@ func TestPublishTree(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			db, closeDB := newSpannerDB(t)
 			defer closeDB()
-			s, err := newSpannerCoordinator(ctx, db, "", 1000)
+			s, err := newSpannerCoordinator(ctx, db, prefixTable(""), 1000)
 			if err != nil {
 				t.Fatalf("newSpannerCoordinator: %v", err)
 			}
@@ -642,7 +649,7 @@ func TestGarbageCollect(t *testing.T) {
 	db, closeDB := newSpannerDB(t)
 	defer closeDB()
 
-	s, err := newSpannerCoordinator(ctx, db, "", batchSize)
+	s, err := newSpannerCoordinator(ctx, db, prefixTable(""), batchSize)
 	if err != nil {
 		t.Fatalf("newSpannerCoordinator: %v", err)
 	}
@@ -751,7 +758,7 @@ func TestGarbageCollectOption(t *testing.T) {
 			db, closeDB := newSpannerDB(t)
 			defer closeDB()
 
-			s, err := newSpannerCoordinator(ctx, db, "", batchSize)
+			s, err := newSpannerCoordinator(ctx, db, prefixTable(""), batchSize)
 			if err != nil {
 				t.Fatalf("newSpannerCoordinator: %v", err)
 			}

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -48,6 +48,11 @@ func init() {
 
 func newSpannerDB(t *testing.T) (*spanner.Client, func()) {
 	t.Helper()
+	return newSpannerDBWithPrefix(t, "")
+}
+
+func newSpannerDBWithPrefix(t *testing.T, tablePrefix string) (*spanner.Client, func()) {
+	t.Helper()
 	srv, err := spannertest.NewServer("localhost:0")
 	if err != nil {
 		t.Fatalf("Failed to set up test spanner: %v", err)
@@ -57,7 +62,7 @@ func newSpannerDB(t *testing.T) (*spanner.Client, func()) {
 	}
 
 	id := "projects/p/instances/i/databases/d"
-	if err := initDB(t.Context(), id); err != nil {
+	if err := initDB(t.Context(), id, tablePrefix); err != nil {
 		t.Fatalf("initDB: %v", err)
 	}
 
@@ -74,7 +79,7 @@ func TestSpannerSequencerAssignEntries(t *testing.T) {
 	db, close := newSpannerDB(t)
 	defer close()
 
-	seq, err := newSpannerCoordinator(ctx, db, 1000)
+	seq, err := newSpannerCoordinator(ctx, db, "", 1000)
 	if err != nil {
 		t.Fatalf("newSpannerCoordinator: %v", err)
 	}
@@ -94,6 +99,72 @@ func TestSpannerSequencerAssignEntries(t *testing.T) {
 			}
 			want++
 		}
+	}
+}
+
+func TestSpannerTablePrefix(t *testing.T) {
+	ctx := t.Context()
+	const prefix = "Tenant1_"
+	db, close := newSpannerDBWithPrefix(t, prefix)
+	defer close()
+
+	seq, err := newSpannerCoordinator(ctx, db, prefix, 1000)
+	if err != nil {
+		t.Fatalf("newSpannerCoordinator: %v", err)
+	}
+
+	entries := []*tessera.Entry{}
+	for i := range 10 {
+		entries = append(entries, tessera.NewEntry(fmt.Appendf(nil, "item %d", i)))
+	}
+	if err := seq.assignEntries(ctx, entries); err != nil {
+		t.Fatalf("assignEntries: %v", err)
+	}
+	next, err := seq.nextIndex(ctx)
+	if err != nil {
+		t.Fatalf("nextIndex: %v", err)
+	}
+	if want := uint64(len(entries)); next != want {
+		t.Errorf("nextIndex: got %d, want %d", next, want)
+	}
+
+	// The state should live in the prefixed tables, and the unprefixed tables should not exist.
+	if _, err := db.Single().ReadRow(ctx, prefix+"SeqCoord", spanner.Key{0}, []string{"next"}); err != nil {
+		t.Errorf("failed to read from prefixed SeqCoord table: %v", err)
+	}
+	if _, err := db.Single().ReadRow(ctx, "SeqCoord", spanner.Key{0}, []string{"next"}); err == nil {
+		t.Error("read from unprefixed SeqCoord table succeeded, want error as table should not exist")
+	}
+}
+
+func TestSpannerTablePrefixValidation(t *testing.T) {
+	ctx := t.Context()
+	for _, test := range []struct {
+		name    string
+		prefix  string
+		wantErr bool
+	}{
+		{name: "empty is valid", prefix: ""},
+		{name: "simple prefix is valid", prefix: "Tenant1_"},
+		{name: "letters digits underscores are valid", prefix: "log1_x"},
+		{name: "64 chars is valid", prefix: strings.Repeat("a", 64)},
+		{name: "65 chars is invalid", prefix: strings.Repeat("a", 65), wantErr: true},
+		{name: "leading digit is invalid", prefix: "1log", wantErr: true},
+		{name: "leading underscore is invalid", prefix: "_log", wantErr: true},
+		{name: "space is invalid", prefix: "a b", wantErr: true},
+		{name: "hyphen is invalid", prefix: "a-b", wantErr: true},
+		{name: "DDL metacharacters are invalid", prefix: "Evil (id INT64) PRIMARY KEY (id); DROP TABLE Tessera;--", wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := New(ctx, Config{
+				Bucket:             "bucket",
+				Spanner:            "projects/p/instances/i/databases/d",
+				SpannerTablePrefix: test.prefix,
+			})
+			if gotErr := err != nil; gotErr != test.wantErr {
+				t.Errorf("New with prefix %q: got err %v, want err %t", test.prefix, err, test.wantErr)
+			}
+		})
 	}
 }
 
@@ -127,7 +198,7 @@ func TestSpannerSequencerPushback(t *testing.T) {
 			db, close := newSpannerDB(t)
 			defer close()
 
-			seq, err := newSpannerCoordinator(ctx, db, test.threshold)
+			seq, err := newSpannerCoordinator(ctx, db, "", test.threshold)
 			if err != nil {
 				t.Fatalf("newSpannerCoordinator: %v", err)
 			}
@@ -157,7 +228,7 @@ func TestSpannerSequencerRoundTrip(t *testing.T) {
 	db, close := newSpannerDB(t)
 	defer close()
 
-	s, err := newSpannerCoordinator(ctx, db, 1000)
+	s, err := newSpannerCoordinator(ctx, db, "", 1000)
 	if err != nil {
 		t.Fatalf("newSpannerCoordinator: %v", err)
 	}
@@ -209,7 +280,7 @@ func TestCheckDataCompatibility(t *testing.T) {
 	db, close := newSpannerDB(t)
 	defer close()
 
-	s, err := newSpannerCoordinator(ctx, db, 1000)
+	s, err := newSpannerCoordinator(ctx, db, "", 1000)
 	if err != nil {
 		t.Fatalf("newSpannerCoordinator: %v", err)
 	}
@@ -376,7 +447,7 @@ func TestSpannerSequencerAssignEntriesBatchSplitting(t *testing.T) {
 		entrySize  = 10 * 1024
 	)
 
-	seq, err := newSpannerCoordinator(ctx, db, uint64(numEntries+1))
+	seq, err := newSpannerCoordinator(ctx, db, "", uint64(numEntries+1))
 	if err != nil {
 		t.Fatalf("newSpannerCoordinator: %v", err)
 	}
@@ -502,7 +573,7 @@ func TestPublishTree(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			db, closeDB := newSpannerDB(t)
 			defer closeDB()
-			s, err := newSpannerCoordinator(ctx, db, 1000)
+			s, err := newSpannerCoordinator(ctx, db, "", 1000)
 			if err != nil {
 				t.Fatalf("newSpannerCoordinator: %v", err)
 			}
@@ -571,7 +642,7 @@ func TestGarbageCollect(t *testing.T) {
 	db, closeDB := newSpannerDB(t)
 	defer closeDB()
 
-	s, err := newSpannerCoordinator(ctx, db, batchSize)
+	s, err := newSpannerCoordinator(ctx, db, "", batchSize)
 	if err != nil {
 		t.Fatalf("newSpannerCoordinator: %v", err)
 	}
@@ -680,7 +751,7 @@ func TestGarbageCollectOption(t *testing.T) {
 			db, closeDB := newSpannerDB(t)
 			defer closeDB()
 
-			s, err := newSpannerCoordinator(ctx, db, batchSize)
+			s, err := newSpannerCoordinator(ctx, db, "", batchSize)
 			if err != nil {
 				t.Fatalf("newSpannerCoordinator: %v", err)
 			}


### PR DESCRIPTION
## What

Adds an optional `SpannerTablePrefix` field to the GCP storage `Config`, which is
prepended to the names of all Spanner tables used for log coordination state
(`Tessera`, `SeqCoord`, `Seq`, `IntCoord`, `PubCoord`, `GCCoord`). The same option is
added to the GCP antispam implementation as `AntispamOpts.SpannerTablePrefix` (for its
`IDSeq` and `FollowCoord` tables).

## Why

This allows multiple logs to share a single Spanner database, with each log's
coordination state in its own set of tables — mirroring the existing `BucketPrefix`
option for GCS objects. Useful for multi-tenant deployments where provisioning a
Spanner database per log is wasteful.

## Notes

- The prefix defaults to empty, which preserves the existing table names and
  behaviour unchanged for current deployments.
- Non-empty prefixes are validated (must start with a letter; letters, digits, or
  underscores only; at most 64 characters) so that prefixed table names remain valid
  Spanner identifiers, and so the value is safe to interpolate into the
  `CREATE TABLE` DDL.
- The prefix namespaces only the Spanner state; logs sharing a database must still
  use a distinct `Bucket`/`BucketPrefix` each, since GCS object paths are unaffected.

## Testing

- New `TestSpannerTablePrefix` exercises a prefixed coordinator end-to-end against
  `spannertest` and asserts state lands in the prefixed tables only.
- New `TestSpannerTablePrefixValidation` covers accepted/rejected prefixes,
  including DDL metacharacters.
- Existing tests pass unchanged with the default empty prefix.
