### PR TITLE
Use subtree consistency proof in mirror client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -219,6 +219,21 @@ func (pb *ProofBuilder) ConsistencyProof(ctx context.Context, smaller, larger ui
 	})
 }
 
+// SubtreeConsistencyProof constructs a subtree consistency proof for the specified range [start, end) in a tree of the proof builder's size.
+func (pb *ProofBuilder) SubtreeConsistencyProof(ctx context.Context, start, end uint64) ([][]byte, error) {
+	return otel.Trace(ctx, "tessera.client.SubtreeConsistencyProof", tracer, func(ctx context.Context, span trace.Span) ([][]byte, error) {
+		if end > pb.treeSize {
+			return nil, fmt.Errorf("requested subtree consistency proof to %d which is larger than tree size %d", end, pb.treeSize)
+		}
+
+		nodes, err := proof.SubtreeConsistency(start, end, pb.treeSize)
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate subtree consistency proof node list: %v", err)
+		}
+		return pb.materialiseProof(ctx, nodes)
+	})
+}
+
 // materialiseProof retrieves the specified proof nodes via pb's nodeCache, recreating ephemeral nodes if necessary.
 func (pb *ProofBuilder) materialiseProof(ctx context.Context, nodes proof.Nodes) ([][]byte, error) {
 	hashes, err := pb.nodeCache.GetNodes(ctx, nodes.IDs)

--- a/client/mirror/client.go
+++ b/client/mirror/client.go
@@ -31,12 +31,14 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/transparency-dev/tessera/api/layout"
 	"github.com/transparency-dev/tessera/client"
 )
 
 // PackageProverFunc computes and returns the proof hashes required by the mirror
-// for the specified entry package covering the index interval [start, end).
-type PackageProverFunc func(ctx context.Context, start, end uint64) ([][]byte, error)
+// for the specified entry package covering the index interval [start, end)
+// in a tree of the specified size.
+type PackageProverFunc func(ctx context.Context, start, end, size uint64) ([][]byte, error)
 
 // Options holds the configuration for a tlog-mirror Client.
 type Options struct {
@@ -118,9 +120,6 @@ func (o *Options) validate() error {
 	if o.mirrorCheckpointFetcher == nil {
 		return errors.New("mirror checkpoint fetcher is required")
 	}
-	if o.packageProver == nil {
-		return errors.New("package prover is required")
-	}
 	return nil
 }
 
@@ -135,6 +134,17 @@ type Client struct {
 func NewClient(_ context.Context, opts *Options) (*Client, error) {
 	if err := opts.validate(); err != nil {
 		return nil, err
+	}
+
+	// Use default subtree consistency proof if not provided.
+	if opts.packageProver == nil {
+		opts.packageProver = func(ctx context.Context, start, end, size uint64) ([][]byte, error) {
+			pb, err := client.NewProofBuilder(ctx, size, opts.tileFetcher)
+			if err != nil {
+				return nil, err
+			}
+			return pb.SubtreeConsistencyProof(ctx, start, end)
+		}
 	}
 
 	return &Client{opts: opts}, nil
@@ -227,6 +237,12 @@ func (c *Client) pushEntries(ctx context.Context, uploadStart, uploadEnd uint64,
 		return nil, parseConflict(resp.Body)
 	}
 
+	// TODO(roger2hk): Update this logic to comply with tlog-mirror specification.
+	// This is a temporary workaround to match the existing behavior of the mirror server.
+	if resp.StatusCode == http.StatusBadRequest {
+		return nil, ErrConflict{}
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("add-entries failed with status %d: %s", resp.StatusCode, string(body))
@@ -310,9 +326,9 @@ func (c *Client) streamEntries(ctx context.Context, uploadStart, uploadEnd uint6
 			}
 		}
 
-		proof, err := c.opts.packageProver(ctx, curr, pkgEnd)
+		proof, err := c.opts.packageProver(ctx, bundleIndex*layout.EntryBundleWidth, pkgEnd, uploadEnd)
 		if err != nil {
-			_ = pw.CloseWithError(fmt.Errorf("failed to generate proof [%d, %d): %w", curr, pkgEnd, err))
+			_ = pw.CloseWithError(fmt.Errorf("failed to generate proof [%d, %d): %w", bundleIndex*layout.EntryBundleWidth, pkgEnd, err))
 			return
 		}
 

--- a/client/mirror/client_test.go
+++ b/client/mirror/client_test.go
@@ -222,7 +222,7 @@ func TestOptionsBuilders(t *testing.T) {
 	var mirrorCheckpointFetcher client.CheckpointFetcherFunc = func(ctx context.Context) ([]byte, error) {
 		return nil, nil
 	}
-	var packageProver PackageProverFunc = func(ctx context.Context, start, end uint64) ([][]byte, error) {
+	var packageProver PackageProverFunc = func(ctx context.Context, start, end, size uint64) ([][]byte, error) {
 		return nil, nil
 	}
 
@@ -266,7 +266,6 @@ func TestNewClientValidation(t *testing.T) {
 	var tileFetcher client.TileFetcherFunc = func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) { return nil, nil }
 	var bundleFetcher client.EntryBundleFetcherFunc = func(ctx context.Context, index uint64, size uint8) ([]byte, error) { return nil, nil }
 	var mirrorCheckpointFetcher client.CheckpointFetcherFunc = func(ctx context.Context) ([]byte, error) { return nil, nil }
-	var packageProver PackageProverFunc = func(ctx context.Context, start, end uint64) ([][]byte, error) { return nil, nil }
 
 	tests := []struct {
 		desc    string
@@ -282,8 +281,7 @@ func TestNewClientValidation(t *testing.T) {
 					WithLogOrigin(logOrigin).
 					WithTileFetcher(tileFetcher).
 					WithBundleFetcher(bundleFetcher).
-					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
-					WithPackageProver(packageProver)
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
 			},
 		},
 		{
@@ -294,8 +292,7 @@ func TestNewClientValidation(t *testing.T) {
 					WithLogOrigin(logOrigin).
 					WithTileFetcher(tileFetcher).
 					WithBundleFetcher(bundleFetcher).
-					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
-					WithPackageProver(packageProver)
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
 			},
 			wantErr: "mirror URL is required",
 		},
@@ -307,8 +304,7 @@ func TestNewClientValidation(t *testing.T) {
 					WithLogOrigin(logOrigin).
 					WithTileFetcher(tileFetcher).
 					WithBundleFetcher(bundleFetcher).
-					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
-					WithPackageProver(packageProver)
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
 				opts.httpClient = nil
 				return opts
 			},
@@ -322,8 +318,7 @@ func TestNewClientValidation(t *testing.T) {
 					WithHTTPClient(httpClient).
 					WithTileFetcher(tileFetcher).
 					WithBundleFetcher(bundleFetcher).
-					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
-					WithPackageProver(packageProver)
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
 			},
 			wantErr: "log origin is required",
 		},
@@ -335,8 +330,7 @@ func TestNewClientValidation(t *testing.T) {
 					WithHTTPClient(httpClient).
 					WithLogOrigin(logOrigin).
 					WithBundleFetcher(bundleFetcher).
-					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
-					WithPackageProver(packageProver)
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
 			},
 			wantErr: "tile fetcher is required",
 		},
@@ -348,8 +342,7 @@ func TestNewClientValidation(t *testing.T) {
 					WithHTTPClient(httpClient).
 					WithLogOrigin(logOrigin).
 					WithTileFetcher(tileFetcher).
-					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
-					WithPackageProver(packageProver)
+					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
 			},
 			wantErr: "bundle fetcher is required",
 		},
@@ -361,23 +354,9 @@ func TestNewClientValidation(t *testing.T) {
 					WithHTTPClient(httpClient).
 					WithLogOrigin(logOrigin).
 					WithTileFetcher(tileFetcher).
-					WithBundleFetcher(bundleFetcher).
-					WithPackageProver(packageProver)
+					WithBundleFetcher(bundleFetcher)
 			},
 			wantErr: "mirror checkpoint fetcher is required",
-		},
-		{
-			desc: "missing package prover",
-			setup: func() *Options {
-				return NewOptions().
-					WithMirrorURL(u).
-					WithHTTPClient(httpClient).
-					WithLogOrigin(logOrigin).
-					WithTileFetcher(tileFetcher).
-					WithBundleFetcher(bundleFetcher).
-					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
-			},
-			wantErr: "package prover is required",
 		},
 	}
 
@@ -518,9 +497,12 @@ func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "text/x.tlog.mirror-info")
 			}
 			w.WriteHeader(status)
-			if status == http.StatusConflict {
+			switch status {
+			case http.StatusConflict:
 				ticketB64 := base64.StdEncoding.EncodeToString(fm.ticket)
 				_, _ = fmt.Fprintf(w, "%d\n%d\n%s\n", fm.initialPendingSize, fm.initialNextEntry, ticketB64)
+			case http.StatusBadRequest:
+				_, _ = w.Write([]byte("no pending checkpoint"))
 			}
 			return
 		}
@@ -599,6 +581,9 @@ func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+
+		// Consume the rest of the gzipped body (including the gzip footer) to prevent client write hangs.
+		_, _ = io.Copy(io.Discard, gr)
 
 		if exp.status != http.StatusOK {
 			if exp.status == http.StatusConflict || exp.status == http.StatusAccepted {
@@ -706,7 +691,7 @@ func TestSync(t *testing.T) {
 		return nil, errors.New("mirror checkpoint fetcher should not be called")
 	}
 
-	packageProver := func(ctx context.Context, start, end uint64) ([][]byte, error) {
+	packageProver := func(ctx context.Context, start, end, size uint64) ([][]byte, error) {
 		return fm.proofHashes, nil
 	}
 
@@ -833,6 +818,20 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:               "initial status query returns no pending checkpoint (bootstrap)",
+			initialPendingSize: 0,
+			initialNextEntry:   0,
+			initialStatus:      http.StatusBadRequest,
+			addEntriesExpectations: []addEntriesExpectation{
+				{
+					start:  0,
+					end:    5,
+					ticket: nil,
+					status: http.StatusOK,
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -875,7 +874,7 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 				return nil, errors.New("mirror checkpoint fetcher should not be called")
 			}
 
-			packageProver := func(ctx context.Context, start, end uint64) ([][]byte, error) {
+			packageProver := func(ctx context.Context, start, end, size uint64) ([][]byte, error) {
 				return fm.proofHashes, nil
 			}
 

--- a/internal/mirror/hammer/hammer.go
+++ b/internal/mirror/hammer/hammer.go
@@ -165,8 +165,7 @@ func main() {
 			WithBundleFetcher(logReader.ReadEntryBundle).
 			WithMirrorCheckpointFetcher(func(ctx context.Context) ([]byte, error) {
 				return nil, nil
-			}).
-			WithPackageProver(dummyPackageProver)
+			})
 		mc, err := mirror.NewClient(ctx, mOpts)
 		if err != nil {
 			slog.ErrorContext(ctx, "Failed to create mirror client", slog.String("url", urlStr), slog.Any("error", err))
@@ -323,11 +322,6 @@ func getKeyFile(path string) (string, error) {
 		return "", fmt.Errorf("failed to read key file: %w", err)
 	}
 	return string(k), nil
-}
-
-// TODO(roger2hk): Replace with the subtree consistency proof from merkle repo.
-func dummyPackageProver(_ context.Context, _ uint64, _ uint64) ([][]byte, error) {
-	return nil, nil
 }
 
 // runMirrorSync syncs the source log to a mirror server.


### PR DESCRIPTION
This pull request replaces the dummy package prover with the subtree consistency proof.

Towards https://github.com/transparency-dev/tessera/issues/945 and https://github.com/transparency-dev/tessera/issues/1010.