### PR TITLE
Handle no pending checkpoint in MTC Mirror

### DIFF
--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -105,10 +105,6 @@ func addEntries(m *MirrorMux) http.HandlerFunc {
 			_, _ = fmt.Fprintf(w, "%d\n%d\n%s\n", pendingSize, nextEntry, base64.StdEncoding.EncodeToString(ticket))
 			return
 
-		case errors.Is(err, tessera.ErrNoPendingCheckpoint):
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-
 		case errors.Is(err, tessera.ErrInvalidProof):
 			// SPEC: If this (subtree consistency proof) verification process fails, it MUST respond with a "422 Unprocessable Entity"
 			// HTTP status code and end processing.

--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -105,6 +105,10 @@ func addEntries(m *MirrorMux) http.HandlerFunc {
 			_, _ = fmt.Fprintf(w, "%d\n%d\n%s\n", pendingSize, nextEntry, base64.StdEncoding.EncodeToString(ticket))
 			return
 
+		case errors.Is(err, tessera.ErrNoPendingCheckpoint):
+			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+			return
+
 		case errors.Is(err, tessera.ErrInvalidProof):
 			// SPEC: If this (subtree consistency proof) verification process fails, it MUST respond with a "422 Unprocessable Entity"
 			// HTTP status code and end processing.

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -211,15 +211,6 @@ func TestAddEntries_StatusCodes(t *testing.T) {
 			wantStatus: http.StatusAccepted,
 			wantBody:   fmt.Sprintf("%d\n%d\n%s\n", testPendingSize, testUploadStart+5, base64.StdEncoding.EncodeToString([]byte(testNewTicket))),
 		}, {
-			name:   "400 no pending checkpoint",
-			origin: testOrigin,
-			mockTarget: &mockTarget{
-				addEntriesFunc: func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
-					return 0, 0, nil, nil, tessera.ErrNoPendingCheckpoint
-				},
-			},
-			wantStatus: http.StatusBadRequest,
-		}, {
 			name:   "400 truncated body (no entries saved)",
 			origin: testOrigin,
 			mockTarget: &mockTarget{

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -235,6 +235,15 @@ func TestAddEntries_StatusCodes(t *testing.T) {
 			wantStatus: http.StatusConflict,
 			wantBody:   fmt.Sprintf("%d\n%d\n%s\n", testPendingSize, testNextIdx, base64.StdEncoding.EncodeToString([]byte(testNewTicket))),
 		}, {
+			name:   "422 no pending checkpoint",
+			origin: testOrigin,
+			mockTarget: &mockTarget{
+				addEntriesFunc: func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
+					return 0, 0, nil, nil, tessera.ErrNoPendingCheckpoint
+				},
+			},
+			wantStatus: http.StatusUnprocessableEntity,
+		}, {
 			name:   "422 unprocessable entity",
 			origin: testOrigin,
 			mockTarget: &mockTarget{

--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -47,6 +47,9 @@ var (
 	// ErrConflict is returned when the requested upload range conflicts with the
 	// current state of the log.
 	ErrConflict = errors.New("tree size conflict")
+	// ErrNoPendingCheckpoint is returned when a pending checkpoint cannot be
+	// determined.
+	ErrNoPendingCheckpoint = errors.New("no pending checkpoint")
 	// ErrInvalidProof is returned when a proof fails to verify.
 	ErrInvalidProof = errors.New("invalid proof")
 )
@@ -418,7 +421,7 @@ func (mt *MirrorTarget) openOrCreateTicket(ctx context.Context, ticketBytes []by
 		slog.DebugContext(ctx, "Invalid or incorrect ticket, returning new ticket", slog.Uint64("next_entry", nextEntry), slog.String("ticketCP", string(ticketCP)), slog.Uint64("expectedSize", expectedSize))
 		ticketBytes, pendingCP, pendingNote, err = mt.createNewTicket(ctx)
 		if err != nil {
-			return 0, 0, userTicketValid, nil, nil, nil, fmt.Errorf("failed to create new ticket: %v", err)
+			return 0, 0, userTicketValid, nil, nil, nil, fmt.Errorf("failed to create new ticket: %w", err)
 		}
 		// If the new pending checkpoint still doesn't match expectedSize, return 409 Conflict with the fresh ticket.
 		if pendingCP.Size != expectedSize {

--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -47,9 +47,6 @@ var (
 	// ErrConflict is returned when the requested upload range conflicts with the
 	// current state of the log.
 	ErrConflict = errors.New("tree size conflict")
-	// ErrNoPendingCheckpoint is returned when a pending checkpoint cannot be
-	// determined.
-	ErrNoPendingCheckpoint = errors.New("no pending checkpoint")
 	// ErrInvalidProof is returned when a proof fails to verify.
 	ErrInvalidProof = errors.New("invalid proof")
 )

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -602,3 +602,65 @@ func TestMirrorTarget_AddEntries_Unaligned_PadsFirstBundle(t *testing.T) {
 		t.Errorf("ReadEntryBundle was not called")
 	}
 }
+
+func TestMirrorTarget_AddEntries_NoPendingCheckpoint_Success(t *testing.T) {
+	const (
+		testIntegratedSize = uint64(100)
+	)
+	ctx := t.Context()
+
+	mt := &MirrorTarget{
+		logVerifier: testLogVerifier,
+		signer:      testMirrorSigner,
+		writer: &fakeMirrorWriter{
+			sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
+		},
+		reader: &fakeLogReader{
+			sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
+		},
+		cpSource: func(ctx context.Context) ([]byte, error) {
+			return nil, nil // No pending checkpoint
+		},
+	}
+
+	nextEntry, pendingSize, _, _, err := mt.AddEntries(ctx, testIntegratedSize, testIntegratedSize, nil, func() (*MirrorPackage, error) {
+		return nil, io.EOF
+	})
+	if err != nil {
+		t.Errorf("got error %v, want nil", err)
+	}
+	if got, want := nextEntry, testIntegratedSize; got != want {
+		t.Errorf("nextEntry: got %d, want %d", got, want)
+	}
+	if got, want := pendingSize, testIntegratedSize; got != want {
+		t.Errorf("pendingSize: got %d, want %d", got, want)
+	}
+}
+
+func TestMirrorTarget_AddEntries_NoPendingCheckpoint_Conflict(t *testing.T) {
+	const (
+		testIntegratedSize = uint64(100)
+	)
+	ctx := t.Context()
+
+	mt := &MirrorTarget{
+		logVerifier: testLogVerifier,
+		signer:      testMirrorSigner,
+		writer: &fakeMirrorWriter{
+			sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
+		},
+		reader: &fakeLogReader{
+			sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
+		},
+		cpSource: func(ctx context.Context) ([]byte, error) {
+			return nil, nil // No pending checkpoint
+		},
+	}
+
+	_, _, _, _, err := mt.AddEntries(ctx, testIntegratedSize, testIntegratedSize+10, nil, func() (*MirrorPackage, error) {
+		return nil, io.EOF
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Errorf("got error %v, want ErrConflict", err)
+	}
+}

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -396,7 +396,6 @@ func TestMirrorTarget_AddEntries_ZeroCheckpoint(t *testing.T) {
 	}
 }
 
-
 func mustGenerateKey(origin string) (note.Signer, note.Verifier) {
 	sk, vk, err := fnote.GenerateMLDSAKey(origin)
 	if err != nil {
@@ -603,41 +602,7 @@ func TestMirrorTarget_AddEntries_Unaligned_PadsFirstBundle(t *testing.T) {
 	}
 }
 
-func TestMirrorTarget_AddEntries_NoPendingCheckpoint_Success(t *testing.T) {
-	const (
-		testIntegratedSize = uint64(100)
-	)
-	ctx := t.Context()
-
-	mt := &MirrorTarget{
-		logVerifier: testLogVerifier,
-		signer:      testMirrorSigner,
-		writer: &fakeMirrorWriter{
-			sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
-		},
-		reader: &fakeLogReader{
-			sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
-		},
-		cpSource: func(ctx context.Context) ([]byte, error) {
-			return nil, nil // No pending checkpoint
-		},
-	}
-
-	nextEntry, pendingSize, _, _, err := mt.AddEntries(ctx, testIntegratedSize, testIntegratedSize, nil, func() (*MirrorPackage, error) {
-		return nil, io.EOF
-	})
-	if err != nil {
-		t.Errorf("got error %v, want nil", err)
-	}
-	if got, want := nextEntry, testIntegratedSize; got != want {
-		t.Errorf("nextEntry: got %d, want %d", got, want)
-	}
-	if got, want := pendingSize, testIntegratedSize; got != want {
-		t.Errorf("pendingSize: got %d, want %d", got, want)
-	}
-}
-
-func TestMirrorTarget_AddEntries_NoPendingCheckpoint_Conflict(t *testing.T) {
+func TestMirrorTarget_AddEntries_NoPendingCheckpoint(t *testing.T) {
 	const (
 		testIntegratedSize = uint64(100)
 	)
@@ -660,7 +625,7 @@ func TestMirrorTarget_AddEntries_NoPendingCheckpoint_Conflict(t *testing.T) {
 	_, _, _, _, err := mt.AddEntries(ctx, testIntegratedSize, testIntegratedSize+10, nil, func() (*MirrorPackage, error) {
 		return nil, io.EOF
 	})
-	if !errors.Is(err, ErrConflict) {
-		t.Errorf("got error %v, want ErrConflict", err)
+	if !errors.Is(err, ErrNoPendingCheckpoint) {
+		t.Errorf("got error %v, want ErrNoPendingCheckpoint", err)
 	}
 }


### PR DESCRIPTION
This pull request removes `ErrNoPendingCheckpoint` and returns `409 Conflict` instead of `400 Bad Request` when there is no pending checkpoint.

Towards #945.