### PR TITLE
Return error for 422 Unprocessable Entity in mirror client

### DIFF
--- a/client/mirror/client.go
+++ b/client/mirror/client.go
@@ -244,10 +244,6 @@ func (c *Client) pushEntries(ctx context.Context, uploadStart, uploadEnd uint64,
 		return nil, parseConflict(resp.Body)
 	}
 
-	if resp.StatusCode == http.StatusUnprocessableEntity {
-		return nil, ErrConflict{}
-	}
-
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("add-entries failed with status %d: %s", resp.StatusCode, string(body))


### PR DESCRIPTION
When mirror client gets 422 Unprocessable Entity from server, it should return error instead of an empty `ErrConflict` struct.

Towards https://github.com/transparency-dev/tessera/issues/945 and https://github.com/transparency-dev/tessera/issues/1010.