### PR TITLE
Fix broken TUI in hammer due to slog

### DIFF
--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -189,6 +189,7 @@ func main() {
 
 	if *showUI {
 		c := loadtest.NewController(hammer, ha)
+		slog.SetDefault(slog.New(slog.NewTextHandler(c.LogWriter(), &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
 		c.Run(ctx)
 	} else {
 		<-ctx.Done()

--- a/internal/hammer/loadtest/tui.go
+++ b/internal/hammer/loadtest/tui.go
@@ -17,6 +17,7 @@ package loadtest
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -142,4 +143,9 @@ func (c *tuiController) updateStatsLoop(ctx context.Context, interval time.Durat
 			c.app.Draw()
 		}
 	}
+}
+
+// LogWriter returns a writer that writes to the log TextView.
+func (c *tuiController) LogWriter() io.Writer {
+	return c.logView
 }

--- a/internal/mirror/hammer/hammer.go
+++ b/internal/mirror/hammer/hammer.go
@@ -230,6 +230,7 @@ func main() {
 
 	if *showUI {
 		c := loadtest.NewController(hammer, ha)
+		slog.SetDefault(slog.New(slog.NewTextHandler(c.LogWriter(), &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
 		c.Run(ctx)
 	} else {
 		<-ctx.Done()

--- a/internal/mirror/hammer/loadtest/tui.go
+++ b/internal/mirror/hammer/loadtest/tui.go
@@ -17,6 +17,7 @@ package loadtest
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -142,4 +143,9 @@ func (c *tuiController) updateStatsLoop(ctx context.Context, interval time.Durat
 			c.app.Draw()
 		}
 	}
+}
+
+// LogWriter returns a writer that writes to the log TextView.
+func (c *tuiController) LogWriter() io.Writer {
+	return c.logView
 }


### PR DESCRIPTION
The hammer TUI is broken when there is any log written to `os.Stderr`. This issue was introduced in the slog migration (https://github.com/transparency-dev/tessera/pull/896 and https://github.com/transparency-dev/tessera/pull/909).

This issue can easily be replicated in the [POSIX conformance test doc](https://github.com/transparency-dev/tessera/blob/main/cmd/conformance/posix/README.md).