### PR TITLE
Refactor hammer TUI log writer

### DIFF
--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -189,7 +189,6 @@ func main() {
 
 	if *showUI {
 		c := loadtest.NewController(hammer, ha)
-		slog.SetDefault(slog.New(slog.NewTextHandler(c.LogWriter(), &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
 		c.Run(ctx)
 	} else {
 		<-ctx.Done()

--- a/internal/hammer/loadtest/tui.go
+++ b/internal/hammer/loadtest/tui.go
@@ -17,7 +17,6 @@ package loadtest
 import (
 	"context"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -69,6 +68,9 @@ func NewController(h *Hammer, a *HammerAnalyser) *tuiController {
 }
 
 func (c *tuiController) Run(ctx context.Context) {
+	// Redirect logs to the view.
+	slog.SetDefault(slog.New(slog.NewTextHandler(c.logView, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
 	go c.updateStatsLoop(ctx, 500*time.Millisecond)
 
 	c.app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
@@ -143,9 +145,4 @@ func (c *tuiController) updateStatsLoop(ctx context.Context, interval time.Durat
 			c.app.Draw()
 		}
 	}
-}
-
-// LogWriter returns a writer that writes to the log TextView.
-func (c *tuiController) LogWriter() io.Writer {
-	return c.logView
 }

--- a/internal/mirror/hammer/hammer.go
+++ b/internal/mirror/hammer/hammer.go
@@ -230,7 +230,6 @@ func main() {
 
 	if *showUI {
 		c := loadtest.NewController(hammer, ha)
-		slog.SetDefault(slog.New(slog.NewTextHandler(c.LogWriter(), &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
 		c.Run(ctx)
 	} else {
 		<-ctx.Done()

--- a/internal/mirror/hammer/loadtest/tui.go
+++ b/internal/mirror/hammer/loadtest/tui.go
@@ -17,7 +17,6 @@ package loadtest
 import (
 	"context"
 	"fmt"
-	"io"
 	"strings"
 	"time"
 
@@ -69,6 +68,9 @@ func NewController(h *Hammer, a *HammerAnalyser) *tuiController {
 }
 
 func (c *tuiController) Run(ctx context.Context) {
+	// Redirect logs to the view.
+	slog.SetDefault(slog.New(slog.NewTextHandler(c.logView, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
 	go c.updateStatsLoop(ctx, 500*time.Millisecond)
 
 	c.app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
@@ -143,9 +145,4 @@ func (c *tuiController) updateStatsLoop(ctx context.Context, interval time.Durat
 			c.app.Draw()
 		}
 	}
-}
-
-// LogWriter returns a writer that writes to the log TextView.
-func (c *tuiController) LogWriter() io.Writer {
-	return c.logView
 }


### PR DESCRIPTION
This is a follow up on https://github.com/transparency-dev/tessera/pull/1058 to revert exposing the hammer log writer to public.

The logic now aligns with the TesseraCT hammer.