### PR TITLE
Bump Go toolchain version to 1.25.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/transparency-dev/tessera
 
 go 1.25.8
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	cloud.google.com/go/spanner v1.92.0


### PR DESCRIPTION
Bumping the Go toolchain version to get rid of the vulnerability found by govulncheck.