### PR TITLE
Enable mirror hammer to use an existing log as a source.

### DIFF
--- a/internal/mirror/hammer/README.md
+++ b/internal/mirror/hammer/README.md
@@ -42,8 +42,8 @@ Example usage to test a deployment of [`cmd/mtc/mirror/posix`](/cmd/mtc/mirror/p
 ```shell
 go run ./internal/mirror/hammer \
   --mirror_url=http://localhost:8080 \
-  --storage_dir=/tmp/hammer-log \
-  --log_private_key=/tmp/hammer-log.key \
+  --local_log_storage_dir=/tmp/hammer-log \
+  --local_log_private_key=/tmp/hammer-log.key \
   --num_writers=256 \
   --max_write_ops=42
 ```
@@ -55,8 +55,8 @@ If the timeout of 1 minute is reached first, then it exits with an exit code of 
 ```shell
 go run ./internal/mirror/hammer \
   --mirror_url=http://localhost:8080 \
-  --storage_dir=/tmp/hammer-log \
-  --log_private_key=/tmp/hammer-log.key \
+  --local_log_storage_dir=/tmp/hammer-log \
+  --local_log_private_key=/tmp/hammer-log.key \
   --num_writers=512 \
   --max_write_ops=512 \
   --max_runtime=1m \
@@ -76,6 +76,6 @@ Then start the hammer in replication mode, e.g.:
 go run ./internal/mirror/hammer \
   --mirror_url=http://localhost:8080 \
   --source_log_url=https://example.com/source-log \
-  --source_log_pubkey_path=/tmp/source-log.pub \
+  --source_log_public_key=/tmp/source-log.pub \
   --show_ui=false
 ```

--- a/internal/mirror/hammer/README.md
+++ b/internal/mirror/hammer/README.md
@@ -15,6 +15,16 @@ For real load-testing applications, especially headless runs as part of a CI pip
 
 ## Usage
 
+There are two modes in which the hammer can be run, in both modes the hammer continuously tracks a source log and replicates its data to one or more target mirrors.
+The difference between the two modes is where the data for the source log originates:
+
+1. **Standalone log**: The hammer creates and continuously populates its own local POSIX log.
+2. **Replication**: The hammer reads from an existing log.
+
+In both cases the hammer uses the data from the source log as the data to send to the mirror server.
+
+### Mode 1: Standalone Hammer Log
+
 First, store the hammer log test private key:
 
 ```shell
@@ -51,5 +61,21 @@ go run ./internal/mirror/hammer \
   --max_write_ops=512 \
   --max_runtime=1m \
   --leaf_write_goal=2500 \
+  --show_ui=false
+```
+
+### Mode 2: Replication
+
+Determine the source log's public key and URL, and ensure that the target mirror is configured to accept data from this log.
+
+Write the source log's `vkey` to a file, e.g. `/tmp/source-log.pub`.
+
+Then start the hammer in replication mode, e.g.:
+
+```shell
+go run ./internal/mirror/hammer \
+  --mirror_url=http://localhost:8080 \
+  --source_log_url=https://example.com/source-log \
+  --source_log_pubkey_path=/tmp/source-log.pub \
   --show_ui=false
 ```

--- a/internal/mirror/hammer/hammer.go
+++ b/internal/mirror/hammer/hammer.go
@@ -37,6 +37,8 @@ import (
 	"github.com/transparency-dev/tessera/storage/posix"
 	"golang.org/x/net/http2"
 
+	sdbNote "golang.org/x/mod/sumdb/note"
+
 	"log/slog"
 )
 
@@ -49,6 +51,8 @@ var (
 
 	storageDir = flag.String("storage_dir", "", "Root directory to store log data")
 	logPrivKey = flag.String("log_private_key", "", "Location of private key file")
+	sourceLogURL        = flag.String("source_log_url", "", "URL of the log to mirror, or empty if using a locally created log.")
+	sourceLogPubKeyPath = flag.String("source_log_public_key_path", "", "Path to the public key of the log to mirror. Required if --source_log_url is set.")
 
 	maxWriteOpsPerSecond = flag.Int("max_write_ops", 0, "The maximum number of write operations per second")
 	numWriters           = flag.Int("num_writers", 0, "The number of independent write tasks to run")
@@ -70,6 +74,12 @@ var (
 
 	hc *http.Client
 )
+
+type logReader interface {
+	ReadCheckpoint(ctx context.Context) ([]byte, error)
+	ReadEntryBundle(ctx context.Context, index uint64, p uint8) ([]byte, error)
+	ReadTile(ctx context.Context, level, index uint64, p uint8) ([]byte, error)
+}
 
 func main() {
 	flag.Parse()
@@ -102,42 +112,15 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Gather the info needed for reading/writing checkpoints.
-	s := getSignerOrDie(ctx)
-
-	// Create the Tessera POSIX storage, using the directory from the --storage_dir flag.
-	driver, err := posix.New(ctx, posix.Config{Path: *storageDir})
-	if err != nil {
-		slog.ErrorContext(ctx, "Failed to construct storage", slog.Any("error", err))
-		os.Exit(1)
-	}
-
-	appender, shutdown, logReader, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
-		WithCheckpointSigner(s).
-		WithCheckpointInterval(time.Second).
-		WithCheckpointRepublishInterval(time.Minute).
-		WithBatching(tessera.DefaultBatchMaxSize, time.Second))
-	if err != nil {
-		slog.ErrorContext(ctx, "Failed to create new appender", slog.Any("error", err))
-		os.Exit(1)
-	}
+	appender, logReader, shutdown, verifier := logFromFlags(ctx)
 	defer func() {
 		if err := shutdown(ctx); err != nil {
 			slog.ErrorContext(ctx, "Failed to shutdown appender", slog.Any("error", err))
 		}
 	}()
 
-	leafWriter := func(ctx context.Context, newLeaf []byte) (uint64, error) {
-		idx, err := appender.Add(ctx, tessera.NewEntry(newLeaf))()
-		if err != nil {
-			return 0, fmt.Errorf("failed to add leaf: %v", err)
-		}
-		return idx.Index, nil
-	}
-
-	var cpRaw []byte
 	cons := client.UnilateralConsensus(logReader.ReadCheckpoint)
-	tracker, err := client.NewLogStateTracker(ctx, logReader.ReadTile, cpRaw, s.Verifier(), s.Verifier().Name(), cons)
+	tracker, err := client.NewLogStateTracker(ctx, logReader.ReadTile, nil, verifier, verifier.Name(), cons)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create LogStateTracker", slog.Any("error", err))
 		os.Exit(1)
@@ -160,7 +143,7 @@ func main() {
 		mOpts := mirror.NewOptions().
 			WithMirrorURL(mURL).
 			WithHTTPClient(hc).
-			WithLogOrigin(s.Verifier().Name()).
+			WithLogOrigin(verifier.Name()).
 			WithTileFetcher(logReader.ReadTile).
 			WithBundleFetcher(logReader.ReadEntryBundle).
 			WithMirrorCheckpointFetcher(func(ctx context.Context) ([]byte, error) {
@@ -175,18 +158,13 @@ func main() {
 		go runMirrorSync(ctx, tracker, mc, mURL)
 	}
 
-	ha := loadtest.NewHammerAnalyser(func() uint64 { return tracker.Latest().Size })
-	ha.Run(ctx)
-
-	gen := newLeafGenerator(tracker.Latest().Size, *leafMinSize, *dupChance)
-	opts := loadtest.HammerOpts{
-		MaxReadOpsPerSecond:  0,
-		MaxWriteOpsPerSecond: *maxWriteOpsPerSecond,
-		NumReadersRandom:     0,
-		NumReadersFull:       0,
-		NumWriters:           *numWriters,
+	var hammer *loadtest.Hammer
+	var ha *loadtest.HammerAnalyser
+	if appender != nil {
+		hammer, ha = newHammer(ctx, appender, logReader, tracker)
+		ha.Run(ctx)
+		hammer.Run(ctx)
 	}
-	hammer := loadtest.NewHammer(tracker, logReader.ReadEntryBundle, leafWriter, gen, ha.SeqLeafChan, ha.ErrChan, opts)
 
 	exitCode := 0
 	if *leafWriteGoal > 0 {
@@ -226,10 +204,9 @@ func main() {
 			}
 		}()
 	}
-	hammer.Run(ctx)
 
 	if *showUI {
-		c := loadtest.NewController(hammer, ha)
+		c := loadtest.NewController(hammer, ha, tracker)
 		c.Run(ctx)
 	} else {
 		<-ctx.Done()
@@ -349,4 +326,104 @@ func runMirrorSync(ctx context.Context, tracker *client.LogStateTracker, mClient
 			lastSyncedSize = latest.Size
 		}
 	}
+}
+
+func logFromFlags(ctx context.Context) (*tessera.Appender, logReader, func(context.Context) error, sdbNote.Verifier) {
+	if *sourceLogURL != "" {
+		if *sourceLogPubKeyPath == "" {
+			slog.ErrorContext(ctx, "Source log URL provided but no public key path.")
+			os.Exit(1)
+		}
+		lr, shutdown, v, err := newRemoteLog(ctx, *sourceLogURL, *sourceLogPubKeyPath)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to create remote log", slog.Any("error", err))
+			os.Exit(1)
+		}
+		return nil, lr, shutdown, v
+	}
+
+	if *storageDir == "" {
+		slog.ErrorContext(ctx, "No storage directory provided.")
+		os.Exit(1)
+	}
+	app, lr, shutdown, v, err := newLocalLog(ctx, *storageDir, getSignerOrDie(ctx))
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to create local log", slog.Any("error", err))
+		os.Exit(1)
+	}
+	return app, lr, shutdown, v
+}
+
+// newLocalLog creates a new local POSIX log which can be used by a hammer to hammer the mirror.
+//
+// Returns an Appender for adding leaves to the log, a LogReader that reads from the local log,
+func newLocalLog(ctx context.Context, storageDir string, s note.Signer) (*tessera.Appender, logReader, func(context.Context) error, sdbNote.Verifier, error) {
+	// Create the Tessera POSIX storage, using the provided directory.
+	driver, err := posix.New(ctx, posix.Config{Path: storageDir})
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to construct storage: %w", err)
+	}
+
+	appender, shutdown, logReader, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
+		WithCheckpointSigner(s).
+		WithCheckpointInterval(time.Second).
+		WithCheckpointRepublishInterval(time.Minute).
+		WithBatching(tessera.DefaultBatchMaxSize, time.Second))
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return appender, logReader, shutdown, s.Verifier(), nil
+}
+
+// newRemoteLog creates a logReader that reads from a remote log, and a shutdown func.
+func newRemoteLog(_ context.Context, logURL string, pubKeyPath string) (logReader, func(context.Context) error, sdbNote.Verifier, error) {
+	pubKRaw, err := getKeyFile(pubKeyPath)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to read public key %q: %v", pubKeyPath, err)
+	}
+
+	pubKey, err := note.NewVerifier(pubKRaw)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to parse public key %q: %v", pubKeyPath, err)
+	}
+
+	var lr logReader
+	u, err := url.Parse(logURL)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to parse log URL %q: %v", logURL, err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+		lr, err = client.NewHTTPFetcher(u, hc)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to create HTTP fetcher: %v", err)
+		}
+	default:
+		lr = client.FileFetcher{Root: logURL}
+	}
+
+	return lr, func(context.Context) error { return nil }, pubKey, nil
+}
+
+func newHammer(_ context.Context, appender *tessera.Appender, logReader logReader, tracker *client.LogStateTracker) (*loadtest.Hammer, *loadtest.HammerAnalyser) {
+	leafWriter := func(ctx context.Context, newLeaf []byte) (uint64, error) {
+		idx, err := appender.Add(ctx, tessera.NewEntry(newLeaf))()
+		if err != nil {
+			return 0, fmt.Errorf("failed to add leaf: %v", err)
+		}
+		return idx.Index, nil
+	}
+	ha := loadtest.NewHammerAnalyser(func() uint64 { return tracker.Latest().Size })
+
+	gen := newLeafGenerator(tracker.Latest().Size, *leafMinSize, *dupChance)
+	opts := loadtest.HammerOpts{
+		MaxReadOpsPerSecond:  0,
+		MaxWriteOpsPerSecond: *maxWriteOpsPerSecond,
+		NumReadersRandom:     0,
+		NumReadersFull:       0,
+		NumWriters:           *numWriters,
+	}
+	hammer := loadtest.NewHammer(tracker, logReader.ReadEntryBundle, leafWriter, gen, ha.SeqLeafChan, ha.ErrChan, opts)
+
+	return hammer, ha
 }

--- a/internal/mirror/hammer/hammer.go
+++ b/internal/mirror/hammer/hammer.go
@@ -49,10 +49,11 @@ func init() {
 var (
 	mirrorURL multiStringFlag
 
-	storageDir = flag.String("storage_dir", "", "Root directory to store log data")
-	logPrivKey = flag.String("log_private_key", "", "Location of private key file")
-	sourceLogURL        = flag.String("source_log_url", "", "URL of the log to mirror, or empty if using a locally created log.")
-	sourceLogPubKeyPath = flag.String("source_log_public_key_path", "", "Path to the public key of the log to mirror. Required if --source_log_url is set.")
+	sourceLogURL    = flag.String("source_log_url", "", "URL of the log to mirror, or empty if using a locally created log.")
+	sourceLogPubKey = flag.String("source_log_public_key", "", "Path to the public key of the log to mirror. Required if --source_log_url is set.")
+
+	localLogStorageDir = flag.String("local_log_storage_dir", "", "Root directory to store the locally created source log. Only relevant if --source_log_url is not set.")
+	localLogPrivKey    = flag.String("local_log_private_key", "", "Path to the private key of the local log created as a source for mirroring. Required if --source_log_url is not set.")
 
 	maxWriteOpsPerSecond = flag.Int("max_write_ops", 0, "The maximum number of write operations per second")
 	numWriters           = flag.Int("num_writers", 0, "The number of independent write tasks to run")
@@ -273,12 +274,12 @@ func getSignerOrDie(ctx context.Context) note.Signer {
 	var privKey string
 	var err error
 
-	if len(*logPrivKey) == 0 {
-		slog.ErrorContext(ctx, "Supply log private key file path using --log_private_key")
+	if len(*localLogPrivKey) == 0 {
+		slog.ErrorContext(ctx, "Supply local log private key file path using --local_log_private_key")
 		os.Exit(1)
 	}
 
-	privKey, err = getKeyFile(*logPrivKey)
+	privKey, err = getKeyFile(*localLogPrivKey)
 	if err != nil {
 		slog.ErrorContext(ctx, "Unable to get private key", slog.Any("error", err))
 		os.Exit(1)
@@ -330,11 +331,11 @@ func runMirrorSync(ctx context.Context, tracker *client.LogStateTracker, mClient
 
 func logFromFlags(ctx context.Context) (*tessera.Appender, logReader, func(context.Context) error, sdbNote.Verifier) {
 	if *sourceLogURL != "" {
-		if *sourceLogPubKeyPath == "" {
+		if *sourceLogPubKey == "" {
 			slog.ErrorContext(ctx, "Source log URL provided but no public key path.")
 			os.Exit(1)
 		}
-		lr, shutdown, v, err := newRemoteLog(ctx, *sourceLogURL, *sourceLogPubKeyPath)
+		lr, shutdown, v, err := newRemoteLog(ctx, *sourceLogURL, *sourceLogPubKey)
 		if err != nil {
 			slog.ErrorContext(ctx, "Failed to create remote log", slog.Any("error", err))
 			os.Exit(1)
@@ -342,11 +343,11 @@ func logFromFlags(ctx context.Context) (*tessera.Appender, logReader, func(conte
 		return nil, lr, shutdown, v
 	}
 
-	if *storageDir == "" {
-		slog.ErrorContext(ctx, "No storage directory provided.")
+	if *localLogStorageDir == "" {
+		slog.ErrorContext(ctx, "No local log storage directory provided. Either provide --local_log_storage_dir or --source_log_url.")
 		os.Exit(1)
 	}
-	app, lr, shutdown, v, err := newLocalLog(ctx, *storageDir, getSignerOrDie(ctx))
+	app, lr, shutdown, v, err := newLocalLog(ctx, *localLogStorageDir, getSignerOrDie(ctx))
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create local log", slog.Any("error", err))
 		os.Exit(1)
@@ -398,8 +399,10 @@ func newRemoteLog(_ context.Context, logURL string, pubKeyPath string) (logReade
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to create HTTP fetcher: %v", err)
 		}
+	case "file":
+		lr = client.FileFetcher{Root: u.Path}
 	default:
-		lr = client.FileFetcher{Root: logURL}
+		return nil, nil, nil, fmt.Errorf("unsupported log URL scheme: %s", u.Scheme)
 	}
 
 	return lr, func(context.Context) error { return nil }, pubKey, nil

--- a/internal/mirror/hammer/hammer.go
+++ b/internal/mirror/hammer/hammer.go
@@ -159,13 +159,13 @@ func main() {
 		go runMirrorSync(ctx, tracker, mc, mURL)
 	}
 
-	var hammer *loadtest.Hammer
-	var ha *loadtest.HammerAnalyser
+	// Don't do any writes if we don't have an appender...
 	if appender != nil {
-		hammer, ha = newHammer(ctx, appender, logReader, tracker)
-		ha.Run(ctx)
-		hammer.Run(ctx)
+		(*maxWriteOpsPerSecond) = 0
 	}
+	hammer, ha := newHammer(ctx, appender, logReader, tracker)
+	ha.Run(ctx)
+	hammer.Run(ctx)
 
 	exitCode := 0
 	if *leafWriteGoal > 0 {

--- a/internal/mirror/hammer/loadtest/tui.go
+++ b/internal/mirror/hammer/loadtest/tui.go
@@ -25,21 +25,24 @@ import (
 	movingaverage "github.com/RobinUS2/golang-moving-average"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+	"github.com/transparency-dev/tessera/client"
 )
 
 type tuiController struct {
 	hammer     *Hammer
 	analyser   *HammerAnalyser
+	tracker    *client.LogStateTracker
 	app        *tview.Application
 	statusView *tview.TextView
 	logView    *tview.TextView
 	helpView   *tview.TextView
 }
 
-func NewController(h *Hammer, a *HammerAnalyser) *tuiController {
+func NewController(h *Hammer, a *HammerAnalyser, t *client.LogStateTracker) *tuiController {
 	c := tuiController{
 		hammer:   h,
 		analyser: a,
+		tracker:  t,
 		app:      tview.NewApplication(),
 	}
 	grid := tview.NewGrid()
@@ -74,29 +77,31 @@ func (c *tuiController) Run(ctx context.Context) {
 	go c.updateStatsLoop(ctx, 500*time.Millisecond)
 
 	c.app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		switch event.Rune() {
-		case '+':
-			slog.InfoContext(ctx, "Increasing the read operations per second")
-			c.hammer.readThrottle.Increase()
-		case '-':
-			slog.InfoContext(ctx, "Decreasing the read operations per second")
-			c.hammer.readThrottle.Decrease()
-		case '>':
-			slog.InfoContext(ctx, "Increasing the write operations per second")
-			c.hammer.writeThrottle.Increase()
-		case '<':
-			slog.InfoContext(ctx, "Decreasing the write operations per second")
-			c.hammer.writeThrottle.Decrease()
-		case 'w':
-			slog.InfoContext(ctx, "Increasing the number of workers")
-			c.hammer.randomReaders.Grow(ctx)
-			c.hammer.fullReaders.Grow(ctx)
-			c.hammer.writers.Grow(ctx)
-		case 'W':
-			slog.InfoContext(ctx, "Decreasing the number of workers")
-			c.hammer.randomReaders.Shrink(ctx)
-			c.hammer.fullReaders.Shrink(ctx)
-			c.hammer.writers.Shrink(ctx)
+		if c.hammer != nil {
+			switch event.Rune() {
+			case '+':
+				slog.InfoContext(ctx, "Increasing the read operations per second")
+				c.hammer.readThrottle.Increase()
+			case '-':
+				slog.InfoContext(ctx, "Decreasing the read operations per second")
+				c.hammer.readThrottle.Decrease()
+			case '>':
+				slog.InfoContext(ctx, "Increasing the write operations per second")
+				c.hammer.writeThrottle.Increase()
+			case '<':
+				slog.InfoContext(ctx, "Decreasing the write operations per second")
+				c.hammer.writeThrottle.Decrease()
+			case 'w':
+				slog.InfoContext(ctx, "Increasing the number of workers")
+				c.hammer.randomReaders.Grow(ctx)
+				c.hammer.fullReaders.Grow(ctx)
+				c.hammer.writers.Grow(ctx)
+			case 'W':
+				slog.InfoContext(ctx, "Decreasing the number of workers")
+				c.hammer.randomReaders.Shrink(ctx)
+				c.hammer.fullReaders.Shrink(ctx)
+				c.hammer.writers.Shrink(ctx)
+			}
 		}
 		return event
 	})
@@ -114,7 +119,7 @@ func (c *tuiController) updateStatsLoop(ctx context.Context, interval time.Durat
 	}
 
 	ticker := time.NewTicker(interval)
-	lastSize := c.hammer.tracker.Latest().Size
+	lastSize := c.tracker.Latest().Size
 	maSlots := int((30 * time.Second) / interval)
 	growth := movingaverage.New(maSlots)
 	for {
@@ -122,24 +127,33 @@ func (c *tuiController) updateStatsLoop(ctx context.Context, interval time.Durat
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s := c.hammer.tracker.Latest().Size
+			s := c.tracker.Latest().Size
 			growth.Add(float64(s - lastSize))
 			lastSize = s
 			qps := growth.Avg() * float64(time.Second/interval)
-			readWorkersLine := fmt.Sprintf("Read (%d workers): %s",
-				c.hammer.fullReaders.Size()+c.hammer.randomReaders.Size(),
-				c.hammer.readThrottle.String())
-			writeWorkersLine := fmt.Sprintf("Write (%d workers): %s",
-				c.hammer.writers.Size(),
-				c.hammer.writeThrottle.String())
+
+			var numR, numW int
+			var rThrottle, wThrottle string
+			if c.hammer != nil {
+				numR = c.hammer.fullReaders.Size() + c.hammer.randomReaders.Size()
+				rThrottle = c.hammer.readThrottle.String()
+				numW = c.hammer.writers.Size()
+				wThrottle = c.hammer.writeThrottle.String()
+			}
+			readWorkersLine := fmt.Sprintf("Read (%d workers): %s", numR, rThrottle)
+			writeWorkersLine := fmt.Sprintf("Write (%d workers): %s", numW, wThrottle)
 			treeSizeLine := fmt.Sprintf("TreeSize: %d (Δ %.0fqps over %ds)",
 				s,
 				qps,
 				time.Duration(maSlots*int(interval))/time.Second)
-			queueLine := fmt.Sprintf("Time-in-queue: %s",
-				formatMovingAverage(c.analyser.QueueTime))
-			integrateLine := fmt.Sprintf("Observed-time-to-integrate: %s",
-				formatMovingAverage(c.analyser.IntegrationTime))
+
+			var qTime, iTime string
+			if c.analyser != nil {
+				qTime = formatMovingAverage(c.analyser.QueueTime)
+				iTime = formatMovingAverage(c.analyser.IntegrationTime)
+			}
+			queueLine := fmt.Sprintf("Time-in-queue: %s", qTime)
+			integrateLine := fmt.Sprintf("Observed-time-to-integrate: %s", iTime)
 			text := strings.Join([]string{readWorkersLine, writeWorkersLine, treeSizeLine, queueLine, integrateLine}, "\n")
 			c.statusView.SetText(text)
 			c.app.Draw()


### PR DESCRIPTION
This PR enables an existing log to optionally be used as the source of entries when hammering a mirror.

Towards #945 