### PR TITLE
Update Mirror client to handle 422 Unprocessable Entity for no pending checkpoint

### DIFF
--- a/client/mirror/client.go
+++ b/client/mirror/client.go
@@ -237,9 +237,7 @@ func (c *Client) pushEntries(ctx context.Context, uploadStart, uploadEnd uint64,
 		return nil, parseConflict(resp.Body)
 	}
 
-	// TODO(roger2hk): Update this logic to comply with tlog-mirror specification.
-	// This is a temporary workaround to match the existing behavior of the mirror server.
-	if resp.StatusCode == http.StatusBadRequest {
+	if resp.StatusCode == http.StatusUnprocessableEntity {
 		return nil, ErrConflict{}
 	}
 

--- a/client/mirror/client_test.go
+++ b/client/mirror/client_test.go
@@ -501,7 +501,7 @@ func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			case http.StatusConflict:
 				ticketB64 := base64.StdEncoding.EncodeToString(fm.ticket)
 				_, _ = fmt.Fprintf(w, "%d\n%d\n%s\n", fm.initialPendingSize, fm.initialNextEntry, ticketB64)
-			case http.StatusBadRequest:
+			case http.StatusUnprocessableEntity:
 				_, _ = w.Write([]byte("no pending checkpoint"))
 			}
 			return
@@ -822,7 +822,7 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 			desc:               "initial status query returns no pending checkpoint (bootstrap)",
 			initialPendingSize: 0,
 			initialNextEntry:   0,
-			initialStatus:      http.StatusBadRequest,
+			initialStatus:      http.StatusUnprocessableEntity,
 			addEntriesExpectations: []addEntriesExpectation{
 				{
 					start:  0,


### PR DESCRIPTION
This pull request updates the mirror client to match the mirror server behaviour when there is no pending checkpoint.

Towards https://github.com/transparency-dev/tessera/issues/945 and https://github.com/transparency-dev/tessera/issues/1010.