### PR TITLE
Move witness API path component into gateway implementation

### DIFF
--- a/internal/witness/client.go
+++ b/internal/witness/client.go
@@ -124,8 +124,11 @@ func NewWitnessGateway(group WitnessGroup, client *http.Client, oldSize uint64, 
 		vs := dedupVerifiers(vs)
 		if len(vs) > 0 {
 			witnesses = append(witnesses, &witnessClient{
-				client:    client,
-				url:       u,
+				client: client,
+				// Can't use path.Join here as it'll nobble the double-slash in URLs.
+				// url.JoinPath returns an error, which we can't handle here, but we already know that the URL is valid since
+				// it's coming via WitnessGroup.WitnessEndpoints(). So we'll just do the string manipulation ourselves.
+				url:       strings.TrimRight(u, "/") + "/add-checkpoint",
 				verifiers: vs,
 				size:      oldSize,
 			})

--- a/internal/witness/client_test.go
+++ b/internal/witness/client_test.go
@@ -77,14 +77,14 @@ func TestWitnessGateway_Update(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		switch r.URL.String() {
-		case w1u.Path:
+		switch r.URL.Path {
+		case w1u.Path + "/add-checkpoint":
 			witCalls.Add(1)
 			_, _ = w.Write(sigForSigner(t, cp, wit1Skey))
-		case w2u.Path:
+		case w2u.Path + "/add-checkpoint":
 			witCalls.Add(1)
 			_, _ = w.Write(sigForSigner(t, cp, wit2Skey))
-		case wbu.Path:
+		case wbu.Path + "/add-checkpoint":
 			witCalls.Add(1)
 			_, _ = w.Write([]byte("this is not a signature\n"))
 		case "/wit_multi/add-checkpoint":
@@ -414,7 +414,7 @@ func TestWitnessConflict(t *testing.T) {
 			var wit1 tessera.Witness
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w1u := mustURL(t, wit1.URL)
-				if got, want := r.URL.String(), w1u.Path; got != want {
+				if got, want := r.URL.String(), w1u.Path+"/add-checkpoint"; got != want {
 					t.Fatalf("got request to URL %q but expected %q", got, want)
 				}
 
@@ -474,7 +474,7 @@ func TestWitnessStateEvolution(t *testing.T) {
 	var count int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w1u := mustURL(t, wit1.URL)
-		if got, want := r.URL.String(), w1u.Path; got != want {
+		if got, want := r.URL.String(), w1u.Path+"/add-checkpoint"; got != want {
 			t.Fatalf("got request to URL %q but expected %q", got, want)
 		}
 
@@ -539,7 +539,7 @@ func TestSlipperyWitness(t *testing.T) {
 	var count int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w1u := mustURL(t, wit1.URL)
-		if got, want := r.URL.String(), w1u.Path; got != want {
+		if got, want := r.URL.String(), w1u.Path+"/add-checkpoint"; got != want {
 			t.Fatalf("Got request to URL %q but expected %q", got, want)
 		}
 
@@ -587,9 +587,9 @@ func TestWitnessReusesProofs(t *testing.T) {
 		w2u := mustURL(t, wit2.URL)
 
 		switch r.URL.String() {
-		case w1u.Path:
+		case w1u.Path + "/add-checkpoint":
 			_, _ = w.Write(sigForSigner(t, n.Text, wit1Skey))
-		case w2u.Path:
+		case w2u.Path + "/add-checkpoint":
 			_, _ = w.Write(sigForSigner(t, n.Text, wit2Skey))
 		default:
 			t.Fatalf("Unknown case: %s", r.URL.String())

--- a/witness.go
+++ b/witness.go
@@ -195,12 +195,10 @@ func NewWitness(vkey string, witnessRoot *url.URL) (Witness, error) {
 		return Witness{}, err
 	}
 
-	u := witnessRoot.JoinPath("/add-checkpoint")
-
 	return Witness{
 		Key: v,
-		URL: u.String(),
-	}, err
+		URL: witnessRoot.String(),
+	}, nil
 }
 
 // Witness represents a single witness that can be reached in order to perform a witnessing operation.

--- a/witness_test.go
+++ b/witness_test.go
@@ -3,6 +3,7 @@ package tessera_test
 import (
 	"net/url"
 	"slices"
+	"strings"
 	"testing"
 
 	f_note "github.com/transparency-dev/formats/note"
@@ -146,34 +147,34 @@ func TestWitnessGroup_URLs(t *testing.T) {
 		{
 			desc:         "witness 1",
 			group:        tessera.NewWitnessGroup(1, wit1),
-			expectedURLs: []string{"https://b1.example.com/wit1prefix/add-checkpoint"},
+			expectedURLs: []string{"https://b1.example.com/wit1prefix"},
 		},
 		{
 			desc:         "witness 2",
 			group:        tessera.NewWitnessGroup(1, wit2),
-			expectedURLs: []string{"https://b1.example.com/wit2prefix/add-checkpoint"},
+			expectedURLs: []string{"https://b1.example.com/wit2prefix"},
 		},
 		{
 			desc:         "witness 3",
 			group:        tessera.NewWitnessGroup(1, wit3),
-			expectedURLs: []string{"https://witness.example.com/add-checkpoint"},
+			expectedURLs: []string{"https://witness.example.com"},
 		},
 		{
 			desc:  "all witnesses in one group",
 			group: tessera.NewWitnessGroup(1, wit1, wit2, wit3),
 			expectedURLs: []string{
-				"https://b1.example.com/wit1prefix/add-checkpoint",
-				"https://b1.example.com/wit2prefix/add-checkpoint",
-				"https://witness.example.com/add-checkpoint",
+				"https://b1.example.com/wit1prefix",
+				"https://b1.example.com/wit2prefix",
+				"https://witness.example.com",
 			},
 		},
 		{
 			desc:  "all witnesses with duplicates in nests",
 			group: tessera.NewWitnessGroup(2, tessera.NewWitnessGroup(1, wit1, wit2), tessera.NewWitnessGroup(1, wit1, wit3)),
 			expectedURLs: []string{
-				"https://b1.example.com/wit1prefix/add-checkpoint",
-				"https://b1.example.com/wit2prefix/add-checkpoint",
-				"https://witness.example.com/add-checkpoint",
+				"https://b1.example.com/wit1prefix",
+				"https://b1.example.com/wit2prefix",
+				"https://witness.example.com",
 			},
 		},
 	}
@@ -181,7 +182,7 @@ func TestWitnessGroup_URLs(t *testing.T) {
 		t.Run(tC.desc, func(t *testing.T) {
 			gotURLs := make([]string, 0)
 			for u := range tC.group.WitnessEndpoints() {
-				gotURLs = append(gotURLs, u)
+				gotURLs = append(gotURLs, strings.TrimRight(u, "/"))
 			}
 			slices.Sort(gotURLs)
 			slices.Sort(tC.expectedURLs)


### PR DESCRIPTION
Move the witness API path detail out of the policy code and into the gateway implementation.

The witness policy handling code shouldn't care about the individual API path(s) on a witness, just its root URL.

Towards #945 