### PR TITLE
Implement MTCLog AddTBS HTTP handler

### DIFF
--- a/cmd/mtc/log/internal/entry/entry.go
+++ b/cmd/mtc/log/internal/entry/entry.go
@@ -49,9 +49,39 @@ type EntryType uint16
 // MTCLogEntry represents leaf node as defined in
 // draft-ietf-plants-merkle-tree-certs section 5.2.1.
 type MTCLogEntry struct {
-	Extensions []MTCLogEntryExtension
-	Type       EntryType // MTCLogEntryTypeNull, MTCLogEntryTypeTBSCert
-	EntryData  []byte    // Raw DER bytes of TBSCertificateLogEntry if Type is TBSCert
+	extensions []MTCLogEntryExtension
+	entryType  EntryType // MTCLogEntryTypeNull, MTCLogEntryTypeTBSCert
+	entryData  []byte    // Raw DER bytes of TBSCertificateLogEntry if Type is TBSCert
+}
+
+// New creates a new MTCLogEntry containing entryData and optional extensions.
+// If entryData is empty, Type is set to MTCLogEntryTypeNull.
+// Otherwise, Type is set to MTCLogEntryTypeTBSCert.
+func New(entryData []byte, extensions ...MTCLogEntryExtension) *MTCLogEntry {
+	entryType := MTCLogEntryTypeTBSCert
+	if len(entryData) == 0 {
+		entryType = MTCLogEntryTypeNull
+	}
+	return &MTCLogEntry{
+		extensions: extensions,
+		entryType:  entryType,
+		entryData:  entryData,
+	}
+}
+
+// Extensions returns the entry's extensions list.
+func (e *MTCLogEntry) Extensions() []MTCLogEntryExtension {
+	return e.extensions
+}
+
+// Type returns the entry's Type.
+func (e *MTCLogEntry) Type() EntryType {
+	return e.entryType
+}
+
+// EntryData returns the raw entry data payload.
+func (e *MTCLogEntry) EntryData() []byte {
+	return e.entryData
 }
 
 // Marshal encodes the MTCLogEntry into TLS Presentation bytes.
@@ -59,7 +89,7 @@ type MTCLogEntry struct {
 // Returns an error if the extensions are not specs compliant, or if the
 // resulting bytes do not fit in a t-log leaf.
 func (e *MTCLogEntry) Marshal() ([]byte, error) {
-	if e.Type == MTCLogEntryTypeNull && len(e.EntryData) > 0 {
+	if e.entryType == MTCLogEntryTypeNull && len(e.entryData) > 0 {
 		return nil, errors.New("null entry must have empty EntryData")
 	}
 	// struct {} Empty;
@@ -90,9 +120,9 @@ func (e *MTCLogEntry) Marshal() ([]byte, error) {
 	// "The extensions list MUST appear in ascending order by extension_type and
 	// MUST NOT contain two extensions with the same extension_type."
 	b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
-		for i, ext := range e.Extensions {
+		for i, ext := range e.extensions {
 			if i > 0 {
-				prevType := e.Extensions[i-1].Type
+				prevType := e.extensions[i-1].Type
 				if ext.Type == prevType {
 					child.SetError(fmt.Errorf("duplicate extension type %d", ext.Type))
 					return
@@ -110,10 +140,10 @@ func (e *MTCLogEntry) Marshal() ([]byte, error) {
 		}
 	})
 
-	b.AddUint16(uint16(e.Type))
+	b.AddUint16(uint16(e.entryType))
 
 	// EntryData fills up the rest of the structure, no size prefix needed.
-	b.AddBytes(e.EntryData)
+	b.AddBytes(e.entryData)
 
 	res, err := b.Bytes()
 	if err != nil {

--- a/cmd/mtc/log/internal/entry/entry_test.go
+++ b/cmd/mtc/log/internal/entry/entry_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 
 	"golang.org/x/crypto/cryptobyte"
@@ -33,7 +34,7 @@ func (e *MTCLogEntry) unmarshal(data []byte) error {
 		return errors.New("malformed extension list length")
 	}
 
-	e.Extensions = nil
+	var extensions []MTCLogEntryExtension
 	for !extListStr.Empty() {
 		var ext MTCLogEntryExtension
 		if !extListStr.ReadUint16((*uint16)(&ext.Type)) {
@@ -44,55 +45,55 @@ func (e *MTCLogEntry) unmarshal(data []byte) error {
 			return fmt.Errorf("failed to read extension length")
 		}
 		ext.Data = append([]byte(nil), extDataStr...)
-		if n := len(e.Extensions); n > 0 {
-			if ext.Type < e.Extensions[n-1].Type {
-				return fmt.Errorf("mtc: entry extensions out of order (type %d after %d)", ext.Type, e.Extensions[n-1].Type)
+		if n := len(extensions); n > 0 {
+			if ext.Type < extensions[n-1].Type {
+				return fmt.Errorf("mtc: entry extensions out of order (type %d after %d)", ext.Type, extensions[n-1].Type)
 			}
-			if ext.Type == e.Extensions[n-1].Type {
+			if ext.Type == extensions[n-1].Type {
 				return fmt.Errorf("mtc: duplicate entry extension type %d", ext.Type)
 			}
 		}
-		e.Extensions = append(e.Extensions, ext)
+		extensions = append(extensions, ext)
 	}
 
-	if !s.ReadUint16((*uint16)(&e.Type)) {
+	var entryType EntryType
+	if !s.ReadUint16((*uint16)(&entryType)) {
 		return errors.New("missing entry type")
 	}
 
-	if e.Type != MTCLogEntryTypeNull && e.Type != MTCLogEntryTypeTBSCert {
-		return fmt.Errorf("unknown or unsupported log entry type %d", e.Type)
+	if entryType != MTCLogEntryTypeNull && entryType != MTCLogEntryTypeTBSCert {
+		return fmt.Errorf("unknown or unsupported log entry type %d", entryType)
 	}
 
-	if e.Type == MTCLogEntryTypeNull && !s.Empty() {
+	if entryType == MTCLogEntryTypeNull && !s.Empty() {
 		return fmt.Errorf("null entry must have empty data")
 	}
 
-	e.EntryData = append([]byte(nil), s...)
+	*e = MTCLogEntry{
+		extensions: extensions,
+		entryType:  entryType,
+		entryData:  slices.Clone(s),
+	}
 	return nil
 }
 
 func TestMTCLogEntry_RoundTrip(t *testing.T) {
 	tests := []struct {
 		name  string
-		entry MTCLogEntry
+		entry *MTCLogEntry
 	}{
 		{
-			name: "null entry no extensions",
-			entry: MTCLogEntry{
-				Type: MTCLogEntryTypeNull,
-			},
+			name:  "null entry no extensions",
+			entry: New(nil),
 		},
 		{
 			name: "tbs cert entry with sorted extensions",
-			entry: MTCLogEntry{
-				Type:      MTCLogEntryTypeTBSCert,
-				EntryData: []byte("fake-der-octets"),
-				Extensions: []MTCLogEntryExtension{
-					{Type: 1, Data: []byte("ext-1-data")},
-					{Type: 5, Data: []byte("ext-5-data")},
-					{Type: 10, Data: []byte("")},
-				},
-			},
+			entry: New(
+				[]byte("fake-der-octets"),
+				MTCLogEntryExtension{Type: 1, Data: []byte("ext-1-data")},
+				MTCLogEntryExtension{Type: 5, Data: []byte("ext-5-data")},
+				MTCLogEntryExtension{Type: 10, Data: []byte("")},
+			),
 		},
 	}
 
@@ -108,19 +109,21 @@ func TestMTCLogEntry_RoundTrip(t *testing.T) {
 				t.Fatalf("unmarshal() unexpected error: %v", err)
 			}
 
-			if got.Type != tc.entry.Type {
-				t.Errorf("Type = %d, want %d", got.Type, tc.entry.Type)
+			if got.Type() != tc.entry.Type() {
+				t.Errorf("Type() = %d, want %d", got.Type(), tc.entry.Type())
 			}
-			if !bytes.Equal(got.EntryData, tc.entry.EntryData) {
-				t.Errorf("EntryData = %x, want %x", got.EntryData, tc.entry.EntryData)
+			if !bytes.Equal(got.EntryData(), tc.entry.EntryData()) {
+				t.Errorf("EntryData() = %x, want %x", got.EntryData(), tc.entry.EntryData())
 			}
 
-			if len(got.Extensions) != len(tc.entry.Extensions) {
-				t.Fatalf("len(Extensions) = %d, want %d", len(got.Extensions), len(tc.entry.Extensions))
+			gotExts := got.Extensions()
+			wantExts := tc.entry.Extensions()
+			if len(gotExts) != len(wantExts) {
+				t.Fatalf("len(Extensions) = %d, want %d", len(gotExts), len(wantExts))
 			}
-			for i := range got.Extensions {
-				if got.Extensions[i].Type != tc.entry.Extensions[i].Type || !bytes.Equal(got.Extensions[i].Data, tc.entry.Extensions[i].Data) {
-					t.Errorf("Extension[%d] = %+v, want %+v", i, got.Extensions[i], tc.entry.Extensions[i])
+			for i := range gotExts {
+				if gotExts[i].Type != wantExts[i].Type || !bytes.Equal(gotExts[i].Data, wantExts[i].Data) {
+					t.Errorf("Extension[%d] = %+v, want %+v", i, gotExts[i], wantExts[i])
 				}
 			}
 		})
@@ -128,58 +131,49 @@ func TestMTCLogEntry_RoundTrip(t *testing.T) {
 }
 
 func TestMTCLogEntry_MarshalErrors(t *testing.T) {
+	nullWithData := New([]byte("unexpected-data"))
+	nullWithData.entryType = MTCLogEntryTypeNull
+
 	tests := []struct {
 		name    string
-		entry   MTCLogEntry
+		entry   *MTCLogEntry
 		wantErr bool
 	}{
 		{
-			name: "trailing data on null entry",
-			entry: MTCLogEntry{
-				Type:      MTCLogEntryTypeNull,
-				EntryData: []byte("unexpected-data"),
-			},
+			name:    "trailing data on null entry",
+			entry:   nullWithData,
 			wantErr: true,
 		},
 		{
 			name: "duplicate extensions with same data",
-			entry: MTCLogEntry{
-				Type: MTCLogEntryTypeTBSCert,
-				Extensions: []MTCLogEntryExtension{
-					{Type: 2, Data: []byte("data-a")},
-					{Type: 2, Data: []byte("data-a")},
-				},
-			},
+			entry: New(
+				[]byte("fake-der"),
+				MTCLogEntryExtension{Type: 2, Data: []byte("data-a")},
+				MTCLogEntryExtension{Type: 2, Data: []byte("data-a")},
+			),
 			wantErr: true,
 		},
 		{
 			name: "duplicate extensions with different data",
-			entry: MTCLogEntry{
-				Type: MTCLogEntryTypeTBSCert,
-				Extensions: []MTCLogEntryExtension{
-					{Type: 2, Data: []byte("data-a")},
-					{Type: 2, Data: []byte("data-b")},
-				},
-			},
+			entry: New(
+				[]byte("fake-der"),
+				MTCLogEntryExtension{Type: 2, Data: []byte("data-a")},
+				MTCLogEntryExtension{Type: 2, Data: []byte("data-b")},
+			),
 			wantErr: true,
 		},
 		{
 			name: "unsorted extensions",
-			entry: MTCLogEntry{
-				Type: MTCLogEntryTypeTBSCert,
-				Extensions: []MTCLogEntryExtension{
-					{Type: 5, Data: []byte("data-5")},
-					{Type: 1, Data: []byte("data-1")},
-				},
-			},
+			entry: New(
+				[]byte("fake-der"),
+				MTCLogEntryExtension{Type: 5, Data: []byte("data-5")},
+				MTCLogEntryExtension{Type: 1, Data: []byte("data-1")},
+			),
 			wantErr: true,
 		},
 		{
-			name: "entry size exceeds tile limit",
-			entry: MTCLogEntry{
-				Type:      MTCLogEntryTypeTBSCert,
-				EntryData: make([]byte, MaxMTCLogEntrySize),
-			},
+			name:    "entry size exceeds tile limit",
+			entry:   New(make([]byte, MaxMTCLogEntrySize)),
 			wantErr: true,
 		},
 	}
@@ -210,7 +204,7 @@ func TestMTCLogEntry_UnmarshalErrors(t *testing.T) {
 		{
 			name: "trailing data on null entry",
 			mutate: func(b []byte) []byte {
-				e := MTCLogEntry{Type: MTCLogEntryTypeNull}
+				e := New(nil)
 				data, _ := e.Marshal()
 				return append(data, 0x00)
 			},

--- a/cmd/mtc/log/internal/handler/handlers.go
+++ b/cmd/mtc/log/internal/handler/handlers.go
@@ -16,18 +16,27 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 
 	"github.com/transparency-dev/tessera/cmd/mtc/log"
 )
 
-type addTBS func(context.Context, log.TBSCertificateLogEntry) (uint64, log.MTCProof, error)
+const (
+	// maxAddTBSRequestBodyBytes is the maximum allowed HTTP request body size
+	// (128 KiB) for JSON submissions. This accommodates base64 encoding and JSON
+	// formatting overhead for certificates up to 64 KiB binary size.
+	maxAddTBSRequestBodyBytes = 128 << 10
+)
+
+type addTBS func(context.Context, log.TBSCertificateLogEntry) (*log.AddTBSRsp, error)
 
 // New returns a new http.Handler for the mtc-tlog service.
 func New(mtcLog *log.MTCLog) http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /add-tbs", addTBSHandler(mtcLog.AddTBS))
+	mux.Handle("POST /add-tbs", http.MaxBytesHandler(addTBSHandler(mtcLog.AddTBS), maxAddTBSRequestBodyBytes))
 	mux.HandleFunc("GET /proof-to-landmark", func(w http.ResponseWriter, r *http.Request) {
 		// TODO parse request
 		// TODO write response
@@ -39,14 +48,45 @@ func New(mtcLog *log.MTCLog) http.Handler {
 	return mux
 }
 
-// addTBSHandler returns a handler which logs a DER-encoded TBSCertificateLogEntry.
-func addTBSHandler(add addTBS) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// TODO: parse request
-		// TODO: write response
-		if _, _, err := add(r.Context(), log.TBSCertificateLogEntry{}); err != nil {
-			slog.ErrorContext(r.Context(), "Failed to add entry to MTC log", slog.Any("error", err))
+// addTBSHandler returns a handler which logs a TBSCertificateLogEntry.
+//
+// This handler:
+//
+//   - Accepts JSON-Encoded TBSCertificateLogentry, serializes it in
+//     DER format, encapsulates it in a TLS encoded MTCLogEntry, and logs it
+//     using the argument add function.
+//   - Returns an AddTBSRsp JSON payload containing an index and an MTCProof.
+func addTBSHandler(add addTBS) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := r.Body.Close(); err != nil {
+				slog.ErrorContext(r.Context(), "resp.Body.Close()", slog.Any("error", err))
+			}
+		}()
+
+		var entry log.TBSCertificateLogEntry
+		if err := json.NewDecoder(r.Body).Decode(&entry); err != nil {
+			slog.WarnContext(r.Context(), "rejection: malformed JSON submission", slog.Any("error", err))
+			http.Error(w, "Invalid TBSCertificateLogEntry JSON payload", http.StatusBadRequest)
+			return
 		}
-		http.Error(w, "not implemented", http.StatusNotImplemented)
-	}
+		if err := entry.Validate(); err != nil {
+			slog.WarnContext(r.Context(), "rejection: invalid TBSCertificateLogEntry fields", slog.Any("error", err))
+			http.Error(w, fmt.Sprintf("Invalid TBSCertificateLogEntry: %v", err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		rsp, err := add(r.Context(), entry)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "failed to add entry to MTC log", slog.Any("error", err))
+			http.Error(w, "Could not add entry to log", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(rsp); err != nil {
+			slog.ErrorContext(r.Context(), "failed to write response", slog.Any("error", err))
+		}
+	})
 }

--- a/cmd/mtc/log/internal/handler/handlers_test.go
+++ b/cmd/mtc/log/internal/handler/handlers_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/cmd/mtc/log"
+	tposix "github.com/transparency-dev/tessera/storage/posix"
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/cryptobyte/asn1"
+	"golang.org/x/mod/sumdb/note"
+)
+
+func setupTestLog(t *testing.T) *log.MTCLog {
+	t.Helper()
+	ctx := t.Context()
+	storageDir := t.TempDir()
+
+	driver, err := tposix.New(ctx, tposix.Config{Path: storageDir})
+	if err != nil {
+		t.Fatalf("Failed to initialize POSIX storage: %v", err)
+	}
+
+	sk := "PRIVATE+KEY+example.com/log/testdata+33d7b496+AeymY/SZAX0jZcJ8enZ5FY1Dz+wTML2yWSkK+9DSF3eg"
+	signer, err := note.NewSigner(sk)
+	if err != nil {
+		t.Fatalf("Failed to create test signer: %v", err)
+	}
+
+	opts := tessera.NewAppendOptions().WithCheckpointSigner(signer)
+	appender, _, _, err := tessera.NewAppender(ctx, driver, opts)
+	if err != nil {
+		t.Fatalf("Failed to initialize Tessera appender: %v", err)
+	}
+
+	return log.NewMTCLog(ctx, appender)
+}
+
+func dummySeq(data string) []byte {
+	var b cryptobyte.Builder
+	b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+		b.AddBytes([]byte(data))
+	})
+	return b.BytesOrPanic()
+}
+
+func dummyTag(tag asn1.Tag, data []byte) []byte {
+	var b cryptobyte.Builder
+	b.AddASN1(tag, func(b *cryptobyte.Builder) {
+		b.AddBytes(data)
+	})
+	return b.BytesOrPanic()
+}
+
+func validEntry() log.TBSCertificateLogEntry {
+	return log.TBSCertificateLogEntry{
+		Version:                   0,
+		Issuer:                    dummySeq("issuer"),
+		Validity:                  dummySeq("validity"),
+		Subject:                   dummySeq("subject"),
+		SubjectPublicKeyAlgorithm: dummySeq("algo"),
+		SubjectPublicKeyInfoHash:  make([]byte, sha256.Size),
+	}
+}
+
+func TestAddTBSHandler(t *testing.T) {
+	mtcLog := setupTestLog(t)
+
+	validJSON, err := json.Marshal(validEntry())
+	if err != nil {
+		t.Fatalf("failed to marshal valid entry: %v", err)
+	}
+
+	missingIssuer := validEntry()
+	missingIssuer.Issuer = nil
+	missingIssuerJSON, _ := json.Marshal(missingIssuer)
+
+	badHashSize := validEntry()
+	badHashSize.SubjectPublicKeyInfoHash = make([]byte, 10)
+	badHashSizeJSON, _ := json.Marshal(badHashSize)
+
+	largeEntry := validEntry()
+	largeEntry.Extensions = dummyTag(asn1.Tag(3).ContextSpecific().Constructed(), bytes.Repeat([]byte("a"), 128*1024))
+	largeJSON, _ := json.Marshal(largeEntry)
+
+	tests := []struct {
+		name       string
+		body       func() io.Reader
+		addFunc    addTBS
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "success",
+			body:       func() io.Reader { return bytes.NewReader(validJSON) },
+			wantStatus: http.StatusCreated,
+			wantBody:   `{"index":0,"mtcproof":{}}`,
+		},
+		{
+			name:       "malformed json",
+			body:       func() io.Reader { return strings.NewReader("not-a-json-payload") },
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "Invalid TBSCertificateLogEntry JSON payload",
+		},
+		{
+			name:       "invalid entry fields missing issuer",
+			body:       func() io.Reader { return bytes.NewReader(missingIssuerJSON) },
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "Invalid TBSCertificateLogEntry",
+		},
+		{
+			name:       "invalid entry fields wrong hash size",
+			body:       func() io.Reader { return bytes.NewReader(badHashSizeJSON) },
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "subjectPublicKeyInfoHash must be 32 bytes",
+		},
+		{
+			name: "add function error",
+			body: func() io.Reader { return bytes.NewReader(validJSON) },
+			addFunc: func(ctx context.Context, entry log.TBSCertificateLogEntry) (*log.AddTBSRsp, error) {
+				return nil, errors.New("storage error")
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantBody:   "Could not add entry to log",
+		},
+		{
+			name:       "payload too large",
+			body:       func() io.Reader { return bytes.NewReader(largeJSON) },
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/add-tbs", tc.body())
+			w := httptest.NewRecorder()
+
+			var h http.Handler
+			if tc.addFunc != nil {
+				h = http.MaxBytesHandler(addTBSHandler(tc.addFunc), maxAddTBSRequestBodyBytes)
+			} else {
+				h = New(mtcLog)
+			}
+			h.ServeHTTP(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Errorf("want status %d, got %d: %s", tc.wantStatus, w.Code, w.Body.String())
+			}
+			if tc.wantBody != "" && !strings.Contains(w.Body.String(), tc.wantBody) {
+				t.Errorf("want body containing %q, got %q", tc.wantBody, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestNew_Routes(t *testing.T) {
+	mtcLog := setupTestLog(t)
+	h := New(mtcLog)
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		body       func() io.Reader
+		wantStatus int
+	}{
+		{
+			name:       "POST /add-tbs valid method routes correctly",
+			method:     http.MethodPost,
+			path:       "/add-tbs",
+			body:       func() io.Reader { return strings.NewReader("bad json") },
+			wantStatus: http.StatusBadRequest, // Proves routing reached addTBSHandler
+		},
+		{
+			name:       "GET /add-tbs invalid method",
+			method:     http.MethodGet,
+			path:       "/add-tbs",
+			body:       func() io.Reader { return nil },
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "GET /proof-to-landmark valid method",
+			method:     http.MethodGet,
+			path:       "/proof-to-landmark",
+			body:       func() io.Reader { return nil },
+			wantStatus: http.StatusNotImplemented,
+		},
+		{
+			name:       "POST /proof-to-landmark invalid method",
+			method:     http.MethodPost,
+			path:       "/proof-to-landmark",
+			body:       func() io.Reader { return nil },
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "unknown route",
+			method:     http.MethodGet,
+			path:       "/unknown",
+			body:       func() io.Reader { return nil },
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, tc.body())
+			w := httptest.NewRecorder()
+
+			h.ServeHTTP(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Errorf("%s %s: want status %d, got %d: %s", tc.method, tc.path, tc.wantStatus, w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/cmd/mtc/log/internal/handler/handlers_test.go
+++ b/cmd/mtc/log/internal/handler/handlers_test.go
@@ -117,7 +117,7 @@ func TestAddTBSHandler(t *testing.T) {
 			name:       "success",
 			body:       func() io.Reader { return bytes.NewReader(validJSON) },
 			wantStatus: http.StatusCreated,
-			wantBody:   `{"index":0,"mtcproof":{}}`,
+			wantBody:   `{"index":0,"mtcProof":{}}`,
 		},
 		{
 			name:       "malformed json",

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/entry"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
 )
@@ -32,6 +33,13 @@ type MTCLog struct {
 // MTCProof represents an MTC inclusion proof as per
 // draft-ietf-plants-merkle-tree-certs section 6.2.
 type MTCProof struct{}
+
+// AddTBSRsp contains enough information from the log
+// to build a standalone certificate.
+type AddTBSRsp struct {
+	Index    uint64   `json:"index"`
+	MTCProof MTCProof `json:"mtcproof"`
+}
 
 // TBSCertificateLogEntry represents a log entry as per
 // draft-ietf-plants-merkle-tree-certs section 7.2.
@@ -120,8 +128,7 @@ func validateASN1Element(data []byte, expectedTag asn1.Tag, fieldName string) er
 }
 
 // Validate checks that TBSCertificateLogEntry fields are correct.
-// It checks that mandatory fields are present, and that all fields are well
-// formatted.
+// It checks that mandatory fields are present, and that all fields are well formatted.
 func (e *TBSCertificateLogEntry) Validate() error {
 	if e.Version < 0 || e.Version > 2 {
 		return fmt.Errorf("invalid version %d", e.Version)
@@ -169,20 +176,48 @@ func (e *TBSCertificateLogEntry) Validate() error {
 	return nil
 }
 
+func (l *MTCLog) accept(tbs TBSCertificateLogEntry) error {
+	return tbs.Validate()
+}
+
 // NewMTCLog creates a new MTCLog compliant with
 // draft-ietf-plants-merkle-tree-certs and http://c2sp.org/mtc-tlog.
 func NewMTCLog(ctx context.Context, a *tessera.Appender) *MTCLog {
 	// TODO: schedule landmark publishing
-	return &MTCLog{a}
+	return &MTCLog{a: a}
 }
 
 // AddTBS adds a TBSCertificateLogEntry to the log.
-func (l *MTCLog) AddTBS(ctx context.Context, e TBSCertificateLogEntry) (uint64, MTCProof, error) {
-	// TODO: marshal
-	// TODO: add to log
+func (l *MTCLog) AddTBS(ctx context.Context, tbs TBSCertificateLogEntry) (*AddTBSRsp, error) {
+	if err := l.accept(tbs); err != nil {
+		return nil, fmt.Errorf("invalid entry: %w", err)
+	}
+
+	tbsb, err := tbs.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshal contents: %w", err)
+	}
+
+	e := entry.New(tbsb)
+	eb, err := e.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %v", err)
+	}
+
+	future := l.a.Add(ctx, tessera.NewEntry(eb))
+
+	index, err := future()
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve tessera future: %v", err)
+	}
+
 	// TODO: get subtree cosignatures
 	// TODO: build MTCProof
-	return 0, MTCProof{}, nil
+
+	return &AddTBSRsp{
+		Index:    index.Index,
+		MTCProof: MTCProof{},
+	}, nil
 }
 
 // ProofToLandmark builds an MTCProof for the entry at idx to a

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -38,7 +38,7 @@ type MTCProof struct{}
 // to build a standalone certificate.
 type AddTBSRsp struct {
 	Index    uint64   `json:"index"`
-	MTCProof MTCProof `json:"mtcproof"`
+	MTCProof MTCProof `json:"mtcProof"`
 }
 
 // TBSCertificateLogEntry represents a log entry as per


### PR DESCRIPTION
Towards #945.

This PR also make `MTCLogEntry` fields private, and introduces a `New` function to create these objects.
We could, in a followup PR move the extension checks to it.. they are not used at the moment, so this this is not super important.