### PR TITLE
Cosign zero sized checkpoints

### DIFF
--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -210,13 +210,13 @@ type MirrorPackage struct {
 // - an opaque ticket for future invocation,
 // - optionally, a cosignature over a pending checkpoint whose size matches uploadEnd if one exists.
 func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticketBytes []byte, next func() (*MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
-	nextEntry, pendingSize, ticketBytes, pendingCP, pendingNote, err := mt.openOrCreateTicket(ctx, ticketBytes, uploadEnd)
+	nextEntry, pendingSize, userTicketValid, ticketBytes, pendingCP, pendingNote, err := mt.openOrCreateTicket(ctx, ticketBytes, uploadEnd)
 	if err != nil {
 		return nextEntry, pendingSize, ticketBytes, nil, err
 	}
 
 	// Handle 409 Conflicts:
-	//    - Zero-request check: If upload_start == 0 and upload_end == 0, the client is
+	//    - Zero-request check: If upload_start == 0 and upload_end == 0 and provided no valid ticket, the client is
 	//      requesting initial mirror information.
 	//    - upload_end:
 	//      * MUST be equal to the tree size of a known pending checkpoint.
@@ -224,7 +224,7 @@ func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd u
 	//    - upload_start:
 	//      * MUST NOT be greater than the mirror's next expected entry index.
 	//      * MUST NOT be too far below the mirror's next entry index.
-	if (uploadStart == 0 && uploadEnd == 0) ||
+	if (uploadStart == 0 && uploadEnd == 0 && !userTicketValid) ||
 		(uploadEnd != pendingSize || uploadEnd < nextEntry) ||
 		(uploadStart > nextEntry) {
 		// TODO(al): add flexibility about re-writing some entries
@@ -393,15 +393,16 @@ func (mt *MirrorTarget) IntegratedSize(ctx context.Context) (uint64, error) {
 
 // openOrCreateTicket handles ticket logic, returning a new ticket if the provided one is invalid/missing.
 //
-// Returns next entry index to upload, size of the pending checkpoint, ticket to return to the caller, pending checkpoint structure, pending note, and error.
-func (mt *MirrorTarget) openOrCreateTicket(ctx context.Context, ticketBytes []byte, expectedSize uint64) (uint64, uint64, []byte, *log.Checkpoint, *note.Note, error) {
+// Returns next entry index to upload, size of the pending checkpoint, a bool indicating whether the provided ticket was valid, the ticket to return to the caller (may be the same as the provided one), pending checkpoint structure, pending note, and error.
+func (mt *MirrorTarget) openOrCreateTicket(ctx context.Context, ticketBytes []byte, expectedSize uint64) (uint64, uint64, bool, []byte, *log.Checkpoint, *note.Note, error) {
 	nextEntry, err := mt.reader.IntegratedSize(ctx)
 	if err != nil {
-		return 0, 0, nil, nil, nil, fmt.Errorf("failed to read integrated size: %v", err)
+		return 0, 0, false, nil, nil, nil, fmt.Errorf("failed to read integrated size: %v", err)
 	}
 
 	var pendingCP *log.Checkpoint
 	var pendingNote *note.Note
+	userTicketValid := false
 
 	ticketCP, err := mt.open(ticketBytes)
 	if err != nil {
@@ -412,6 +413,7 @@ func (mt *MirrorTarget) openOrCreateTicket(ctx context.Context, ticketBytes []by
 			slog.DebugContext(ctx, "Failed to parse ticket", slog.Any("error", err))
 		} else {
 			slog.DebugContext(ctx, "Valid ticket", slog.Uint64("nextEntry", nextEntry), slog.Uint64("pendingSize", pendingCP.Size))
+			userTicketValid = true
 		}
 	}
 
@@ -419,16 +421,16 @@ func (mt *MirrorTarget) openOrCreateTicket(ctx context.Context, ticketBytes []by
 		slog.DebugContext(ctx, "Invalid or incorrect ticket, returning new ticket", slog.Uint64("next_entry", nextEntry), slog.String("ticketCP", string(ticketCP)), slog.Uint64("expectedSize", expectedSize))
 		ticketBytes, pendingCP, pendingNote, err = mt.createNewTicket(ctx)
 		if err != nil {
-			return 0, 0, nil, nil, nil, fmt.Errorf("failed to create new ticket: %v", err)
+			return 0, 0, userTicketValid, nil, nil, nil, fmt.Errorf("failed to create new ticket: %v", err)
 		}
 		// If the new pending checkpoint still doesn't match expectedSize, return 409 Conflict with the fresh ticket.
 		if pendingCP.Size != expectedSize {
-			return nextEntry, pendingCP.Size, ticketBytes, pendingCP, pendingNote, ErrConflict
+			return nextEntry, pendingCP.Size, userTicketValid, ticketBytes, pendingCP, pendingNote, ErrConflict
 		}
 		// Otherwise, allow the request to continue (because their uploadEnd == pendingCP.Size).
 	}
 
-	return nextEntry, pendingCP.Size, ticketBytes, pendingCP, pendingNote, nil
+	return nextEntry, pendingCP.Size, userTicketValid, ticketBytes, pendingCP, pendingNote, nil
 }
 
 func (mt *MirrorTarget) createNewTicket(ctx context.Context) (ticket []byte, pendingCP *log.Checkpoint, pendingNote *note.Note, err error) {

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -116,9 +116,13 @@ func TestTicketRoundTrip(t *testing.T) {
 		return nil, nil // Unreachable.
 	}
 
-	_, _, newTicket, _, _, err := mt.openOrCreateTicket(t.Context(), ticket, testPendingCPSize)
+	_, _, oldTicketValid, newTicket, _, _, err := mt.openOrCreateTicket(t.Context(), ticket, testPendingCPSize)
 	if err != nil {
 		t.Fatalf("openOrCreateTicket: %v", err)
+	}
+
+	if !oldTicketValid {
+		t.Fatalf("openOrCreateTicket: oldTicketValid = %v, want true", oldTicketValid)
 	}
 
 	if !bytes.Equal(ticket, newTicket) {
@@ -151,22 +155,25 @@ func TestCreateNewTicket(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name          string
-		ticket        []byte
-		expectedSize  uint64
-		wantNewTicket bool
-		wantConflict  bool
+		name            string
+		ticket          []byte
+		expectedSize    uint64
+		wantTicketValid bool
+		wantNewTicket   bool
+		wantConflict    bool
 	}{
 		{
-			name:         "ticket valid",
-			ticket:       ticket,
-			expectedSize: testPendingCPSize - 1, // Expect old size
+			name:            "ticket valid",
+			ticket:          ticket,
+			expectedSize:    testPendingCPSize - 1, // Expect old size
+			wantTicketValid: true,
 		}, {
-			name:          "ticket stale",
-			ticket:        ticket,
-			expectedSize:  testPendingCPSize, // Expect new size because we want a new ticket.
-			wantNewTicket: true,
-			wantConflict:  true,
+			name:            "ticket stale",
+			ticket:          ticket,
+			expectedSize:    testPendingCPSize, // Expect new size because we want a new ticket.
+			wantTicketValid: true,
+			wantNewTicket:   true,
+			wantConflict:    true,
 		}, {
 			name:          "ticket corrupt",
 			ticket:        append(append([]byte{}, ticket[:len(ticket)-1]...), ticket[len(ticket)-1]^0xff),
@@ -175,7 +182,7 @@ func TestCreateNewTicket(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			_, _, newTicket, _, _, err := mt.openOrCreateTicket(t.Context(), test.ticket, test.expectedSize)
+			_, _, oldTicketValid, newTicket, _, _, err := mt.openOrCreateTicket(t.Context(), test.ticket, test.expectedSize)
 			if err != nil {
 				gotConflict := errors.Is(err, ErrConflict)
 				if gotConflict != test.wantConflict {
@@ -186,6 +193,9 @@ func TestCreateNewTicket(t *testing.T) {
 				}
 			}
 
+			if test.wantTicketValid != oldTicketValid {
+				t.Fatalf("openOrCreateTicket: newTicket Valid = %v, want %v", oldTicketValid, test.wantTicketValid)
+			}
 			if test.wantNewTicket {
 				if bytes.Equal(test.ticket, newTicket) {
 					t.Fatalf("ticket should have been updated")

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -329,6 +329,74 @@ func TestMirrorTarget_AddEntries_CompleteUpload(t *testing.T) {
 	}
 }
 
+func TestMirrorTarget_AddEntries_ZeroCheckpoint(t *testing.T) {
+	testPendingCPZero := mustSignCP(testPendingCPOrigin, 0, testPendingCPRoot, testLogSigner)
+	ctx := context.Background()
+	var gotUpdatedCP []byte
+	mt := &MirrorTarget{
+		logVerifier: testLogVerifier,
+		signer:      testMirrorSigner,
+		writer: &fakeMirrorWriter{
+			integrateFunc: func(ctx context.Context, fromBundleIdx uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
+				pendingCPRoot, err := base64.StdEncoding.DecodeString(testPendingCPRoot)
+				return 0, pendingCPRoot, err
+			},
+			updateCheckpointFunc: func(ctx context.Context, f func(oldCP []byte) (newCP []byte, err error)) error {
+				cp, err := f(nil)
+				gotUpdatedCP = cp
+				return err
+			},
+		},
+		reader: &fakeLogReader{
+			sizeFunc: func(ctx context.Context) (uint64, error) { return 0, nil },
+		},
+		cpSource: func(ctx context.Context) ([]byte, error) { return []byte(testPendingCPZero), nil },
+	}
+
+	// 1. First call with no ticket and uploadStart=0, uploadEnd=0.
+	// This should request the initial mirror info/ticket and return ErrConflict.
+	nextEntry, pendingSize, ticket, cosigs, err := mt.AddEntries(ctx, 0, 0, nil, func() (*MirrorPackage, error) {
+		return nil, io.EOF
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("first call got err: %v, want ErrConflict", err)
+	}
+	if nextEntry != 0 {
+		t.Errorf("first call got nextEntry %d, want 0", nextEntry)
+	}
+	if pendingSize != 0 {
+		t.Errorf("first call got pendingSize %d, want 0", pendingSize)
+	}
+	if len(ticket) == 0 {
+		t.Fatalf("first call got empty ticket, want a valid ticket")
+	}
+	if len(cosigs) != 0 {
+		t.Errorf("first call got cosigs, want none")
+	}
+
+	// 2. Second call with the ticket returned from the first call.
+	// This should succeed and return the cosignature.
+	nextEntry, pendingSize, _, cosigs, err = mt.AddEntries(ctx, 0, 0, ticket, func() (*MirrorPackage, error) {
+		return nil, io.EOF
+	})
+	if err != nil {
+		t.Fatalf("second call got err: %v, want nil", err)
+	}
+	if nextEntry != 0 {
+		t.Errorf("second call got nextEntry %d, want 0", nextEntry)
+	}
+	if pendingSize != 0 {
+		t.Errorf("second call got pendingSize %d, want 0", pendingSize)
+	}
+	if len(cosigs) == 0 {
+		t.Errorf("second call got empty cosigs, want non-empty")
+	}
+	if wantCP := append([]byte(testPendingCPZero), cosigs...); !bytes.Equal(gotUpdatedCP, wantCP) {
+		t.Errorf("got updated CP %s, want %s", gotUpdatedCP, wantCP)
+	}
+}
+
+
 func mustGenerateKey(origin string) (note.Signer, note.Verifier) {
 	sk, vk, err := fnote.GenerateMLDSAKey(origin)
 	if err != nil {


### PR DESCRIPTION
Enable clients to gather mirror-cosignatures for zero-sized log checkpoints.

Previously, we'd always consider uploadStart == uploadEnd == 0 to be a client trying to get a new ticket. Now, IFF the client sends these values but _also_ sends a valid ticket, then we'll proceed to do ~no work, and then return a cosig for the zero sized checkpoint.

Towards #945 