### PR TITLE
Mirror client fixes

### DIFF
--- a/client/mirror/client.go
+++ b/client/mirror/client.go
@@ -489,27 +489,45 @@ func (c *Client) Sync(ctx context.Context, targetCheckpointRaw []byte, targetSiz
 	// targetSize must equal the size of the tree that targetCheckpointRaw represents; since we're attempting
 	// to fetch a cosig for this checkpoint from the mirror, it's meaningless to upload any further.
 	uploadEnd := targetSize
+	uploadStart := c.nextEntry
 
 	var cosigs []byte
 	for {
 		var err error
-		cosigs, err = c.pushEntries(ctx, c.nextEntry, uploadEnd, c.ticket)
+		cosigs, err = c.pushEntries(ctx, uploadStart, uploadEnd, c.ticket)
 		if err != nil {
 			var conflict ErrConflict
 			if !errors.As(err, &conflict) {
 				return nil, fmt.Errorf("sync failed during entry upload: %v", err)
 			}
 
-			uploadEnd = conflict.PendingSize
-			c.nextEntry = conflict.NextEntry
+			// Update our view of the mirror state in light of the conflict, and figure out what to do next.
 			c.ticket = conflict.Ticket
+			c.nextEntry = conflict.NextEntry
+			if c.nextEntry >= uploadEnd {
+				// The mirror has moved on from at least our nextEntry (and may have caught up with uploadEnd).
+				// We'll try a zero-sized request to get a cosig on our checkpoint.
 
-			if uploadEnd < targetSize {
-				return nil, fmt.Errorf("mirror size reverted to %d, which is smaller than target %d", uploadEnd, targetSize)
+				// Check if a previous zero-sized request returned a conflict.
+				if uploadStart == uploadEnd {
+					// If so this means that the mirror has already moved on from the checkpoint we're trying to upload, so we're done.
+					return nil, fmt.Errorf("mirror rejected checkpoint size %d: %w", uploadEnd, conflict)
+				}
+
+				// Since the mirror already has all the entries covered by the checkpoint we're currently trying to upload, set
+				// uploadStart to uploadEnd to perform a zero-sized update on the next iteration.
+				uploadStart = uploadEnd
+				continue
+			}
+			uploadStart = c.nextEntry
+
+			if conflict.PendingSize < targetSize {
+				return nil, fmt.Errorf("mirror size reverted to %d, which is smaller than target %d", conflict.PendingSize, targetSize)
 			}
 			continue
 		}
-		c.nextEntry = uploadEnd
+		// We've successfully uploaded our entries, so keep track of which entries we now know the mirror has.
+		c.nextEntry = max(c.nextEntry, uploadEnd)
 
 		break
 	}

--- a/client/mirror/client.go
+++ b/client/mirror/client.go
@@ -315,6 +315,10 @@ func (c *Client) streamEntries(ctx context.Context, uploadStart, uploadEnd uint6
 		startIdx := curr % 256
 		endIdx := startIdx + numEntries
 
+		if uint64(len(bundle.Entries)) < endIdx {
+			_ = pw.CloseWithError(fmt.Errorf("bundle %d has only %d entries, expected at least %d", bundleIndex, len(bundle.Entries), endIdx))
+			return
+		}
 		for i := startIdx; i < endIdx; i++ {
 			entry := bundle.Entries[i]
 			if err := binary.Write(gw, binary.BigEndian, uint16(len(entry))); err != nil {
@@ -443,10 +447,14 @@ func (c *Client) buildCheckpointRequestBody(oldSize uint64, proof [][]byte, chec
 // up to the specified targetSize. It returns the mirror's cosignatures on success.
 func (c *Client) Sync(ctx context.Context, targetCheckpointRaw []byte, targetSize uint64) ([]byte, error) {
 	var conflict ErrConflict
-	nextEntry := c.oldSize
+	var nextEntry uint64
 
 	// Push the checkpoint with the old size (0 if not provided).
-	for c.oldSize < targetSize {
+	// Keep trying for as long we we get conflict errors or the context is not cancelled.
+	// Ensure we send the checkpoint at least once, this serves two purposes:
+	// 1. We refresh the witness' timestamped view of the log, committing to the fact that the log hasn't grown.
+	// 2. If this is the first time we're pushing the checkpoint (i.e. c.oldSize == 0), we're ensuring that we'll send a zero-sized checkpoint.
+	for {
 		err := c.pushCheckpoint(ctx, c.oldSize, targetSize, targetCheckpointRaw)
 		if err != nil {
 			if !errors.As(err, &conflict) {
@@ -458,6 +466,7 @@ func (c *Client) Sync(ctx context.Context, targetCheckpointRaw []byte, targetSiz
 
 		nextEntry = c.oldSize
 		c.oldSize = targetSize
+		break
 	}
 
 	// Push entries up to target size in packages of 256, handling concurrent conflicts and retries.

--- a/client/mirror/client.go
+++ b/client/mirror/client.go
@@ -464,7 +464,7 @@ func (c *Client) Sync(ctx context.Context, targetCheckpointRaw []byte, targetSiz
 	// 2. If this is the first time we're pushing the checkpoint (i.e. c.oldCPSize == 0), we're ensuring that we'll send a zero-sized checkpoint.
 	//
 	// This section _only_ deals with the checkpoint and does not upload any entries. It's important to bear in mind that this means
-	// that getting a conflict here doesn't necessarily mean that the mirror actually _has_ tne entries implied by the returned checkpoint
+	// that getting a conflict here doesn't necessarily mean that the mirror actually _has_ the entries implied by the returned checkpoint
 	// size - they may not have yet been uploaded by a client, so we cannot use this value to infer anything about what the mirror's
 	// nextEntry value might be - we'll figure that out below.
 	for {
@@ -474,7 +474,7 @@ func (c *Client) Sync(ctx context.Context, targetCheckpointRaw []byte, targetSiz
 			if !errors.As(err, &stale) {
 				return nil, fmt.Errorf("failed to push checkpoint: %v", err)
 			}
-			c.oldCPSize = max(c.oldCPSize, stale.OldSize)
+			c.oldCPSize = stale.OldSize
 			if c.oldCPSize > targetSize {
 				break
 			}

--- a/client/mirror/client.go
+++ b/client/mirror/client.go
@@ -133,8 +133,9 @@ type Client struct {
 
 	// TODO(roger2hk): Add a mutex just in case client is used across multiple goroutines.
 	// State of the mirror.
-	oldSize uint64
-	ticket  []byte
+	oldCPSize uint64
+	nextEntry uint64
+	ticket    []byte
 }
 
 // NewClient creates a new Client with the provided options.
@@ -155,6 +156,16 @@ func NewClient(_ context.Context, opts *Options) (*Client, error) {
 	}
 
 	return &Client{opts: opts}, nil
+}
+
+// ErrCheckpointStale is returned by the tlog-mirror client when the old-size sent to `add-checkpoint` does not match
+// the witness's current checkpoint size.
+type ErrCheckpointStale struct {
+	OldSize uint64
+}
+
+func (e ErrCheckpointStale) Error() string {
+	return fmt.Sprintf("checkpoint stale: old size %d", e.OldSize)
 }
 
 // ErrConflict is returned by tlog-mirror client operations when the mirror returns a 409 Conflict.
@@ -407,8 +418,8 @@ func (c *Client) pushCheckpoint(ctx context.Context, oldSize, targetSize uint64,
 			}
 			slog.InfoContext(ctx, "Witness replied with x.tlog.size different than our hint", slog.String("url", u.String()), slog.Uint64("reply", newWitSize), slog.Uint64("hinted", oldSize))
 
-			return ErrConflict{
-				PendingSize: newWitSize,
+			return ErrCheckpointStale{
+				OldSize: newWitSize,
 			}
 		}
 	}
@@ -446,52 +457,61 @@ func (c *Client) buildCheckpointRequestBody(oldSize uint64, proof [][]byte, chec
 // Sync synchronizes all entries and the checkpoint from the source log to the mirror
 // up to the specified targetSize. It returns the mirror's cosignatures on success.
 func (c *Client) Sync(ctx context.Context, targetCheckpointRaw []byte, targetSize uint64) ([]byte, error) {
-	var conflict ErrConflict
-	var nextEntry uint64
-
 	// Push the checkpoint with the old size (0 if not provided).
-	// Keep trying for as long we we get conflict errors or the context is not cancelled.
+	// Keep trying for as long as we get conflict errors (until the context expires).
 	// Ensure we send the checkpoint at least once, this serves two purposes:
-	// 1. We refresh the witness' timestamped view of the log, committing to the fact that the log hasn't grown.
-	// 2. If this is the first time we're pushing the checkpoint (i.e. c.oldSize == 0), we're ensuring that we'll send a zero-sized checkpoint.
+	// 1. We refresh the mirror's timestamped view of the log, committing to the fact that the log hasn't grown.
+	// 2. If this is the first time we're pushing the checkpoint (i.e. c.oldCPSize == 0), we're ensuring that we'll send a zero-sized checkpoint.
+	//
+	// This section _only_ deals with the checkpoint and does not upload any entries. It's important to bear in mind that this means
+	// that getting a conflict here doesn't necessarily mean that the mirror actually _has_ tne entries implied by the returned checkpoint
+	// size - they may not have yet been uploaded by a client, so we cannot use this value to infer anything about what the mirror's
+	// nextEntry value might be - we'll figure that out below.
 	for {
-		err := c.pushCheckpoint(ctx, c.oldSize, targetSize, targetCheckpointRaw)
+		err := c.pushCheckpoint(ctx, c.oldCPSize, targetSize, targetCheckpointRaw)
 		if err != nil {
-			if !errors.As(err, &conflict) {
+			var stale ErrCheckpointStale
+			if !errors.As(err, &stale) {
 				return nil, fmt.Errorf("failed to push checkpoint: %v", err)
 			}
-			c.oldSize = max(c.oldSize, conflict.PendingSize)
+			c.oldCPSize = max(c.oldCPSize, stale.OldSize)
+			if c.oldCPSize > targetSize {
+				break
+			}
 			continue
 		}
 
-		nextEntry = c.oldSize
-		c.oldSize = targetSize
+		c.oldCPSize = targetSize
 		break
 	}
 
 	// Push entries up to target size in packages of 256, handling concurrent conflicts and retries.
-	uploadEnd := max(targetSize, c.oldSize)
+	// targetSize must equal the size of the tree that targetCheckpointRaw represents; since we're attempting
+	// to fetch a cosig for this checkpoint from the mirror, it's meaningless to upload any further.
+	uploadEnd := targetSize
 
 	var cosigs []byte
 	for {
 		var err error
-		cosigs, err = c.pushEntries(ctx, nextEntry, uploadEnd, c.ticket)
-		if err == nil {
-			break
-		}
+		cosigs, err = c.pushEntries(ctx, c.nextEntry, uploadEnd, c.ticket)
+		if err != nil {
+			var conflict ErrConflict
+			if !errors.As(err, &conflict) {
+				return nil, fmt.Errorf("sync failed during entry upload: %v", err)
+			}
 
-		if !errors.As(err, &conflict) {
-			return nil, fmt.Errorf("sync failed during entry upload: %v", err)
-		}
+			uploadEnd = conflict.PendingSize
+			c.nextEntry = conflict.NextEntry
+			c.ticket = conflict.Ticket
 
-		uploadEnd = conflict.PendingSize
-		nextEntry = conflict.NextEntry
-		c.ticket = conflict.Ticket
-		c.oldSize = conflict.PendingSize
-
-		if uploadEnd < targetSize {
-			return nil, fmt.Errorf("mirror size reverted to %d, which is smaller than target %d", uploadEnd, targetSize)
+			if uploadEnd < targetSize {
+				return nil, fmt.Errorf("mirror size reverted to %d, which is smaller than target %d", uploadEnd, targetSize)
+			}
+			continue
 		}
+		c.nextEntry = uploadEnd
+
+		break
 	}
 
 	return cosigs, nil

--- a/client/mirror/client_test.go
+++ b/client/mirror/client_test.go
@@ -925,9 +925,12 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 					status: http.StatusConflict,
 					body:   "10\n8\ndGlja2V0LW5ldw==\n",
 				},
+				// The client should attempt to get a cosig for the checkpoint it's currently trying to upload.
+				// Since all entries are already on the mirror, this will look like an zero-length upload starting and ending
+				// at the checkpoint size.
 				{
-					start:  8,
-					end:    10,
+					start:  5,
+					end:    5,
 					ticket: []byte("ticket-new"),
 					status: http.StatusOK,
 				},
@@ -941,6 +944,37 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 				}
 				return buf.Bytes(), nil
 			},
+		},
+		{
+			desc:               "mirror pending size greater than target size and rejects zero-length upload",
+			initialPendingSize: 10,
+			initialNextEntry:   8,
+			addEntriesExpectations: []addEntriesExpectation{
+				{
+					start:  0,
+					end:    5,
+					ticket: nil,
+					status: http.StatusConflict,
+					body:   "10\n8\ndGlja2V0LW5ldw==\n",
+				},
+				{
+					start:  5,
+					end:    5,
+					ticket: []byte("ticket-new"),
+					status: http.StatusConflict,
+					body:   "10\n8\ndGlja2V0LW5ldw==\n",
+				},
+			},
+			bundleFetcher: func(ctx context.Context, bundleIndex uint64, p uint8) ([]byte, error) {
+				var buf bytes.Buffer
+				for i := range 10 {
+					entry := fmt.Appendf(nil, "entry-%d", i)
+					_ = binary.Write(&buf, binary.BigEndian, uint16(len(entry)))
+					buf.Write(entry)
+				}
+				return buf.Bytes(), nil
+			},
+			wantErr: "mirror rejected checkpoint size 5",
 		},
 		{
 			desc:               "bundle has fewer entries than expected",

--- a/client/mirror/client_test.go
+++ b/client/mirror/client_test.go
@@ -631,6 +631,12 @@ func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
+		if oldSize > uint64(fm.numEntries) {
+			w.Header().Set("Content-Type", "text/x.tlog.size")
+			w.WriteHeader(http.StatusConflict)
+			_, _ = fmt.Fprintf(w, "%d\n", fm.initialPendingSize)
+			return
+		}
 		if oldSize != fm.initialPendingSize {
 			w.Header().Set("Content-Type", "text/x.tlog.size")
 			w.WriteHeader(http.StatusConflict)
@@ -817,7 +823,7 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 		{
 			desc:               "consistency proof succeeds and checkpoint push succeeds",
 			initialPendingSize: 1,
-			initialNextEntry:   1,
+			initialNextEntry:   0,
 			tileFetcher: func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
 				if p == 5 {
 					return make([]byte, 5*32), nil
@@ -826,7 +832,7 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 			},
 			addEntriesExpectations: []addEntriesExpectation{
 				{
-					start:  1,
+					start:  0,
 					end:    5,
 					ticket: nil,
 					status: http.StatusOK,
@@ -906,6 +912,35 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 				},
 			},
 			wantErr: "mirror size reverted to 2, which is smaller than target 5",
+		},
+		{
+			desc:               "mirror pending size greater than target size",
+			initialPendingSize: 10,
+			initialNextEntry:   8,
+			addEntriesExpectations: []addEntriesExpectation{
+				{
+					start:  0,
+					end:    5,
+					ticket: nil,
+					status: http.StatusConflict,
+					body:   "10\n8\ndGlja2V0LW5ldw==\n",
+				},
+				{
+					start:  8,
+					end:    10,
+					ticket: []byte("ticket-new"),
+					status: http.StatusOK,
+				},
+			},
+			bundleFetcher: func(ctx context.Context, bundleIndex uint64, p uint8) ([]byte, error) {
+				var buf bytes.Buffer
+				for i := range 10 {
+					entry := fmt.Appendf(nil, "entry-%d", i)
+					_ = binary.Write(&buf, binary.BigEndian, uint16(len(entry)))
+					buf.Write(entry)
+				}
+				return buf.Bytes(), nil
+			},
 		},
 		{
 			desc:               "bundle has fewer entries than expected",

--- a/client/mirror/client_test.go
+++ b/client/mirror/client_test.go
@@ -403,6 +403,7 @@ type fakeMirror struct {
 	initialStatus          int
 	addEntriesExpectations []addEntriesExpectation
 	addEntriesCallCount    int
+	expectClientError      bool
 }
 
 type addEntriesExpectation struct {
@@ -428,6 +429,13 @@ func newFakeMirror(t *testing.T, origin string) *fakeMirror {
 	}
 }
 
+func (fm *fakeMirror) handleReadError(err error, msg string, w http.ResponseWriter) {
+	if !fm.expectClientError {
+		fm.t.Errorf("%s: %v", msg, err)
+	}
+	w.WriteHeader(http.StatusBadRequest)
+}
+
 // ServeHTTP handles incoming HTTP requests to mock mirror endpoints (/add-entries, /add-checkpoint).
 func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
@@ -439,8 +447,7 @@ func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		gr, err := gzip.NewReader(r.Body)
 		if err != nil {
-			fm.t.Errorf("gzip.NewReader failed: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
+			fm.handleReadError(err, "gzip.NewReader failed", w)
 			return
 		}
 		defer func() {
@@ -449,14 +456,12 @@ func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		var originLen uint16
 		if err := binary.Read(gr, binary.BigEndian, &originLen); err != nil {
-			fm.t.Errorf("failed to read origin length: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
+			fm.handleReadError(err, "failed to read origin length", w)
 			return
 		}
 		gotOrigin := make([]byte, originLen)
 		if _, err := io.ReadFull(gr, gotOrigin); err != nil {
-			fm.t.Errorf("failed to read origin: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
+			fm.handleReadError(err, "failed to read origin", w)
 			return
 		}
 		if string(gotOrigin) != fm.origin {
@@ -465,26 +470,22 @@ func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		var start uint64
 		if err := binary.Read(gr, binary.BigEndian, &start); err != nil {
-			fm.t.Errorf("failed to read start: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
+			fm.handleReadError(err, "failed to read start", w)
 			return
 		}
 		var end uint64
 		if err := binary.Read(gr, binary.BigEndian, &end); err != nil {
-			fm.t.Errorf("failed to read end: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
+			fm.handleReadError(err, "failed to read end", w)
 			return
 		}
 		var gotTicketLen uint16
 		if err := binary.Read(gr, binary.BigEndian, &gotTicketLen); err != nil {
-			fm.t.Errorf("failed to read ticket length: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
+			fm.handleReadError(err, "failed to read ticket length", w)
 			return
 		}
 		gotTicket := make([]byte, gotTicketLen)
 		if _, err := io.ReadFull(gr, gotTicket); err != nil {
-			fm.t.Errorf("failed to read ticket: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
+			fm.handleReadError(err, "failed to read ticket", w)
 			return
 		}
 
@@ -539,14 +540,12 @@ func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		for i := range numExpectedEntries {
 			var entryLen uint16
 			if err := binary.Read(gr, binary.BigEndian, &entryLen); err != nil {
-				fm.t.Errorf("failed to read entry %d length: %v", i, err)
-				w.WriteHeader(http.StatusBadRequest)
+				fm.handleReadError(err, fmt.Sprintf("failed to read entry %d length", i), w)
 				return
 			}
 			entry := make([]byte, entryLen)
 			if _, err := io.ReadFull(gr, entry); err != nil {
-				fm.t.Errorf("failed to read entry %d: %v", i, err)
-				w.WriteHeader(http.StatusBadRequest)
+				fm.handleReadError(err, fmt.Sprintf("failed to read entry %d", i), w)
 				return
 			}
 			expectedEntry := fmt.Appendf(nil, "entry-%d", i+int(start))
@@ -557,28 +556,28 @@ func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		var numHashes uint8
-		if err := binary.Read(gr, binary.BigEndian, &numHashes); err != nil {
-			fm.t.Errorf("failed to read numHashes: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		if int(numHashes) != len(fm.proofHashes) {
-			fm.t.Errorf("numHashes = %d, want %d", numHashes, len(fm.proofHashes))
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		for i, expectedHash := range fm.proofHashes {
-			gotHash := make([]byte, 32)
-			if _, err := io.ReadFull(gr, gotHash); err != nil {
-				fm.t.Errorf("failed to read hash %d: %v", i, err)
+		if start < end {
+			var numHashes uint8
+			if err := binary.Read(gr, binary.BigEndian, &numHashes); err != nil {
+				fm.handleReadError(err, "failed to read numHashes", w)
+				return
+			}
+			if int(numHashes) != len(fm.proofHashes) {
+				fm.t.Errorf("numHashes = %d, want %d", numHashes, len(fm.proofHashes))
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
-			if !bytes.Equal(gotHash, expectedHash) {
-				fm.t.Errorf("hash %d = %x, want %x", i, gotHash, expectedHash)
-				w.WriteHeader(http.StatusBadRequest)
-				return
+			for i, expectedHash := range fm.proofHashes {
+				gotHash := make([]byte, 32)
+				if _, err := io.ReadFull(gr, gotHash); err != nil {
+					fm.handleReadError(err, fmt.Sprintf("failed to read hash %d", i), w)
+					return
+				}
+				if !bytes.Equal(gotHash, expectedHash) {
+					fm.t.Errorf("hash %d = %x, want %x", i, gotHash, expectedHash)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
 			}
 		}
 
@@ -638,7 +637,7 @@ func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			_, _ = fmt.Fprintf(w, "%d\n", fm.initialPendingSize)
 			return
 		}
-		if oldSize > 0 && len(headerLines) <= 1 {
+		if oldSize > 0 && oldSize < uint64(fm.numEntries) && len(headerLines) <= 1 {
 			fm.t.Errorf("expected consistency proof lines in header")
 			w.WriteHeader(http.StatusBadRequest)
 			return
@@ -665,65 +664,130 @@ func (fm *fakeMirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // checkpoint updating, and entry streaming.
 func TestSync(t *testing.T) {
 	origin := "test-origin"
-	fm := newFakeMirror(t, origin)
-	fm.addEntriesExpectations = []addEntriesExpectation{
+
+	type syncStep struct {
+		checkpoint   []byte
+		targetSize   uint64
+		beforeSync   func(fm *fakeMirror)
+		expectCosigs []byte
+	}
+
+	for _, tc := range []struct {
+		desc                   string
+		addEntriesExpectations []addEntriesExpectation
+		steps                  []syncStep
+	}{
 		{
-			start:  0,
-			end:    uint64(fm.numEntries),
-			ticket: nil,
-			status: http.StatusOK,
+			desc: "single sync",
+			addEntriesExpectations: []addEntriesExpectation{
+				{
+					start:  0,
+					end:    5,
+					ticket: nil,
+					status: http.StatusOK,
+				},
+			},
+			steps: []syncStep{
+				{
+					checkpoint:   []byte("checkpoint-raw-bytes"),
+					targetSize:   5,
+					expectCosigs: []byte("mock-cosignatures"),
+				},
+			},
 		},
-	}
-	server := httptest.NewServer(fm)
-	defer server.Close()
+		{
+			desc: "sync twice",
+			addEntriesExpectations: []addEntriesExpectation{
+				{
+					start:  0,
+					end:    5,
+					ticket: nil,
+					status: http.StatusOK,
+				},
+				{
+					start:  5,
+					end:    5,
+					ticket: nil,
+					status: http.StatusOK,
+				},
+			},
+			steps: []syncStep{
+				{
+					checkpoint:   []byte("checkpoint-raw-bytes"),
+					targetSize:   5,
+					expectCosigs: []byte("mock-cosignatures"),
+				},
+				{
+					checkpoint:   []byte("checkpoint-raw-bytes"),
+					targetSize:   5,
+					expectCosigs: []byte("mock-cosignatures"),
+					beforeSync: func(fm *fakeMirror) {
+						fm.initialPendingSize = 5
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			fm := newFakeMirror(t, origin)
+			fm.addEntriesExpectations = tc.addEntriesExpectations
 
-	u, err := url.Parse(server.URL + "/")
-	if err != nil {
-		t.Fatalf("failed to parse server URL: %v", err)
-	}
+			server := httptest.NewServer(fm)
+			defer server.Close()
 
-	tileFetcher := func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
-		return nil, errors.New("tile fetcher should not be called")
-	}
+			u, err := url.Parse(server.URL + "/")
+			if err != nil {
+				t.Fatalf("failed to parse server URL: %v", err)
+			}
 
-	bundleFetcher := func(ctx context.Context, bundleIndex uint64, p uint8) ([]byte, error) {
-		var buf bytes.Buffer
-		for i := range fm.numEntries {
-			entry := fmt.Appendf(nil, "entry-%d", i)
-			_ = binary.Write(&buf, binary.BigEndian, uint16(len(entry)))
-			buf.Write(entry)
-		}
-		return buf.Bytes(), nil
-	}
+			tileFetcher := func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
+				return nil, errors.New("tile fetcher should not be called")
+			}
 
-	mirrorCheckpointFetcher := func(ctx context.Context) ([]byte, error) {
-		return nil, errors.New("mirror checkpoint fetcher should not be called")
-	}
+			bundleFetcher := func(ctx context.Context, bundleIndex uint64, p uint8) ([]byte, error) {
+				var buf bytes.Buffer
+				for i := range fm.numEntries {
+					entry := fmt.Appendf(nil, "entry-%d", i)
+					_ = binary.Write(&buf, binary.BigEndian, uint16(len(entry)))
+					buf.Write(entry)
+				}
+				return buf.Bytes(), nil
+			}
 
-	packageProver := func(ctx context.Context, start, end, size uint64) ([][]byte, error) {
-		return fm.proofHashes, nil
-	}
+			mirrorCheckpointFetcher := func(ctx context.Context) ([]byte, error) {
+				return nil, errors.New("mirror checkpoint fetcher should not be called")
+			}
 
-	opts := NewOptions().
-		WithMirrorURL(u).
-		WithLogOrigin(origin).
-		WithTileFetcher(tileFetcher).
-		WithBundleFetcher(bundleFetcher).
-		WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
-		WithPackageProver(packageProver)
+			packageProver := func(ctx context.Context, start, end, size uint64) ([][]byte, error) {
+				return fm.proofHashes, nil
+			}
 
-	c, err := NewClient(context.Background(), opts)
-	if err != nil {
-		t.Fatalf("NewClient() = _, %v, want _, nil", err)
-	}
+			opts := NewOptions().
+				WithMirrorURL(u).
+				WithLogOrigin(origin).
+				WithTileFetcher(tileFetcher).
+				WithBundleFetcher(bundleFetcher).
+				WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
+				WithPackageProver(packageProver)
 
-	cosigs, err := c.Sync(context.Background(), fm.targetCheckpoint, uint64(fm.numEntries))
-	if err != nil {
-		t.Fatalf("Sync() = _, %v, want _, nil", err)
-	}
+			c, err := NewClient(context.Background(), opts)
+			if err != nil {
+				t.Fatalf("NewClient() = _, %v, want _, nil", err)
+			}
 
-	if !bytes.Equal(cosigs, fm.expectedCosigs) {
-		t.Errorf("Sync() = %q, want %q", string(cosigs), string(fm.expectedCosigs))
+			for i, step := range tc.steps {
+				if step.beforeSync != nil {
+					step.beforeSync(fm)
+				}
+				cosigs, err := c.Sync(context.Background(), step.checkpoint, step.targetSize)
+				if err != nil {
+					t.Fatalf("Sync() step %d = _, %v, want _, nil", i+1, err)
+				}
+				if !bytes.Equal(cosigs, step.expectCosigs) {
+					t.Errorf("Sync() step %d = %q, want %q", i+1, string(cosigs), string(step.expectCosigs))
+				}
+			}
+		})
 	}
 }
 
@@ -738,6 +802,7 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 		addEntriesExpectations []addEntriesExpectation
 		addCheckpointStatus    int
 		tileFetcher            client.TileFetcherFunc
+		bundleFetcher          client.EntryBundleFetcherFunc
 		wantErr                string
 	}{
 		{
@@ -842,6 +907,22 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 			},
 			wantErr: "mirror size reverted to 2, which is smaller than target 5",
 		},
+		{
+			desc:               "bundle has fewer entries than expected",
+			initialPendingSize: 0,
+			initialNextEntry:   0,
+			bundleFetcher: func(ctx context.Context, bundleIndex uint64, p uint8) ([]byte, error) {
+				var buf bytes.Buffer
+				// Return only 2 entries even though fm.numEntries is 5
+				for i := range 2 {
+					entry := fmt.Appendf(nil, "entry-%d", i)
+					_ = binary.Write(&buf, binary.BigEndian, uint16(len(entry)))
+					buf.Write(entry)
+				}
+				return buf.Bytes(), nil
+			},
+			wantErr: "bundle 0 has only 2 entries, expected at least 5",
+		},
 	}
 
 	for _, tc := range tests {
@@ -854,6 +935,7 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 			if tc.addCheckpointStatus != 0 {
 				fm.addCheckpointStatus = tc.addCheckpointStatus
 			}
+			fm.expectClientError = tc.wantErr != ""
 
 			server := httptest.NewServer(fm)
 			defer server.Close()
@@ -870,14 +952,17 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 				}
 			}
 
-			bundleFetcher := func(ctx context.Context, bundleIndex uint64, p uint8) ([]byte, error) {
-				var buf bytes.Buffer
-				for i := range fm.numEntries {
-					entry := fmt.Appendf(nil, "entry-%d", i)
-					_ = binary.Write(&buf, binary.BigEndian, uint16(len(entry)))
-					buf.Write(entry)
+			bundleFetcher := tc.bundleFetcher
+			if bundleFetcher == nil {
+				bundleFetcher = func(ctx context.Context, bundleIndex uint64, p uint8) ([]byte, error) {
+					var buf bytes.Buffer
+					for i := range fm.numEntries {
+						entry := fmt.Appendf(nil, "entry-%d", i)
+						_ = binary.Write(&buf, binary.BigEndian, uint16(len(entry)))
+						buf.Write(entry)
+					}
+					return buf.Bytes(), nil
 				}
-				return buf.Bytes(), nil
 			}
 
 			mirrorCheckpointFetcher := func(ctx context.Context) ([]byte, error) {


### PR DESCRIPTION
This PR makes a couple of minor fixes to the MTC mirror client:
1. Allow zero-sized checkpoints to collect cosignatures / refresh checkpoints on quiescent logs.
2. Don't panic if a "short" entry bundle is returned from the source log.
3. Handle situations where the mirror is further ahead than the client believes.

Towards #945