### PR TITLE
Fix incorrect appender check in mirror hammer

### DIFF
--- a/internal/mirror/hammer/hammer.go
+++ b/internal/mirror/hammer/hammer.go
@@ -165,7 +165,7 @@ func main() {
 	}
 
 	// Don't do any writes if we don't have an appender...
-	if appender != nil {
+	if appender == nil {
 		(*maxWriteOpsPerSecond) = 0
 	}
 	hammer, ha := newHammer(ctx, appender, logReader, tracker)


### PR DESCRIPTION
This PR fixes the inverted logic introduced in https://github.com/transparency-dev/tessera/pull/1062.

Towards https://github.com/transparency-dev/tessera/issues/945