### PR TITLE
Refactor MTCLog file structure and handlers

### DIFF
--- a/cmd/mtc/log/internal/handler/handlers.go
+++ b/cmd/mtc/log/internal/handler/handlers.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/transparency-dev/tessera/cmd/mtc/log"
+)
+
+type addTBS func(context.Context, log.TBSCertificateLogEntry) (uint64, log.MTCProof, error)
+
+// New returns a new http.Handler for the mtc-tlog service.
+func New(mtcLog *log.MTCLog) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /add-tbs", addTBSHandler(mtcLog.AddTBS))
+	mux.HandleFunc("GET /proof-to-landmark", func(w http.ResponseWriter, r *http.Request) {
+		// TODO parse request
+		// TODO write response
+		if _, err := mtcLog.ProofToLandmark(r.Context(), 0); err != nil {
+			slog.ErrorContext(r.Context(), "Failed to fetch inclusion proof to landmark", slog.Any("error", err))
+		}
+		http.Error(w, "not implemented", http.StatusNotImplemented)
+	})
+	return mux
+}
+
+// addTBSHandler returns a handler which logs a DER-encoded TBSCertificateLogEntry.
+func addTBSHandler(add addTBS) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// TODO: parse request
+		// TODO: write response
+		if _, _, err := add(r.Context(), log.TBSCertificateLogEntry{}); err != nil {
+			slog.ErrorContext(r.Context(), "Failed to add entry to MTC log", slog.Any("error", err))
+		}
+		http.Error(w, "not implemented", http.StatusNotImplemented)
+	}
+}

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mtc
+package log
 
 import (
 	"context"

--- a/cmd/mtc/log/posix/main.go
+++ b/cmd/mtc/log/posix/main.go
@@ -25,7 +25,8 @@ import (
 
 	"github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/tessera"
-	mtc "github.com/transparency-dev/tessera/cmd/mtc/log"
+	"github.com/transparency-dev/tessera/cmd/mtc/log"
+	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/handler"
 	"github.com/transparency-dev/tessera/storage/posix"
 )
 
@@ -56,29 +57,12 @@ func main() {
 	ctx := context.Background()
 
 	appender, shutdown := newAppenderFromFlags(ctx)
-	mtcLog := mtc.NewMTCLog(ctx, appender)
+	mtcLog := log.NewMTCLog(ctx, appender)
+	mux := handler.New(mtcLog)
 
 	var protocols http.Protocols
 	protocols.SetHTTP1(true)
 	protocols.SetUnencryptedHTTP2(true)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("POST /add-tbs", func(w http.ResponseWriter, r *http.Request) {
-		// TODO: parse request
-		// TODO write response
-		if _, _, err := mtcLog.AddTBS(ctx, mtc.TBSCertificateLogEntry{}); err != nil {
-			slog.ErrorContext(ctx, "Failed to add entry to MTC log", slog.Any("error", err))
-		}
-		http.Error(w, "not implemented", http.StatusNotImplemented)
-	})
-	mux.HandleFunc("GET /proof-to-landmark", func(w http.ResponseWriter, r *http.Request) {
-		// TODO parse request
-		// TODO write response
-		if _, err := mtcLog.ProofToLandmark(ctx, 0); err != nil {
-			slog.ErrorContext(ctx, "Failed to fetch inclusion proof to landmark", slog.Any("error", err))
-		}
-		http.Error(w, "not implemented", http.StatusNotImplemented)
-	})
 
 	server := &http.Server{
 		Addr:              *listenAddr,


### PR DESCRIPTION
This PR moves handlers to their own file, and renames the mtc package to "log", to match the directory name.

 
Towards #945 